### PR TITLE
Support for int written as float

### DIFF
--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -16,7 +16,9 @@ def parse_int(value: str) -> int:
     try:
         return int(value)
     except ValueError:
-        return int(float(value))
+        v = float(value)
+        assert v.is_integer()
+        return int(v)
 
 _ODX_TYPE_PARSER: Dict[str, Callable[[str], PythonType]] = {
     "A_INT32": parse_int,

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -12,9 +12,15 @@ def bytefield_to_bytearray(bytefield: str) -> bytearray:
 PythonType = Union[str, int, float, bytearray]
 LiteralPythonType = Type[Union[str, int, float, bytearray]]
 
+def parse_int(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        return int(float(value))
+
 _ODX_TYPE_PARSER: Dict[str, Callable[[str], PythonType]] = {
-    "A_INT32": int,
-    "A_UINT32": int,
+    "A_INT32": parse_int,
+    "A_UINT32": parse_int,
     "A_FLOAT32": float,
     "A_FLOAT64": float,
     "A_UNICODE2STRING": str,


### PR DESCRIPTION
It may sound strange, but I got PDX files from a big OEM, where values are integer but written as float, example `15.0` instead of `15`