### PR TITLE
Support COMPU-NUMERATOR with only one V

### DIFF
--- a/odxtools/compumethods/readcompumethod.py
+++ b/odxtools/compumethods/readcompumethod.py
@@ -46,7 +46,8 @@ def _parse_compu_scale_to_linear_compu_method(scale_element,
     nums = coeffs.iterfind("COMPU-NUMERATOR/V")
 
     offset = computation_python_type(next(nums).text)
-    factor = computation_python_type(next(nums).text)
+    factor_el = next(nums, None)
+    factor = computation_python_type(factor_el.text if factor_el else '0')
     if coeffs.find("COMPU-DENOMINATOR/V") is not None:
         kwargs["denominator"] = float(
             coeffs.find("COMPU-DENOMINATOR/V").text)


### PR DESCRIPTION
ODX XSD does not indicate an upper limit for the number of V elements in COMPU-NUMERATOR, but it does indicate that the minimum number of V elements is 1 and not 2