### PR TITLE
readcompumethod: do type conversions on strings

### DIFF
--- a/odxtools/compumethods/readcompumethod.py
+++ b/odxtools/compumethods/readcompumethod.py
@@ -133,9 +133,9 @@ def read_compu_method_from_odx(et_element, internal_type: DataType, physical_typ
                                               internal_type=internal_type)
 
             if (vt := scale.find("COMPU-INVERSE-VALUE/VT")) is not None:
-                compu_inverse_value = internal_type.from_string(vt)
+                compu_inverse_value = internal_type.from_string(vt.text)
             elif (v := scale.find("COMPU-INVERSE-VALUE/V")) is not None:
-                compu_inverse_value = internal_type.from_string(v)
+                compu_inverse_value = internal_type.from_string(v.text)
             else:
                 compu_inverse_value = None
 


### PR DESCRIPTION
... instead passing `ElementTree` objects. thanks to [at]minkeetan for the catch.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)