### PR TITLE
Do not raise an exception when encountering an unknown trouble code

### DIFF
--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -370,15 +370,15 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
 
-        dtc1 = DiagnosticTroubleCode("dtcID1",
-                                     "P34_sn",
-                                     0x34,
-                                     "Error encountered",
+        dtc1 = DiagnosticTroubleCode(id="dtcID1",
+                                     short_name="P34_sn",
+                                     trouble_code=0x34,
+                                     text="Error encountered",
                                      display_trouble_code="P34")
-        dtc2 = DiagnosticTroubleCode("dtcID2",
-                                     "P56_sn",
-                                     0x56,
-                                     "Crashed into wall",
+        dtc2 = DiagnosticTroubleCode(id="dtcID2",
+                                     short_name="P56_sn",
+                                     trouble_code=0x56,
+                                     text="Crashed into wall",
                                      display_trouble_code="P56")
         dtcs = [dtc1, dtc2]
         dop = DtcDop("dtc.dop.id",


### PR DESCRIPTION
Sometimes it happens that the PDX files are not 100% complete and they miss a DTC which the ECU can occasionally send. Bailing out in this case makes dealing with reading such errors quite cumbersome, so let's refrain from this.

The approach taken for these DTCs is to simply provide the trouble code number without any additional context. (An external tool can then be used to it interpret it.)

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)