### PR TITLE
minor maintenance

### DIFF
--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -15,9 +15,9 @@ def jinja2_odxraise_helper(msg):
     raise Exception(msg)
 
 
-__module_filname = inspect.getsourcefile(odxtools)
-assert isinstance(__module_filname, str)
-__pdx_stub_dir = os.path.sep.join([os.path.dirname(__module_filname),
+__module_filename = inspect.getsourcefile(odxtools)
+assert isinstance(__module_filename, str)
+__pdx_stub_dir = os.path.sep.join([os.path.dirname(__module_filename),
                                   "pdx_stub"])
 def write_pdx_file(output_file_name : str,
                    database : odxtools.Database,


### PR DESCRIPTION
- fix a typo in a variable name
- get rid of the deprecation warnings in the `somersaultlazy.py`
  example when using python >=3.10

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
