### PR TITLE
Fix email adress and links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,19 @@
 <!-- SPDX-License-Identifier: MIT -->
 # Contributing
 
-This document explains how to contribute to `odxtools`.  By
+This document explains how to contribute to `odxtools`. By
 contributing you will implicitly agree that your contribution will be
 made available under the same license as the relevant content of the
 repository.
 
 ## Table of Contents
 
-- Communication
-- Contributions
+* [Communication](#communication)
+* [Contributions](#contributions)
 
 ## Communication
 
-We use GitHub to handle bug repors, feature requests, questions and
+We use GitHub to handle bug reports, feature requests, questions and
 general discussions (via the "issues" and "discussions" features of
 GitHub) as well as for managing code and documentation improvements
 (via pull requests). Transparent, inclusive and open communication is
@@ -21,7 +21,7 @@ important to us; thus, all project-related communication should happen
 exclusively on GitHub and using the English language.
 
 In the context of project-related discussions, please respect our
-[Code of Conduct](https://github.com/Daimler/daimler-foss/blob/master/CODE_OF_CONDUCT.md).
+[Code of Conduct](https://github.com/mercedes-benz/daimler-foss/blob/master/CODE_OF_CONDUCT.md).
 
 ## Contributions
 
@@ -30,7 +30,7 @@ In the context of project-related discussions, please respect our
 Before your first pull request can be merged, you need to sign our
 [Contributor License Agreement (CLA)](CONTRIBUTORS_LICENSE_AGREEMENT.md)
 and send it to
-[cla-mbition@daimler.com](mailto:cla-mbition@daimler.com).
+[cla-mbition@mercedes-benz.com](mailto:cla-mbition@mercedes-benz.com).
 
 After sending the signed document, your code contributions can
 immediately be merged, i.e., you do not need to wait for any


### PR DESCRIPTION
This PR fixes the email address to send the CLA to (and also fixes another link).

Refs https://github.com/mercedes-benz/foss/issues/47.

Oliver Kopp &lt;<oliver.kopp@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/). [Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md).