### PR TITLE
Better DESC extraction

### DIFF
--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -12,7 +12,9 @@ def read_description_from_odx(et_element: ElementTree.Element):
     if et_element is None:
         return None
  
-    raw_string = (et_element.text or '') + ''.join(ElementTree.tostring(e, encoding='unicode') for e in et_element)
+    raw_string = et_element.text
+    for e in et_element:
+        raw_string += ElementTree.tostring(e, encoding='unicode')
 
     return raw_string.strip()
 

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -4,8 +4,6 @@
 from typing import Dict, Literal
 from xml.etree import ElementTree
 
-def content(tag):
-    return 
 
 def read_description_from_odx(et_element: ElementTree.Element):
     """Read a DESCRIPTION element. The element usually has the name DESC."""

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -4,6 +4,8 @@
 from typing import Dict, Literal
 from xml.etree import ElementTree
 
+def content(tag):
+    return 
 
 def read_description_from_odx(et_element: ElementTree.Element):
     """Read a DESCRIPTION element. The element usually has the name DESC."""
@@ -12,14 +14,8 @@ def read_description_from_odx(et_element: ElementTree.Element):
     if et_element is None:
         return None
 
-    raw_string = ElementTree.tostring(et_element,
-                                      encoding="unicode",
-                                      method="xml").strip()
-    # Remove DESC start and end tag.
-    assert raw_string.startswith("<DESC>"), raw_string
-    assert raw_string.endswith("</DESC>"), raw_string
-    # Remove starting and ending tag
-    raw_string = raw_string[len("<DESC>"):-len("</DESC>")]
+    raw_string = et_element.text + ''.join(ET.tostring(e, encoding='unicode') for e in et_element)
+
     return raw_string.strip()
 
 

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -11,8 +11,8 @@ def read_description_from_odx(et_element: ElementTree.Element):
     #       This just represents it as XHTML string. 
     if et_element is None:
         return None
-
-    raw_string = et_element.text + ''.join(ElementTree.tostring(e, encoding='unicode') for e in et_element)
+ 
+    raw_string = (et_element.text or '') + ''.join(ElementTree.tostring(e, encoding='unicode') for e in et_element)
 
     return raw_string.strip()
 

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -12,7 +12,7 @@ def read_description_from_odx(et_element: ElementTree.Element):
     if et_element is None:
         return None
  
-    raw_string = et_element.text
+    raw_string = et_element.text or ''
     for e in et_element:
         raw_string += ElementTree.tostring(e, encoding='unicode')
 

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -12,7 +12,7 @@ def read_description_from_odx(et_element: ElementTree.Element):
     if et_element is None:
         return None
 
-    raw_string = et_element.text + ''.join(ET.tostring(e, encoding='unicode') for e in et_element)
+    raw_string = et_element.text + ''.join(ElementTree.tostring(e, encoding='unicode') for e in et_element)
 
     return raw_string.strip()
 


### PR DESCRIPTION
Current implimentation fails for sample below DESC, since the attribute will cause `raw_string.startswith("<DESC>")` to fail

```
<DESC TI="some_attribute_value">some value <p> other value</p> end</DESC>
```

Solution based on https://stackoverflow.com/a/3446055/1438522