### PR TITLE
Use bytearray for scale limit

### DIFF
--- a/odxtools/compumethods/readcompumethod.py
+++ b/odxtools/compumethods/readcompumethod.py
@@ -96,7 +96,10 @@ def read_limit_from_odx(et_element, internal_type: DataType):
                 limit = Limit(float("inf"), interval_type)
         else:
             if internal_type == DataType.A_BYTEFIELD:
-                limit = Limit(bytearray.fromhex(et_element.text), interval_type)
+                hex_text = et_element.text
+                if len(hex_text) % 2 == 1:
+                    hex_text = '0' + hex_text
+                limit = Limit(bytearray.fromhex(hex_text), interval_type)
             else:
                 limit = Limit(internal_type.from_string(et_element.text),
                               interval_type)

--- a/odxtools/compumethods/readcompumethod.py
+++ b/odxtools/compumethods/readcompumethod.py
@@ -96,7 +96,7 @@ def read_limit_from_odx(et_element, internal_type: DataType):
                 limit = Limit(float("inf"), interval_type)
         else:
             if internal_type == DataType.A_BYTEFIELD:
-                limit = Limit(int(et_element.text, 16), interval_type)
+                limit = Limit(bytearray.fromhex(et_element.text), interval_type)
             else:
                 limit = Limit(internal_type.from_string(et_element.text),
                               interval_type)


### PR DESCRIPTION
Comparison for bytearray is well defined in Python
```python
a = bytearray.fromhex('aa')
b = bytearray.fromhex('bb')
print(a < b) # True
print(a > b) # False
```

Using `int` breaks the assert in [odxtools\compumethods\texttablecompumethod.py:](https://github.com/mercedes-benz/odxtools/blob/b56eb61b54fbfca4fa38247c8d5e188344a82efc/odxtools/compumethods/texttablecompumethod.py#L27)