### PR TITLE
Warn instead of assert when for unkown parent ref type

### DIFF
--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -3,6 +3,7 @@
 
 from itertools import chain
 from typing import Optional, Any, Dict, Iterable, List, Union
+import warnings
 
 from .exceptions import *
 from .globals import logger, xsi
@@ -53,8 +54,9 @@ class DiagLayer:
             not_inherited_dops: List[str]
                 short names of not inherited DOPs
             """
-            assert ref_type in ["PROTOCOL-REF", "BASE-VARIANT-REF",
-                                "ECU-SHARED-DATA-REF", "FUNCTIONAL-GROUP-REF"]
+            if ref_type not in ["PROTOCOL-REF", "BASE-VARIANT-REF",
+                                "ECU-SHARED-DATA-REF", "FUNCTIONAL-GROUP-REF"]:
+                warnings.warn(f'Unknown parent ref type {ref_type}', OdxWarning)
             if isinstance(reference, str):
                 self.id_ref = reference
                 self.referenced_diag_layer = None

--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -9,3 +9,6 @@ class EncodeError(OdxError):
 
 class DecodeError(OdxError):
     """Decoding raw data failed."""
+
+class OdxWarning(Warning):
+    """Any warning that happens during interacting with diagnostic objects."""


### PR DESCRIPTION
* ref_type is never actually used by the code, making an assert is an overkill
* Using warnings module ensure that we still see the error, but we can choose to ignore it or suppress it
* This servers as reference idea for future cases where checks needs to be made but can be tolerated in some edge cases