### PR TITLE
Don't fail parsing if one ODX file have no DIAG-LAYER-CONTAINER

### DIFF
--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -39,12 +39,13 @@ class Database:
                     logger.info(f"Processing the file {zip_member}")
                     d = pdx_zip.read(zip_member)
                     root = ElementTree.fromstring(d)
-
-                    dlc_elements.append(root.find("DIAG-LAYER-CONTAINER"))
+                    dlc = root.find("DIAG-LAYER-CONTAINER")
+                    if dlc is not None:
+                        dlc_elements.append(dlc)
 
             tmp = [
                 read_diag_layer_container_from_odx(dlc_el, enable_candela_workarounds=enable_candela_workarounds) \
-                  for dlc_el in filter(None, dlc_elements)
+                  for dlc_el in dlc_elements
             ]
             self._diag_layer_containers = NamedItemList(lambda x: x.short_name, tmp)
             self._diag_layer_containers.sort(key=lambda x: x.short_name)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -44,7 +44,7 @@ class Database:
 
             tmp = [
                 read_diag_layer_container_from_odx(dlc_el, enable_candela_workarounds=enable_candela_workarounds) \
-                  for dlc_el in dlc_elements
+                  for dlc_el in filter(None, dlc_elements)
             ]
             self._diag_layer_containers = NamedItemList(lambda x: x.short_name, tmp)
             self._diag_layer_containers.sort(key=lambda x: x.short_name)


### PR DESCRIPTION
According to the XSD, DIAG-LAYER-CONTAINER is one choice of what the ODX could contain

The ODX could contain FLASH, ECU-CONFIG, VEHICLE-INFO-SPEC...

If an ODX file in the PDX does not have a DIAG-LAYER-CONTAINER the parser will now ignore it instead of failing the whole PDX.