### PR TITLE
Better overlap and gap handling

### DIFF
--- a/odxtools/parameters/parameterbase.py
+++ b/odxtools/parameters/parameterbase.py
@@ -4,9 +4,11 @@
 
 import abc
 from typing import Optional
+import warnings
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
+from ..exceptions import OdxWarning
 from ..globals import logger
 
 
@@ -117,9 +119,13 @@ class Parameter(abc.ABC):
         if len(old_rpc) < min_length:
             # Make byte code longer if necessary
             new_rpc += bytearray([0] * (min_length - len(old_rpc)))
-        for byte_idx_val, byte_idx_rpc in enumerate(range(byte_position, byte_position + len(byte_value))):
+        for byte_idx_val, byte_idx_rpc in enumerate(
+                range(byte_position, byte_position + len(byte_value))):
             # insert byte value
-            assert new_rpc[byte_idx_rpc] & byte_value[byte_idx_val] == 0, "Bytes are already set!"
+            if new_rpc[byte_idx_rpc] & byte_value[byte_idx_val] != 0:
+                warnings.warn(
+                    f"Parameter {self.short_name} overlaps with another parameter (bytes are already set)",
+                    OdxWarning)
             new_rpc[byte_idx_rpc] |= byte_value[byte_idx_val]
 
         logger.debug(f"Param {self.short_name} inserts"

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -140,8 +140,7 @@ class BasicStructure(DopBase):
             bit_length: Optional[int]):
 
         if self._byte_size is not None:
-            # We definetly broke something if we didn't respect the explicit
-            # byte_size
+            # We definitely broke something if we didn't respect the explicit byte_size
             assert len(coded_rpc) == self._byte_size, self._get_encode_error_str('was', coded_rpc, self._byte_size * 8)
             # forget what we calcualted, ODX defined an explicit byte_size
             # if bit_length was less than _byte_size then we have padding or gaps between parameters

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -175,7 +175,7 @@ class BasicStructure(DopBase):
         return str(f"Structure {self.short_name} {verb} encoded uncorrectly:" +
                 f" actual length is {len(coded_rpc)}," +
                 f" computed byte length is {bit_length // 8}," +
-                f" computed_rpc is {coded_rpc.hex()}" +
+                f" computed_rpc is {coded_rpc.hex()}\n" +
                 '\n'.join(self.__message_format_lines()))
 
 

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -127,7 +127,7 @@ class BasicStructure(DopBase):
 
         if self._byte_size is not None and len(coded_rpc) < self._byte_size:
             # Padding bytes needed
-            coded_rpc = coded_rpc.ljust(self._byte_size, '\0')
+            coded_rpc = coded_rpc.ljust(self._byte_size, b'\0')
 
         # Assert that length is as expected
         self._validate_coded_rpc(coded_rpc, bit_length)

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -157,9 +157,9 @@ class BasicStructure(DopBase):
                 f"Structure {self.short_name} length {bit_length} is not divisible by 8, i.e. is not a full sequence of bytes.",
                 OdxWarning)
             # Round up so not to trigger double alarms
-            bit_length = math.ceil(bit_length / 8)
+            bit_length = math.ceil(bit_length / 8) * 8
 
-        if len(coded_rpc) != bit_length * 8:
+        if len(coded_rpc) * 8 != bit_length:
             # We may have broke something
             # but it could be that bit_length was mis calculated and not the actual bytes are wrong
             # Could happen with overlapping parameters and parameters with gaps


### PR DESCRIPTION
Handle the case were parameters overlap and have gap between them a bit better

Currently the encoding logic do encode them correctly but still bails if it encounter such parameters due to bit_length checking

One simple example is a struct defining a DTC code, it can be treated as a whole number, or have its individual components each treated as a parameter, for convenience, user could define both in the same struct.

![image](https://user-images.githubusercontent.com/1814900/186142364-4005ec55-e59e-4f06-b84a-f5cdde31ed1b.png)
