### PR TITLE
Feature: add states output to find

### DIFF
--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -34,7 +34,7 @@ def print_diagnostic_service(service: DiagService, print_params=False, print_pre
         pre_condition_states_short_names = [pre_condition_state.short_name for pre_condition_state in service.pre_condition_states]
         print(f"  Pre-Condition-States: {', '.join(pre_condition_states_short_names)}")
 
-    if print_audiences:
+    if print_audiences and service.audience:
         enabled_audiences_short_names = [enabled_audience.short_name for enabled_audience in service.audience.enabled_audiences]
         print(f"  Enabled-Audiences: {', '.join(enabled_audiences_short_names)}")
 

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -21,13 +21,22 @@ def format_desc(desc, ident=0):
     return desc
 
 
-def print_diagnostic_service(service: DiagService, print_params=False, allow_unknown_bit_lengths=False):
+def print_diagnostic_service(service: DiagService, print_params=False, print_pre_condition_states=False,
+                             print_audiences=False, allow_unknown_bit_lengths=False):
 
     print(f" {service.short_name} <ID: {service.id}>")
 
     if service.description:
         desc = format_desc(service.description, ident=3)
         print(f"  Service description: " + desc)
+
+    if print_pre_condition_states:
+        pre_condition_states_short_names = [pre_condition_state.short_name for pre_condition_state in service.pre_condition_states]
+        print(f"  Pre-Condition-States: {', '.join(pre_condition_states_short_names)}")
+
+    if print_audiences:
+        enabled_audiences_short_names = [enabled_audience.short_name for enabled_audience in service.audience.enabled_audiences]
+        print(f"  Enabled-Audiences: {', '.join(enabled_audiences_short_names)}")
 
     if print_params:
         assert service.request is not None

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -22,7 +22,7 @@ def format_desc(desc, ident=0):
 
 
 def print_diagnostic_service(service: DiagService, print_params=False, print_pre_condition_states=False,
-                             print_audiences=False, allow_unknown_bit_lengths=False):
+                             print_state_transitions=False, print_audiences=False, allow_unknown_bit_lengths=False):
 
     print(f" {service.short_name} <ID: {service.id}>")
 
@@ -30,9 +30,13 @@ def print_diagnostic_service(service: DiagService, print_params=False, print_pre
         desc = format_desc(service.description, ident=3)
         print(f"  Service description: " + desc)
 
-    if print_pre_condition_states:
+    if print_pre_condition_states and len(service.pre_condition_states) > 0:
         pre_condition_states_short_names = [pre_condition_state.short_name for pre_condition_state in service.pre_condition_states]
         print(f"  Pre-Condition-States: {', '.join(pre_condition_states_short_names)}")
+
+    if print_state_transitions and len(service.state_transitions) > 0:
+        state_transitions = [f"{state_transition.source_short_name} -> {state_transition.target_short_name}" for state_transition in service.state_transitions]
+        print(f"  State-Transitions: {', '.join(state_transitions)}")
 
     if print_audiences and service.audience:
         enabled_audiences_short_names = [enabled_audience.short_name for enabled_audience in service.audience.enabled_audiences]

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -69,7 +69,9 @@ def print_summary(odxdb: Database,
         print(f"{filler}\n\n")
         print_diagnostic_service(service,
                                  print_params=print_params,
-                                 allow_unknown_bit_lengths=allow_unknown_bit_lengths)
+                                 allow_unknown_bit_lengths=allow_unknown_bit_lengths,
+                                 print_pre_condition_states=True,
+                                 print_audiences=True)
         if decode:
             print_decoded_message(service, data)
 

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -71,6 +71,7 @@ def print_summary(odxdb: Database,
                                  print_params=print_params,
                                  allow_unknown_bit_lengths=allow_unknown_bit_lengths,
                                  print_pre_condition_states=True,
+                                 print_state_transitions=True,
                                  print_audiences=True)
         if decode:
             print_decoded_message(service, data)

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -7,6 +7,7 @@ from typing import Dict, Iterable, List, Union
 from .exceptions import *
 from .globals import logger, xsi
 from .state import read_state_from_odx
+from .state_transition import read_state_transition_from_odx
 
 from .utils import read_description_from_odx
 from .nameditemlist import NamedItemList
@@ -101,7 +102,8 @@ class DiagLayer:
                  id_lookup=None,
                  additional_audiences=[],
                  functional_classes=[],
-                 states=[]
+                 states=[],
+                 state_transitions=[]
                  ):
         logger.info(f"Initializing variant type {variant_type}")
         self.variant_type = variant_type
@@ -136,6 +138,7 @@ class DiagLayer:
         self.additional_audiences = additional_audiences
         self.functional_classes = functional_classes
         self.states = states
+        self.state_transitions = state_transitions
 
         # Properties that include inherited objects
         self._services: NamedItemList[DiagService]\
@@ -191,7 +194,8 @@ class DiagLayer:
                          self.negative_responses,
                          self.additional_audiences,
                          self.functional_classes,
-                         self.states):
+                         self.states,
+                         self.state_transitions):
             id_lookup[obj.id] = obj
 
         if self.local_diag_data_dictionary_spec:
@@ -554,6 +558,10 @@ def read_diag_layer_from_odx(et_element, enable_candela_workarounds=True):
     states = [
         read_state_from_odx(el) for el in et_element.iterfind("STATE-CHARTS/STATE-CHART/STATES/STATE")]
 
+    state_transitions = [
+        read_state_transition_from_odx(el) for el in
+        et_element.iterfind("STATE-CHARTS/STATE-CHART/STATE-TRANSITIONS/STATE-TRANSITION")]
+
     if et_element.find("DIAG-DATA-DICTIONARY-SPEC"):
         diag_data_dictionary_spec = read_diag_data_dictionary_spec_from_odx(
             et_element.find("DIAG-DATA-DICTIONARY-SPEC"))
@@ -579,6 +587,7 @@ def read_diag_layer_from_odx(et_element, enable_candela_workarounds=True):
                    additional_audiences=additional_audiences,
                    functional_classes=functional_classes,
                    states=states,
+                   state_transitions=state_transitions,
                    enable_candela_workarounds=enable_candela_workarounds,
                    )
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Union
 
 from .exceptions import *
 from .globals import logger, xsi
+from .state import read_state_from_odx
 
 from .utils import read_description_from_odx
 from .nameditemlist import NamedItemList
@@ -99,7 +100,8 @@ class DiagLayer:
                  enable_candela_workarounds=True,
                  id_lookup=None,
                  additional_audiences=[],
-                 functional_classes=[]
+                 functional_classes=[],
+                 states=[]
                  ):
         logger.info(f"Initializing variant type {variant_type}")
         self.variant_type = variant_type
@@ -133,6 +135,7 @@ class DiagLayer:
 
         self.additional_audiences = additional_audiences
         self.functional_classes = functional_classes
+        self.states = states
 
         # Properties that include inherited objects
         self._services: NamedItemList[DiagService]\
@@ -156,8 +159,8 @@ class DiagLayer:
     @property
     def data_object_properties(self) -> NamedItemList[DopBase]:
         """All data object properties including inherited ones.
-        This attribute corresponds to all specializations of DOP-BASE 
-        defined in the DIAG-DATA-DICTIONARY-SPEC of this diag layer as well as 
+        This attribute corresponds to all specializations of DOP-BASE
+        defined in the DIAG-DATA-DICTIONARY-SPEC of this diag layer as well as
         in the DIAG-DATA-DICTIONARY-SPEC of any parent.
         """
         return self._data_object_properties
@@ -171,7 +174,7 @@ class DiagLayer:
         """Resolves all references.
 
         This method should be called whenever the diag layer (or a referenced object) was changed.
-        Particularly, this method assumes that all inherited diag layer are correctly initialized, 
+        Particularly, this method assumes that all inherited diag layer are correctly initialized,
         i.e., have resolved their references.
         """
         id_lookup.update(self._build_id_lookup())
@@ -187,7 +190,8 @@ class DiagLayer:
                          self.positive_responses,
                          self.negative_responses,
                          self.additional_audiences,
-                         self.functional_classes):
+                         self.functional_classes,
+                         self.states):
             id_lookup[obj.id] = obj
 
         if self.local_diag_data_dictionary_spec:
@@ -547,6 +551,9 @@ def read_diag_layer_from_odx(et_element, enable_candela_workarounds=True):
     functional_classes = [
         read_functional_class_from_odx(el) for el in et_element.iterfind("FUNCT-CLASSS/FUNCT-CLASS")]
 
+    states = [
+        read_state_from_odx(el) for el in et_element.iterfind("STATE-CHARTS/STATE-CHART/STATES/STATE")]
+
     if et_element.find("DIAG-DATA-DICTIONARY-SPEC"):
         diag_data_dictionary_spec = read_diag_data_dictionary_spec_from_odx(
             et_element.find("DIAG-DATA-DICTIONARY-SPEC"))
@@ -571,6 +578,7 @@ def read_diag_layer_from_odx(et_element, enable_candela_workarounds=True):
                    communication_parameters=com_params,
                    additional_audiences=additional_audiences,
                    functional_classes=functional_classes,
+                   states=states,
                    enable_candela_workarounds=enable_candela_workarounds,
                    )
 

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -47,6 +47,9 @@ class DiagService:
         self.functional_class_refs: List[str] = functional_class_refs
         self._functional_classes: Union[List[FunctionalClass],
                                         NamedItemList[FunctionalClass]] = []
+        self.pre_condition_state_refs: List[str] = pre_condition_state_refs
+        self.pre_condition_states: Union[List[StateClass],
+                                         NamedItemList[StateClass]] = []
 
         self._request: Optional[Request]
         self.request_ref_id: str
@@ -187,6 +190,12 @@ class DiagService:
 
     def __repr__(self):
         return self.__str__()
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, DiagService) and self.id == o.id
 
 
 def read_diag_service_from_odx(et_element):

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 MBition GmbH
+
+from dataclasses import dataclass
+from typing import Optional
+from odxtools.utils import read_description_from_odx
+
+
+@dataclass()
+class State:
+    """
+    Corresponds to STATE.
+    """
+    id: str
+    short_name: str
+    long_name: Optional[str] = None
+    description: Optional[str] = None
+
+
+def read_state_from_odx(et_element):
+    short_name = et_element.find("SHORT-NAME").text
+    id = et_element.get("ID")
+
+    long_name = et_element.find(
+        "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
+    description = read_description_from_odx(et_element.find("DESC"))
+
+    return State(id=id,
+                 short_name=short_name,
+                 long_name=long_name,
+                 description=description)

--- a/odxtools/state_transition.py
+++ b/odxtools/state_transition.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 MBition GmbH
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass()
+class StateTransition:
+    """
+    Corresponds to STATE.
+    """
+    id: str
+    short_name: str
+    long_name: Optional[str] = None
+    source_short_name: Optional[str] = None
+    target_short_name: Optional[str] = None
+
+
+def read_state_transition_from_odx(et_element):
+    short_name = et_element.find("SHORT-NAME").text
+    id = et_element.get("ID")
+
+    long_name = et_element.find(
+        "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
+    source_short_name = et_element.find("SOURCE-SNREF").attrib["SHORT-NAME"] if et_element.find("SOURCE-SNREF") is not None else None
+    target_short_name = et_element.find("TARGET-SNREF").attrib["SHORT-NAME"] if et_element.find("TARGET-SNREF") is not None else None
+
+    return StateTransition(id=id,
+                           short_name=short_name,
+                           long_name=long_name,
+                           source_short_name=source_short_name,
+                           target_short_name=target_short_name)


### PR DESCRIPTION
Adds display of state-preconditions to the find command
Adds display of state transitions to the find command
Adds enabled audiences to the find command
Makes DiagService hashable, so it can be used in a dict (used to group services by variants)

--
Florian Roks \<florian.roks@daimler.com\>, Daimler TSS GmbH
[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)
