### PR TITLE
No 'id' attributes anymore and remove `read_element_id()`

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -67,7 +67,7 @@ cp_iso15765_3_doc_frags = [ OdxDocFragment("ISO_15765_3", "COMPARAM-SPEC") ]
 # company datas
 somersault_team_members = {
     "doggy":
-    TeamMember(id=OdxLinkId("TM.Doggy", doc_frags),
+    TeamMember(odx_link_id=OdxLinkId("TM.Doggy", doc_frags),
                short_name="Doggy",
                long_name="Doggy the dog",
                description="<p>Dog is man's best friend</p>",
@@ -81,7 +81,7 @@ somersault_team_members = {
                email="info@suncus.com"),
 
     "horsey":
-    TeamMember(id=OdxLinkId("TM.Horsey", doc_frags),
+    TeamMember(odx_link_id=OdxLinkId("TM.Horsey", doc_frags),
                short_name="Horsey",
                long_name="Horsey the horse",
                description="<p>Trustworthy worker</p>",
@@ -95,13 +95,13 @@ somersault_team_members = {
                email="info@suncus.com"),
 
     "slothy":
-    TeamMember(id=OdxLinkId("TM.Slothy", doc_frags),
+    TeamMember(odx_link_id=OdxLinkId("TM.Slothy", doc_frags),
                short_name="Slothy")
 }
 
 somersault_company_datas = {
     "suncus":
-    CompanyData(id=OdxLinkId("CD.Suncus", doc_frags),
+    CompanyData(odx_link_id=OdxLinkId("CD.Suncus", doc_frags),
                 short_name="Suncus",
                 long_name="Circus of the sun",
                 description="<p>Prestigious group of performers</p>",
@@ -128,7 +128,7 @@ somersault_company_datas = {
                 ),
 
     "acme":
-    CompanyData(id=OdxLinkId("CD.ACME", doc_frags),
+    CompanyData(odx_link_id=OdxLinkId("CD.ACME", doc_frags),
                 short_name="ACME_Corporation",
                 team_members=NamedItemList(short_name_as_id,
                                            [
@@ -177,13 +177,13 @@ somersault_admin_data = \
 somersault_functional_classes = {
     "flip":
     FunctionalClass(
-        id=OdxLinkId("somersault.FNC.flip", doc_frags),
+        odx_link_id=OdxLinkId("somersault.FNC.flip", doc_frags),
         short_name="flip",
         long_name="Flip"),
 
     "session":
     FunctionalClass(
-        id=OdxLinkId("somersault.FNC.session", doc_frags),
+        odx_link_id=OdxLinkId("somersault.FNC.session", doc_frags),
         short_name="session",
         long_name="Session"),
 }
@@ -192,13 +192,13 @@ somersault_functional_classes = {
 somersault_additional_audiences = {
     "attentive_admirer":
     AdditionalAudience(
-        id=OdxLinkId("somersault.AA.attentive_admirer", doc_frags),
+        odx_link_id=OdxLinkId("somersault.AA.attentive_admirer", doc_frags),
         short_name="attentive_admirer",
         long_name="Attentive Admirer"),
 
     "anyone":
     AdditionalAudience(
-        id=OdxLinkId("somersault.AA.anyone", doc_frags),
+        odx_link_id=OdxLinkId("somersault.AA.anyone", doc_frags),
         short_name="anyone",
         long_name="Anyone"),
 }
@@ -223,7 +223,7 @@ somersault_diagcodedtypes = {
 
 somersault_physical_dimensions = {
     "second": PhysicalDimension(
-        id=OdxLinkId("somersault.PD.second", doc_frags),
+        odx_link_id=OdxLinkId("somersault.PD.second", doc_frags),
         short_name="second",
         long_name="Second",
         time_exp=1
@@ -233,24 +233,24 @@ somersault_physical_dimensions = {
 somersault_units = {
     "second":
         Unit(
-            id=OdxLinkId("somersault.unit.second", doc_frags),
+            odx_link_id=OdxLinkId("somersault.unit.second", doc_frags),
             short_name="second",
             display_name="s",
             long_name="Second",
             description="<p>SI unit for the time</p>",
             factor_si_to_unit=1,
             offset_si_to_unit=0,
-            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].id)
+            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].odx_link_id)
         ),
     "minute":
         Unit(
-            id=OdxLinkId("somersault.unit.minute", doc_frags),
+            odx_link_id=OdxLinkId("somersault.unit.minute", doc_frags),
             short_name="minute",
             display_name="min",
             long_name="Minute",
             factor_si_to_unit=60,
             offset_si_to_unit=0,
-            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].id)
+            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].odx_link_id)
         ),
 }
 
@@ -260,8 +260,8 @@ somersault_unit_groups = {
             short_name="european_duration",
             category="COUNTRY",
             unit_refs=[
-                OdxLinkRef.from_id(somersault_units["second"].id),
-                OdxLinkRef.from_id(somersault_units["minute"].id)],
+                OdxLinkRef.from_id(somersault_units["second"].odx_link_id),
+                OdxLinkRef.from_id(somersault_units["minute"].odx_link_id)],
             long_name="Duration",
             description="<p>Units for measuring a duration</p>"
         ),
@@ -293,7 +293,7 @@ somersault_compumethods = {
 somersault_dops = {
     "num_flips":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.num_flips", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.num_flips", doc_frags),
         short_name="num_flips",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -301,7 +301,7 @@ somersault_dops = {
 
     "soberness_check":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.soberness_check", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.soberness_check", doc_frags),
         short_name="soberness_check",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -309,7 +309,7 @@ somersault_dops = {
 
     "dizzyness_level":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.dizzyness_level", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.dizzyness_level", doc_frags),
         short_name="dizzyness_level",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -317,7 +317,7 @@ somersault_dops = {
 
     "happiness_level":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.happiness_level", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.happiness_level", doc_frags),
         short_name="happiness_level",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -325,16 +325,16 @@ somersault_dops = {
 
     "duration":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.duration", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.duration", doc_frags),
         short_name="duration",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
         compu_method=somersault_compumethods["uint_passthrough"],
-        unit_ref=OdxLinkRef.from_id(somersault_units["second"].id)),
+        unit_ref=OdxLinkRef.from_id(somersault_units["second"].odx_link_id)),
 
     "error_code":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.error_code", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.error_code", doc_frags),
         short_name="error_code",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -342,7 +342,7 @@ somersault_dops = {
 
     "boolean":
     DataObjectProperty(
-        id=OdxLinkId("somersault.DOP.boolean", doc_frags),
+        odx_link_id=OdxLinkId("somersault.DOP.boolean", doc_frags),
         short_name="boolean",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UNICODE2STRING),
@@ -352,35 +352,35 @@ somersault_dops = {
 # tables
 somersault_tables = {
     "flip_quality": Table(
-        id=OdxLinkId("somersault.table.flip_quality", doc_frags),
+        odx_link_id=OdxLinkId("somersault.table.flip_quality", doc_frags),
         short_name="flip_quality",
         long_name="Flip Quality",
         description="<p>The quality the flip (average, good or best)</p>",
         semantic="QUALITY",
-        key_dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+        key_dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
         table_rows=[
             TableRow(
-                id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
+                odx_link_id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
                 short_name="average",
                 long_name="Average",
                 key=3,
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
                 description="<p>The quality of the flip is average</p>",
                 semantic="QUALITY-KEY",
             ),
             TableRow(
-                id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
+                odx_link_id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
                 short_name="good",
                 long_name="Good",
                 key=5,
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
             ),
             TableRow(
-                id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
+                odx_link_id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
                 short_name="best",
                 long_name="Best",
                 key=10,
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
             ),
         ]
     )
@@ -390,19 +390,19 @@ somersault_tables = {
 # muxs
 somersault_muxs = {
     "flip_preference": Multiplexer(
-        id=OdxLinkId("somersault.multiplexer.flip_preference", doc_frags),
+        odx_link_id=OdxLinkId("somersault.multiplexer.flip_preference", doc_frags),
         short_name="flip_preference",
         long_name="Flip Preference",
         byte_position=0,
         switch_key=MultiplexerSwitchKey(
             byte_position=0,
             bit_position=0,
-            dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+            dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
         ),
         default_case=MultiplexerDefaultCase(
             short_name="default_case",
             long_name="Default Case",
-            structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+            structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
         ),
         cases=[
             MultiplexerCase(
@@ -410,14 +410,14 @@ somersault_muxs = {
                 long_name="Forward Flip",
                 lower_limit="1",
                 upper_limit="3",
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
             ),
             MultiplexerCase(
                 short_name="backward_flip",
                 long_name="Backward Flip",
                 lower_limit="1",
                 upper_limit="3",
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
             )
         ]
     )
@@ -426,7 +426,7 @@ somersault_muxs = {
 # env-data
 somersault_env_datas = {
     "flip_env_data": EnvironmentData(
-        id=OdxLinkId("somersault.env_data.flip_env_data", doc_frags),
+        odx_link_id=OdxLinkId("somersault.env_data.flip_env_data", doc_frags),
         short_name="flip_env_data",
         long_name="Flip Env Data",
         parameters=[
@@ -435,7 +435,7 @@ somersault_env_datas = {
                 long_name="Flip Speed",
                 byte_position=0,
                 semantic="DATA",
-                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
             ),
             PhysicalConstantParameter(
                 short_name="flip_direction",
@@ -443,7 +443,7 @@ somersault_env_datas = {
                 byte_position=1,
                 semantic="DATA",
                 physical_constant_value=1,
-                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].id),
+                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
             ),
         ]
     )
@@ -452,7 +452,7 @@ somersault_env_datas = {
 # env-data-desc
 somersault_env_data_descs = {
     "flip_env_data_desc": EnvironmentDataDescription(
-        id=OdxLinkId("somersault.env_data_desc.flip_env_data_desc", doc_frags),
+        odx_link_id=OdxLinkId("somersault.env_data_desc.flip_env_data_desc", doc_frags),
         short_name="flip_env_data_desc",
         long_name="Flip Env Data Desc",
         param_snref="flip_speed",
@@ -465,7 +465,7 @@ somersault_env_data_descs = {
 somersault_requests = {
     "start_session":
     Request(
-        id=OdxLinkId("somersault.RQ.start_session", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.start_session", doc_frags),
         short_name="start_session",
         long_name="Start the diagnostic session & do some mischief",
         parameters=[
@@ -476,7 +476,7 @@ somersault_requests = {
                 coded_value=SID.DiagnosticSessionControl.value, # type: ignore
             ),
             CodedConstParameter(
-                short_name="id",
+                short_name="odx_link_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x0,
@@ -486,7 +486,7 @@ somersault_requests = {
 
     "stop_session":
     Request(
-        id=OdxLinkId("somersault.RQ.stop_session", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.stop_session", doc_frags),
         short_name="stop_session",
         long_name="Terminate the current diagnostic session",
         parameters=[
@@ -497,7 +497,7 @@ somersault_requests = {
                 coded_value=SID.DiagnosticSessionControl.value, # type: ignore
             ),
             CodedConstParameter(
-                short_name="id",
+                short_name="odx_link_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x1,
@@ -507,7 +507,7 @@ somersault_requests = {
 
     "tester_present":
     Request(
-        id=OdxLinkId("somersault.RQ.tester_present", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.tester_present", doc_frags),
         short_name="tester_present",
         long_name="Prevent the current diagnostic session from timing out",
         parameters=[
@@ -518,7 +518,7 @@ somersault_requests = {
                 coded_value=SID.TesterPresent.value # type: ignore
             ),
             CodedConstParameter(
-                short_name="id",
+                short_name="odx_link_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x0
@@ -528,7 +528,7 @@ somersault_requests = {
 
     "set_operation_params":
     Request(
-        id=OdxLinkId("somersault.RQ.set_operation_params", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.set_operation_params", doc_frags),
         short_name="set_operation_params",
         long_name=\
         "Specify the mode of operation for the ECU; e.g. if rings "
@@ -551,7 +551,7 @@ somersault_requests = {
 
     "forward_flips":
     Request(
-        id=OdxLinkId("somersault.RQ.do_forward_flips", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.do_forward_flips", doc_frags),
         short_name="do_forward_flips",
         long_name="Do forward somersaults & some other mischief",
         parameters=[
@@ -576,7 +576,7 @@ somersault_requests = {
 
     "backward_flips":
     Request(
-        id=OdxLinkId("somersault.RQ.do_backward_flips", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.do_backward_flips", doc_frags),
         short_name="do_backward_flips",
         long_name="Do a backward somersault & some other mischief",
         parameters=[
@@ -602,7 +602,7 @@ somersault_requests = {
 
     "report_status":
     Request(
-        id=OdxLinkId("somersault.RQ.report_status", doc_frags),
+        odx_link_id=OdxLinkId("somersault.RQ.report_status", doc_frags),
         short_name="report_status",
         long_name="Report back the current level of dizzy- & happiness.",
         parameters=[
@@ -613,7 +613,7 @@ somersault_requests = {
                 coded_value=SID.ReadDataByIdentifier.value, # type: ignore
             ),
             CodedConstParameter(
-                short_name="id",
+                short_name="odx_link_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x0,
@@ -626,7 +626,7 @@ somersault_requests = {
 # positive responses
 somersault_positive_responses = {
     "session":
-    Response(id=OdxLinkId("somersault.PR.session_start", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.session_start", doc_frags),
              short_name="session",
              response_type="POS-RESPONSE",
              parameters=[
@@ -644,7 +644,7 @@ somersault_positive_responses = {
              ]),
 
     "tester_ok":
-    Response(id=OdxLinkId("somersault.PR.tester_present", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.tester_present", doc_frags),
              short_name="tester_present",
              response_type="POS-RESPONSE",
              parameters=[
@@ -663,7 +663,7 @@ somersault_positive_responses = {
              ]),
 
     "forward_flips_grudgingly_done":
-    Response(id=OdxLinkId("somersault.PR.grudging_forward", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.grudging_forward", doc_frags),
              short_name="grudging_forward",
              response_type="POS-RESPONSE",
              parameters=[
@@ -681,7 +681,7 @@ somersault_positive_responses = {
              ]),
 
     "forward_flips_happily_done":
-    Response(id=OdxLinkId("somersault.PR.happy_forward", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.happy_forward", doc_frags),
              short_name="happy_forward",
              response_type="POS-RESPONSE",
              parameters=[
@@ -703,7 +703,7 @@ somersault_positive_responses = {
              ]),
 
     "backward_flips_grudgingly_done":
-    Response(id=OdxLinkId("somersault.PR.grudging_backward", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.grudging_backward", doc_frags),
              short_name="grudging_backward",
              response_type="POS-RESPONSE",
              parameters=[
@@ -723,7 +723,7 @@ somersault_positive_responses = {
     # Note that there is no such thing as a "backwards flip done happily"!
 
     "status_report":
-    Response(id=OdxLinkId("somersault.PR.status_report", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.status_report", doc_frags),
              short_name="status_report",
              response_type="POS-RESPONSE",
              parameters=[
@@ -744,7 +744,7 @@ somersault_positive_responses = {
              ]),
 
     "set_operation_params":
-    Response(id=OdxLinkId("somersault.PR.set_operation_params", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.PR.set_operation_params", doc_frags),
              short_name="set_operation_params",
              response_type="POS-RESPONSE",
              parameters=[
@@ -760,7 +760,7 @@ somersault_positive_responses = {
 # negative responses
 somersault_negative_responses = {
     "general":
-    Response(id=OdxLinkId("somersault.NR.general_negative_response", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.NR.general_negative_response", doc_frags),
              short_name="general_negative_response",
              response_type="NEG-RESPONSE",
              parameters=[
@@ -784,7 +784,7 @@ somersault_negative_responses = {
     # responses because it must be fully specified a-priory to be able
     # to extract it for the COMPARAMS.
     "tester_nok":
-    Response(id=OdxLinkId("somersault.NR.tester_nok", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.NR.tester_nok", doc_frags),
              short_name="tester_nok",
              response_type="NEG-RESPONSE",
              parameters=[
@@ -803,7 +803,7 @@ somersault_negative_responses = {
              ]),
 
     "flips_not_done":
-    Response(id=OdxLinkId("somersault.NR.flips_not_done", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault.NR.flips_not_done", doc_frags),
              short_name="flips_not_done",
              response_type="NEG-RESPONSE",
              parameters=[
@@ -838,127 +838,127 @@ somersault_negative_responses = {
 # services
 somersault_services = {
     "start_session":
-    DiagService(id=OdxLinkId("somersault.service.session_start", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.session_start", doc_frags),
                 short_name="session_start",
-                request=OdxLinkRef.from_id(somersault_requests["start_session"].id),
+                request=OdxLinkRef.from_id(somersault_requests["start_session"].odx_link_id),
                 semantic="SESSION",
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["session"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["session"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["session"].id),
+                    OdxLinkRef.from_id(somersault_functional_classes["session"].odx_link_id),
                 ]
                 ),
 
     "stop_session":
-    DiagService(id=OdxLinkId("somersault.service.session_stop", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.session_stop", doc_frags),
                 short_name="session_stop",
                 semantic="SESSION",
-                request=OdxLinkRef.from_id(somersault_requests["stop_session"].id),
+                request=OdxLinkRef.from_id(somersault_requests["stop_session"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["session"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["session"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["session"].id)
+                    OdxLinkRef.from_id(somersault_functional_classes["session"].odx_link_id)
                 ]
                 ),
 
     "tester_present":
-    DiagService(id=OdxLinkId("somersault.service.tester_present", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.tester_present", doc_frags),
                 short_name="tester_present",
                 semantic="TESTERPRESENT",
-                request=OdxLinkRef.from_id(somersault_requests["tester_present"].id),
+                request=OdxLinkRef.from_id(somersault_requests["tester_present"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["tester_ok"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["tester_ok"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["tester_nok"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["tester_nok"].odx_link_id),
                 ],
                 audience=Audience(
                     enabled_audience_refs=[
-                        OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].id),
-                        OdxLinkRef.from_id(somersault_additional_audiences["anyone"].id),
+                        OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id),
+                        OdxLinkRef.from_id(somersault_additional_audiences["anyone"].odx_link_id),
                     ],
                     is_development=False)
                 ),
 
     "set_operation_params":
-    DiagService(id=OdxLinkId("somersault.service.set_operation_params", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.set_operation_params", doc_frags),
                 short_name="set_operation_params",
                 semantic="FUNCTION",
-                request=OdxLinkRef.from_id(somersault_requests["set_operation_params"].id),
+                request=OdxLinkRef.from_id(somersault_requests["set_operation_params"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["set_operation_params"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["set_operation_params"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
                 ],
                 ),
 
     "forward_flips":
-    DiagService(id=OdxLinkId("somersault.service.do_forward_flips", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.do_forward_flips", doc_frags),
                 short_name="do_forward_flips",
                 description="<p>Do a forward flip.</p>",
                 semantic="FUNCTION",
-                request=OdxLinkRef.from_id(somersault_requests["forward_flips"].id),
+                request=OdxLinkRef.from_id(somersault_requests["forward_flips"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["forward_flips_grudgingly_done"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["forward_flips_grudgingly_done"].odx_link_id),
                     # TODO: implement handling of multiple responses
-                    #OdxLinkRef.from_id(somersault_positive_responses["forward_flips_happily_done"].id),
+                    #OdxLinkRef.from_id(somersault_positive_responses["forward_flips_happily_done"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_link_id),
                     # TODO (?): implement handling of multiple possible responses
-                    #OdxLinkRef.from_id(somersault_negative_responses["stumbled"].id),
-                    #OdxLinkRef.from_id(somersault_negative_responses["too_dizzy"].id),
-                    #OdxLinkRef.from_id(somersault_negative_responses["not_sober"].id),
+                    #OdxLinkRef.from_id(somersault_negative_responses["stumbled"].odx_link_id),
+                    #OdxLinkRef.from_id(somersault_negative_responses["too_dizzy"].odx_link_id),
+                    #OdxLinkRef.from_id(somersault_negative_responses["not_sober"].odx_link_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["flip"].id)
+                    OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_link_id)
                 ],
                 audience=Audience(
-                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].id)],
+                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)],
                     is_development=False)
                 ),
 
     "backward_flips":
-    DiagService(id=OdxLinkId("somersault.service.do_backward_flips", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.do_backward_flips", doc_frags),
                 short_name="do_backward_flips",
                 semantic="FUNCTION",
-                request=OdxLinkRef.from_id(somersault_requests["backward_flips"].id),
+                request=OdxLinkRef.from_id(somersault_requests["backward_flips"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["backward_flips_grudgingly_done"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["backward_flips_grudgingly_done"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_link_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["flip"].id)
+                    OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_link_id)
                 ],
                 audience=Audience(
-                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].id)],
+                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)],
                     is_development=False)
                 ),
 
     "report_status":
-    DiagService(id=OdxLinkId("somersault.service.report_status", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault.service.report_status", doc_frags),
                 short_name="report_status",
                 semantic="CURRENTDATA",
-                request=OdxLinkRef.from_id(somersault_requests["report_status"].id),
+                request=OdxLinkRef.from_id(somersault_requests["report_status"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["status_report"].id),
+                    OdxLinkRef.from_id(somersault_positive_responses["status_report"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
                 ],
                 audience=Audience(
-                    disabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].id)],
+                    disabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)],
                     is_aftersales=False,
                     is_aftermarket=False)
                 ),
@@ -967,7 +967,7 @@ somersault_services = {
 
 somersault_single_ecu_jobs = {
     "compulsory_program":
-    SingleEcuJob(id=OdxLinkId("somersault.service.compulsory_program", doc_frags),
+    SingleEcuJob(odx_link_id=OdxLinkId("somersault.service.compulsory_program", doc_frags),
                  short_name="compulsory_program",
                  long_name="Compulsory Program",
                  description="<p>Do several fancy moves.</p>",
@@ -1100,7 +1100,7 @@ somersault_diag_data_dictionary_spec = DiagDataDictionarySpec(
 # diagnostics layer
 somersault_diaglayer = DiagLayer(
     variant_type="BASE-VARIANT",
-    id=OdxLinkId("somersault", doc_frags),
+    odx_link_id=OdxLinkId("somersault", doc_frags),
     short_name="somersault",
     long_name="Somersault base variant",
     description="<p>Base variant of the somersault ECU &amp; cetera</p>",
@@ -1121,13 +1121,13 @@ somersault_diaglayer = DiagLayer(
 # TODO: inheritance (without too much code duplication)
 somersault_lazy_diaglayer = DiagLayer(
     variant_type="ECU-VARIANT",
-    id=OdxLinkId("somersault_lazy", doc_frags),
+    odx_link_id=OdxLinkId("somersault_lazy", doc_frags),
     short_name="somersault_lazy",
     long_name="Somersault lazy ECU",
     description="<p>Sloppy variant of the somersault ECU (lazy &lt; assiduous)</p>",
     parent_refs=[
         DiagLayer.ParentRef( # <- TODO: this is a bit sketchy IMO
-            parent=OdxLinkRef.from_id(somersault_diaglayer.id),
+            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_link_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does not do backflips
             not_inherited_diag_comms=[
@@ -1147,14 +1147,14 @@ somersault_lazy_diaglayer = DiagLayer(
 # TODO: inheritance (without too much code duplication)
 somersault_assiduous_diaglayer = DiagLayer(
     variant_type="ECU-VARIANT",
-    id=OdxLinkId("somersault_assiduous", doc_frags),
+    odx_link_id=OdxLinkId("somersault_assiduous", doc_frags),
     short_name="somersault_assiduous",
     long_name="Somersault assiduous ECU",
     description="<p>Hard-working variant of the somersault ECU (lazy &lt; assiduous)</p>",
     diag_data_dictionary_spec=DiagDataDictionarySpec(),
     parent_refs=[
         DiagLayer.ParentRef( # <- TODO: this is a bit sketchy IMO
-            parent=OdxLinkRef.from_id(somersault_diaglayer.id),
+            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_link_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does everything which the base variant does
         )],
@@ -1166,7 +1166,7 @@ somersault_assiduous_diaglayer = DiagLayer(
 somersault_assiduous_requests = {
     "headstand":
     Request(
-        id=OdxLinkId("somersault_assiduous.RQ.do_headstand", doc_frags),
+        odx_link_id=OdxLinkId("somersault_assiduous.RQ.do_headstand", doc_frags),
         short_name="do_headstand",
         long_name="Do a headstand & whatever else is required to entertain the customer",
         parameters=[
@@ -1187,7 +1187,7 @@ somersault_assiduous_requests = {
 # positive responses
 somersault_assiduous_positive_responses = {
     "headstand_done":
-    Response(id=OdxLinkId("somersault_assiduous.PR.headstand_done", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault_assiduous.PR.headstand_done", doc_frags),
              short_name="headstand_done",
              parameters=[
                  CodedConstParameter(
@@ -1207,7 +1207,7 @@ somersault_assiduous_positive_responses = {
 # negative responses
 somersault_assiduous_negative_responses = {
     "fell_over":
-    Response(id=OdxLinkId("somersault_assiduous.NR.fell_over", doc_frags),
+    Response(odx_link_id=OdxLinkId("somersault_assiduous.NR.fell_over", doc_frags),
              short_name="fell_over",
              parameters=[
                  CodedConstParameter(
@@ -1228,16 +1228,16 @@ somersault_assiduous_negative_responses = {
 # services
 somersault_assiduous_services = {
     "headstand":
-    DiagService(id=OdxLinkId("somersault_assiduous.service.headstand", doc_frags),
+    DiagService(odx_link_id=OdxLinkId("somersault_assiduous.service.headstand", doc_frags),
                 short_name="headstand",
-                request=OdxLinkRef.from_id(somersault_assiduous_requests["headstand"].id),
+                request=OdxLinkRef.from_id(somersault_assiduous_requests["headstand"].odx_link_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_assiduous_positive_responses["headstand_done"].id),
+                    OdxLinkRef.from_id(somersault_assiduous_positive_responses["headstand_done"].odx_link_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_assiduous_negative_responses["fell_over"].id),
+                    OdxLinkRef.from_id(somersault_assiduous_negative_responses["fell_over"].odx_link_id),
                 ],
-                audience=Audience(enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].id)])
+                audience=Audience(enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)])
                 ),
 }
 
@@ -1253,7 +1253,7 @@ somersault_assiduous_diaglayer.negative_responses = NamedItemList(short_name_as_
 
 # create a "diagnosis layer container" object
 somersault_dlc = DiagLayerContainer(
-    id=OdxLinkId("DLC.somersault", doc_frags),
+    odx_link_id=OdxLinkId("DLC.somersault", doc_frags),
     short_name=dlc_short_name,
     long_name="Collect all saults in the summer",
     description="<p>This contains ECUs which do somersaults &amp; cetera</p>",

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -67,7 +67,7 @@ cp_iso15765_3_doc_frags = [ OdxDocFragment("ISO_15765_3", "COMPARAM-SPEC") ]
 # company datas
 somersault_team_members = {
     "doggy":
-    TeamMember(odx_link_id=OdxLinkId("TM.Doggy", doc_frags),
+    TeamMember(odx_id=OdxLinkId("TM.Doggy", doc_frags),
                short_name="Doggy",
                long_name="Doggy the dog",
                description="<p>Dog is man's best friend</p>",
@@ -81,7 +81,7 @@ somersault_team_members = {
                email="info@suncus.com"),
 
     "horsey":
-    TeamMember(odx_link_id=OdxLinkId("TM.Horsey", doc_frags),
+    TeamMember(odx_id=OdxLinkId("TM.Horsey", doc_frags),
                short_name="Horsey",
                long_name="Horsey the horse",
                description="<p>Trustworthy worker</p>",
@@ -95,13 +95,13 @@ somersault_team_members = {
                email="info@suncus.com"),
 
     "slothy":
-    TeamMember(odx_link_id=OdxLinkId("TM.Slothy", doc_frags),
+    TeamMember(odx_id=OdxLinkId("TM.Slothy", doc_frags),
                short_name="Slothy")
 }
 
 somersault_company_datas = {
     "suncus":
-    CompanyData(odx_link_id=OdxLinkId("CD.Suncus", doc_frags),
+    CompanyData(odx_id=OdxLinkId("CD.Suncus", doc_frags),
                 short_name="Suncus",
                 long_name="Circus of the sun",
                 description="<p>Prestigious group of performers</p>",
@@ -128,7 +128,7 @@ somersault_company_datas = {
                 ),
 
     "acme":
-    CompanyData(odx_link_id=OdxLinkId("CD.ACME", doc_frags),
+    CompanyData(odx_id=OdxLinkId("CD.ACME", doc_frags),
                 short_name="ACME_Corporation",
                 team_members=NamedItemList(short_name_as_id,
                                            [
@@ -177,13 +177,13 @@ somersault_admin_data = \
 somersault_functional_classes = {
     "flip":
     FunctionalClass(
-        odx_link_id=OdxLinkId("somersault.FNC.flip", doc_frags),
+        odx_id=OdxLinkId("somersault.FNC.flip", doc_frags),
         short_name="flip",
         long_name="Flip"),
 
     "session":
     FunctionalClass(
-        odx_link_id=OdxLinkId("somersault.FNC.session", doc_frags),
+        odx_id=OdxLinkId("somersault.FNC.session", doc_frags),
         short_name="session",
         long_name="Session"),
 }
@@ -192,13 +192,13 @@ somersault_functional_classes = {
 somersault_additional_audiences = {
     "attentive_admirer":
     AdditionalAudience(
-        odx_link_id=OdxLinkId("somersault.AA.attentive_admirer", doc_frags),
+        odx_id=OdxLinkId("somersault.AA.attentive_admirer", doc_frags),
         short_name="attentive_admirer",
         long_name="Attentive Admirer"),
 
     "anyone":
     AdditionalAudience(
-        odx_link_id=OdxLinkId("somersault.AA.anyone", doc_frags),
+        odx_id=OdxLinkId("somersault.AA.anyone", doc_frags),
         short_name="anyone",
         long_name="Anyone"),
 }
@@ -223,7 +223,7 @@ somersault_diagcodedtypes = {
 
 somersault_physical_dimensions = {
     "second": PhysicalDimension(
-        odx_link_id=OdxLinkId("somersault.PD.second", doc_frags),
+        odx_id=OdxLinkId("somersault.PD.second", doc_frags),
         short_name="second",
         long_name="Second",
         time_exp=1
@@ -233,24 +233,24 @@ somersault_physical_dimensions = {
 somersault_units = {
     "second":
         Unit(
-            odx_link_id=OdxLinkId("somersault.unit.second", doc_frags),
+            odx_id=OdxLinkId("somersault.unit.second", doc_frags),
             short_name="second",
             display_name="s",
             long_name="Second",
             description="<p>SI unit for the time</p>",
             factor_si_to_unit=1,
             offset_si_to_unit=0,
-            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].odx_link_id)
+            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].odx_id)
         ),
     "minute":
         Unit(
-            odx_link_id=OdxLinkId("somersault.unit.minute", doc_frags),
+            odx_id=OdxLinkId("somersault.unit.minute", doc_frags),
             short_name="minute",
             display_name="min",
             long_name="Minute",
             factor_si_to_unit=60,
             offset_si_to_unit=0,
-            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].odx_link_id)
+            physical_dimension_ref=OdxLinkRef.from_id(somersault_physical_dimensions["second"].odx_id)
         ),
 }
 
@@ -260,8 +260,8 @@ somersault_unit_groups = {
             short_name="european_duration",
             category="COUNTRY",
             unit_refs=[
-                OdxLinkRef.from_id(somersault_units["second"].odx_link_id),
-                OdxLinkRef.from_id(somersault_units["minute"].odx_link_id)],
+                OdxLinkRef.from_id(somersault_units["second"].odx_id),
+                OdxLinkRef.from_id(somersault_units["minute"].odx_id)],
             long_name="Duration",
             description="<p>Units for measuring a duration</p>"
         ),
@@ -293,7 +293,7 @@ somersault_compumethods = {
 somersault_dops = {
     "num_flips":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.num_flips", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.num_flips", doc_frags),
         short_name="num_flips",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -301,7 +301,7 @@ somersault_dops = {
 
     "soberness_check":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.soberness_check", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.soberness_check", doc_frags),
         short_name="soberness_check",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -309,7 +309,7 @@ somersault_dops = {
 
     "dizzyness_level":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.dizzyness_level", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.dizzyness_level", doc_frags),
         short_name="dizzyness_level",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -317,7 +317,7 @@ somersault_dops = {
 
     "happiness_level":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.happiness_level", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.happiness_level", doc_frags),
         short_name="happiness_level",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -325,16 +325,16 @@ somersault_dops = {
 
     "duration":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.duration", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.duration", doc_frags),
         short_name="duration",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
         compu_method=somersault_compumethods["uint_passthrough"],
-        unit_ref=OdxLinkRef.from_id(somersault_units["second"].odx_link_id)),
+        unit_ref=OdxLinkRef.from_id(somersault_units["second"].odx_id)),
 
     "error_code":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.error_code", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.error_code", doc_frags),
         short_name="error_code",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UINT32),
@@ -342,7 +342,7 @@ somersault_dops = {
 
     "boolean":
     DataObjectProperty(
-        odx_link_id=OdxLinkId("somersault.DOP.boolean", doc_frags),
+        odx_id=OdxLinkId("somersault.DOP.boolean", doc_frags),
         short_name="boolean",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
         physical_type=PhysicalType(DataType.A_UNICODE2STRING),
@@ -352,35 +352,35 @@ somersault_dops = {
 # tables
 somersault_tables = {
     "flip_quality": Table(
-        odx_link_id=OdxLinkId("somersault.table.flip_quality", doc_frags),
+        odx_id=OdxLinkId("somersault.table.flip_quality", doc_frags),
         short_name="flip_quality",
         long_name="Flip Quality",
         description="<p>The quality the flip (average, good or best)</p>",
         semantic="QUALITY",
-        key_dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+        key_dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
         table_rows=[
             TableRow(
-                odx_link_id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
+                odx_id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
                 short_name="average",
                 long_name="Average",
                 key=3,
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
                 description="<p>The quality of the flip is average</p>",
                 semantic="QUALITY-KEY",
             ),
             TableRow(
-                odx_link_id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
+                odx_id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
                 short_name="good",
                 long_name="Good",
                 key=5,
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
             ),
             TableRow(
-                odx_link_id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
+                odx_id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
                 short_name="best",
                 long_name="Best",
                 key=10,
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
             ),
         ]
     )
@@ -390,19 +390,19 @@ somersault_tables = {
 # muxs
 somersault_muxs = {
     "flip_preference": Multiplexer(
-        odx_link_id=OdxLinkId("somersault.multiplexer.flip_preference", doc_frags),
+        odx_id=OdxLinkId("somersault.multiplexer.flip_preference", doc_frags),
         short_name="flip_preference",
         long_name="Flip Preference",
         byte_position=0,
         switch_key=MultiplexerSwitchKey(
             byte_position=0,
             bit_position=0,
-            dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+            dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
         ),
         default_case=MultiplexerDefaultCase(
             short_name="default_case",
             long_name="Default Case",
-            structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+            structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
         ),
         cases=[
             MultiplexerCase(
@@ -410,14 +410,14 @@ somersault_muxs = {
                 long_name="Forward Flip",
                 lower_limit="1",
                 upper_limit="3",
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
             ),
             MultiplexerCase(
                 short_name="backward_flip",
                 long_name="Backward Flip",
                 lower_limit="1",
                 upper_limit="3",
-                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
             )
         ]
     )
@@ -426,7 +426,7 @@ somersault_muxs = {
 # env-data
 somersault_env_datas = {
     "flip_env_data": EnvironmentData(
-        odx_link_id=OdxLinkId("somersault.env_data.flip_env_data", doc_frags),
+        odx_id=OdxLinkId("somersault.env_data.flip_env_data", doc_frags),
         short_name="flip_env_data",
         long_name="Flip Env Data",
         parameters=[
@@ -435,7 +435,7 @@ somersault_env_datas = {
                 long_name="Flip Speed",
                 byte_position=0,
                 semantic="DATA",
-                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
             ),
             PhysicalConstantParameter(
                 short_name="flip_direction",
@@ -443,7 +443,7 @@ somersault_env_datas = {
                 byte_position=1,
                 semantic="DATA",
                 physical_constant_value=1,
-                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_link_id),
+                dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
             ),
         ]
     )
@@ -452,7 +452,7 @@ somersault_env_datas = {
 # env-data-desc
 somersault_env_data_descs = {
     "flip_env_data_desc": EnvironmentDataDescription(
-        odx_link_id=OdxLinkId("somersault.env_data_desc.flip_env_data_desc", doc_frags),
+        odx_id=OdxLinkId("somersault.env_data_desc.flip_env_data_desc", doc_frags),
         short_name="flip_env_data_desc",
         long_name="Flip Env Data Desc",
         param_snref="flip_speed",
@@ -465,7 +465,7 @@ somersault_env_data_descs = {
 somersault_requests = {
     "start_session":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.start_session", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.start_session", doc_frags),
         short_name="start_session",
         long_name="Start the diagnostic session & do some mischief",
         parameters=[
@@ -476,7 +476,7 @@ somersault_requests = {
                 coded_value=SID.DiagnosticSessionControl.value, # type: ignore
             ),
             CodedConstParameter(
-                short_name="odx_link_id",
+                short_name="odx_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x0,
@@ -486,7 +486,7 @@ somersault_requests = {
 
     "stop_session":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.stop_session", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.stop_session", doc_frags),
         short_name="stop_session",
         long_name="Terminate the current diagnostic session",
         parameters=[
@@ -497,7 +497,7 @@ somersault_requests = {
                 coded_value=SID.DiagnosticSessionControl.value, # type: ignore
             ),
             CodedConstParameter(
-                short_name="odx_link_id",
+                short_name="odx_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x1,
@@ -507,7 +507,7 @@ somersault_requests = {
 
     "tester_present":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.tester_present", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.tester_present", doc_frags),
         short_name="tester_present",
         long_name="Prevent the current diagnostic session from timing out",
         parameters=[
@@ -518,7 +518,7 @@ somersault_requests = {
                 coded_value=SID.TesterPresent.value # type: ignore
             ),
             CodedConstParameter(
-                short_name="odx_link_id",
+                short_name="odx_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x0
@@ -528,7 +528,7 @@ somersault_requests = {
 
     "set_operation_params":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.set_operation_params", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.set_operation_params", doc_frags),
         short_name="set_operation_params",
         long_name=\
         "Specify the mode of operation for the ECU; e.g. if rings "
@@ -551,7 +551,7 @@ somersault_requests = {
 
     "forward_flips":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.do_forward_flips", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.do_forward_flips", doc_frags),
         short_name="do_forward_flips",
         long_name="Do forward somersaults & some other mischief",
         parameters=[
@@ -576,7 +576,7 @@ somersault_requests = {
 
     "backward_flips":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.do_backward_flips", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.do_backward_flips", doc_frags),
         short_name="do_backward_flips",
         long_name="Do a backward somersault & some other mischief",
         parameters=[
@@ -602,7 +602,7 @@ somersault_requests = {
 
     "report_status":
     Request(
-        odx_link_id=OdxLinkId("somersault.RQ.report_status", doc_frags),
+        odx_id=OdxLinkId("somersault.RQ.report_status", doc_frags),
         short_name="report_status",
         long_name="Report back the current level of dizzy- & happiness.",
         parameters=[
@@ -613,7 +613,7 @@ somersault_requests = {
                 coded_value=SID.ReadDataByIdentifier.value, # type: ignore
             ),
             CodedConstParameter(
-                short_name="odx_link_id",
+                short_name="odx_id",
                 diag_coded_type=somersault_diagcodedtypes["uint8"],
                 byte_position=1,
                 coded_value=0x0,
@@ -626,7 +626,7 @@ somersault_requests = {
 # positive responses
 somersault_positive_responses = {
     "session":
-    Response(odx_link_id=OdxLinkId("somersault.PR.session_start", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.session_start", doc_frags),
              short_name="session",
              response_type="POS-RESPONSE",
              parameters=[
@@ -644,7 +644,7 @@ somersault_positive_responses = {
              ]),
 
     "tester_ok":
-    Response(odx_link_id=OdxLinkId("somersault.PR.tester_present", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.tester_present", doc_frags),
              short_name="tester_present",
              response_type="POS-RESPONSE",
              parameters=[
@@ -663,7 +663,7 @@ somersault_positive_responses = {
              ]),
 
     "forward_flips_grudgingly_done":
-    Response(odx_link_id=OdxLinkId("somersault.PR.grudging_forward", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.grudging_forward", doc_frags),
              short_name="grudging_forward",
              response_type="POS-RESPONSE",
              parameters=[
@@ -681,7 +681,7 @@ somersault_positive_responses = {
              ]),
 
     "forward_flips_happily_done":
-    Response(odx_link_id=OdxLinkId("somersault.PR.happy_forward", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.happy_forward", doc_frags),
              short_name="happy_forward",
              response_type="POS-RESPONSE",
              parameters=[
@@ -703,7 +703,7 @@ somersault_positive_responses = {
              ]),
 
     "backward_flips_grudgingly_done":
-    Response(odx_link_id=OdxLinkId("somersault.PR.grudging_backward", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.grudging_backward", doc_frags),
              short_name="grudging_backward",
              response_type="POS-RESPONSE",
              parameters=[
@@ -723,7 +723,7 @@ somersault_positive_responses = {
     # Note that there is no such thing as a "backwards flip done happily"!
 
     "status_report":
-    Response(odx_link_id=OdxLinkId("somersault.PR.status_report", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.status_report", doc_frags),
              short_name="status_report",
              response_type="POS-RESPONSE",
              parameters=[
@@ -744,7 +744,7 @@ somersault_positive_responses = {
              ]),
 
     "set_operation_params":
-    Response(odx_link_id=OdxLinkId("somersault.PR.set_operation_params", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.PR.set_operation_params", doc_frags),
              short_name="set_operation_params",
              response_type="POS-RESPONSE",
              parameters=[
@@ -760,7 +760,7 @@ somersault_positive_responses = {
 # negative responses
 somersault_negative_responses = {
     "general":
-    Response(odx_link_id=OdxLinkId("somersault.NR.general_negative_response", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.NR.general_negative_response", doc_frags),
              short_name="general_negative_response",
              response_type="NEG-RESPONSE",
              parameters=[
@@ -784,7 +784,7 @@ somersault_negative_responses = {
     # responses because it must be fully specified a-priory to be able
     # to extract it for the COMPARAMS.
     "tester_nok":
-    Response(odx_link_id=OdxLinkId("somersault.NR.tester_nok", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.NR.tester_nok", doc_frags),
              short_name="tester_nok",
              response_type="NEG-RESPONSE",
              parameters=[
@@ -803,7 +803,7 @@ somersault_negative_responses = {
              ]),
 
     "flips_not_done":
-    Response(odx_link_id=OdxLinkId("somersault.NR.flips_not_done", doc_frags),
+    Response(odx_id=OdxLinkId("somersault.NR.flips_not_done", doc_frags),
              short_name="flips_not_done",
              response_type="NEG-RESPONSE",
              parameters=[
@@ -838,127 +838,127 @@ somersault_negative_responses = {
 # services
 somersault_services = {
     "start_session":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.session_start", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.session_start", doc_frags),
                 short_name="session_start",
-                request=OdxLinkRef.from_id(somersault_requests["start_session"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["start_session"].odx_id),
                 semantic="SESSION",
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["session"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["session"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["session"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_functional_classes["session"].odx_id),
                 ]
                 ),
 
     "stop_session":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.session_stop", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.session_stop", doc_frags),
                 short_name="session_stop",
                 semantic="SESSION",
-                request=OdxLinkRef.from_id(somersault_requests["stop_session"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["stop_session"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["session"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["session"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["session"].odx_link_id)
+                    OdxLinkRef.from_id(somersault_functional_classes["session"].odx_id)
                 ]
                 ),
 
     "tester_present":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.tester_present", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.tester_present", doc_frags),
                 short_name="tester_present",
                 semantic="TESTERPRESENT",
-                request=OdxLinkRef.from_id(somersault_requests["tester_present"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["tester_present"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["tester_ok"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["tester_ok"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["tester_nok"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["tester_nok"].odx_id),
                 ],
                 audience=Audience(
                     enabled_audience_refs=[
-                        OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id),
-                        OdxLinkRef.from_id(somersault_additional_audiences["anyone"].odx_link_id),
+                        OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id),
+                        OdxLinkRef.from_id(somersault_additional_audiences["anyone"].odx_id),
                     ],
                     is_development=False)
                 ),
 
     "set_operation_params":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.set_operation_params", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.set_operation_params", doc_frags),
                 short_name="set_operation_params",
                 semantic="FUNCTION",
-                request=OdxLinkRef.from_id(somersault_requests["set_operation_params"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["set_operation_params"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["set_operation_params"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["set_operation_params"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
                 ],
                 ),
 
     "forward_flips":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.do_forward_flips", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.do_forward_flips", doc_frags),
                 short_name="do_forward_flips",
                 description="<p>Do a forward flip.</p>",
                 semantic="FUNCTION",
-                request=OdxLinkRef.from_id(somersault_requests["forward_flips"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["forward_flips"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["forward_flips_grudgingly_done"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["forward_flips_grudgingly_done"].odx_id),
                     # TODO: implement handling of multiple responses
-                    #OdxLinkRef.from_id(somersault_positive_responses["forward_flips_happily_done"].odx_link_id),
+                    #OdxLinkRef.from_id(somersault_positive_responses["forward_flips_happily_done"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_id),
                     # TODO (?): implement handling of multiple possible responses
-                    #OdxLinkRef.from_id(somersault_negative_responses["stumbled"].odx_link_id),
-                    #OdxLinkRef.from_id(somersault_negative_responses["too_dizzy"].odx_link_id),
-                    #OdxLinkRef.from_id(somersault_negative_responses["not_sober"].odx_link_id),
+                    #OdxLinkRef.from_id(somersault_negative_responses["stumbled"].odx_id),
+                    #OdxLinkRef.from_id(somersault_negative_responses["too_dizzy"].odx_id),
+                    #OdxLinkRef.from_id(somersault_negative_responses["not_sober"].odx_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_link_id)
+                    OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_id)
                 ],
                 audience=Audience(
-                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)],
+                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
                     is_development=False)
                 ),
 
     "backward_flips":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.do_backward_flips", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.do_backward_flips", doc_frags),
                 short_name="do_backward_flips",
                 semantic="FUNCTION",
-                request=OdxLinkRef.from_id(somersault_requests["backward_flips"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["backward_flips"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["backward_flips_grudgingly_done"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["backward_flips_grudgingly_done"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_id),
                 ],
                 functional_class_refs=[
-                    OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_link_id)
+                    OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_id)
                 ],
                 audience=Audience(
-                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)],
+                    enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
                     is_development=False)
                 ),
 
     "report_status":
-    DiagService(odx_link_id=OdxLinkId("somersault.service.report_status", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault.service.report_status", doc_frags),
                 short_name="report_status",
                 semantic="CURRENTDATA",
-                request=OdxLinkRef.from_id(somersault_requests["report_status"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_requests["report_status"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_positive_responses["status_report"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_positive_responses["status_report"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
                 ],
                 audience=Audience(
-                    disabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)],
+                    disabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
                     is_aftersales=False,
                     is_aftermarket=False)
                 ),
@@ -967,7 +967,7 @@ somersault_services = {
 
 somersault_single_ecu_jobs = {
     "compulsory_program":
-    SingleEcuJob(odx_link_id=OdxLinkId("somersault.service.compulsory_program", doc_frags),
+    SingleEcuJob(odx_id=OdxLinkId("somersault.service.compulsory_program", doc_frags),
                  short_name="compulsory_program",
                  long_name="Compulsory Program",
                  description="<p>Do several fancy moves.</p>",
@@ -1100,7 +1100,7 @@ somersault_diag_data_dictionary_spec = DiagDataDictionarySpec(
 # diagnostics layer
 somersault_diaglayer = DiagLayer(
     variant_type="BASE-VARIANT",
-    odx_link_id=OdxLinkId("somersault", doc_frags),
+    odx_id=OdxLinkId("somersault", doc_frags),
     short_name="somersault",
     long_name="Somersault base variant",
     description="<p>Base variant of the somersault ECU &amp; cetera</p>",
@@ -1121,13 +1121,13 @@ somersault_diaglayer = DiagLayer(
 # TODO: inheritance (without too much code duplication)
 somersault_lazy_diaglayer = DiagLayer(
     variant_type="ECU-VARIANT",
-    odx_link_id=OdxLinkId("somersault_lazy", doc_frags),
+    odx_id=OdxLinkId("somersault_lazy", doc_frags),
     short_name="somersault_lazy",
     long_name="Somersault lazy ECU",
     description="<p>Sloppy variant of the somersault ECU (lazy &lt; assiduous)</p>",
     parent_refs=[
         DiagLayer.ParentRef( # <- TODO: this is a bit sketchy IMO
-            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_link_id),
+            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does not do backflips
             not_inherited_diag_comms=[
@@ -1147,14 +1147,14 @@ somersault_lazy_diaglayer = DiagLayer(
 # TODO: inheritance (without too much code duplication)
 somersault_assiduous_diaglayer = DiagLayer(
     variant_type="ECU-VARIANT",
-    odx_link_id=OdxLinkId("somersault_assiduous", doc_frags),
+    odx_id=OdxLinkId("somersault_assiduous", doc_frags),
     short_name="somersault_assiduous",
     long_name="Somersault assiduous ECU",
     description="<p>Hard-working variant of the somersault ECU (lazy &lt; assiduous)</p>",
     diag_data_dictionary_spec=DiagDataDictionarySpec(),
     parent_refs=[
         DiagLayer.ParentRef( # <- TODO: this is a bit sketchy IMO
-            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_link_id),
+            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does everything which the base variant does
         )],
@@ -1166,7 +1166,7 @@ somersault_assiduous_diaglayer = DiagLayer(
 somersault_assiduous_requests = {
     "headstand":
     Request(
-        odx_link_id=OdxLinkId("somersault_assiduous.RQ.do_headstand", doc_frags),
+        odx_id=OdxLinkId("somersault_assiduous.RQ.do_headstand", doc_frags),
         short_name="do_headstand",
         long_name="Do a headstand & whatever else is required to entertain the customer",
         parameters=[
@@ -1187,7 +1187,7 @@ somersault_assiduous_requests = {
 # positive responses
 somersault_assiduous_positive_responses = {
     "headstand_done":
-    Response(odx_link_id=OdxLinkId("somersault_assiduous.PR.headstand_done", doc_frags),
+    Response(odx_id=OdxLinkId("somersault_assiduous.PR.headstand_done", doc_frags),
              short_name="headstand_done",
              parameters=[
                  CodedConstParameter(
@@ -1207,7 +1207,7 @@ somersault_assiduous_positive_responses = {
 # negative responses
 somersault_assiduous_negative_responses = {
     "fell_over":
-    Response(odx_link_id=OdxLinkId("somersault_assiduous.NR.fell_over", doc_frags),
+    Response(odx_id=OdxLinkId("somersault_assiduous.NR.fell_over", doc_frags),
              short_name="fell_over",
              parameters=[
                  CodedConstParameter(
@@ -1228,16 +1228,16 @@ somersault_assiduous_negative_responses = {
 # services
 somersault_assiduous_services = {
     "headstand":
-    DiagService(odx_link_id=OdxLinkId("somersault_assiduous.service.headstand", doc_frags),
+    DiagService(odx_id=OdxLinkId("somersault_assiduous.service.headstand", doc_frags),
                 short_name="headstand",
-                request=OdxLinkRef.from_id(somersault_assiduous_requests["headstand"].odx_link_id),
+                request=OdxLinkRef.from_id(somersault_assiduous_requests["headstand"].odx_id),
                 positive_responses=[
-                    OdxLinkRef.from_id(somersault_assiduous_positive_responses["headstand_done"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_assiduous_positive_responses["headstand_done"].odx_id),
                 ],
                 negative_responses=[
-                    OdxLinkRef.from_id(somersault_assiduous_negative_responses["fell_over"].odx_link_id),
+                    OdxLinkRef.from_id(somersault_assiduous_negative_responses["fell_over"].odx_id),
                 ],
-                audience=Audience(enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_link_id)])
+                audience=Audience(enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)])
                 ),
 }
 
@@ -1253,7 +1253,7 @@ somersault_assiduous_diaglayer.negative_responses = NamedItemList(short_name_as_
 
 # create a "diagnosis layer container" object
 somersault_dlc = DiagLayerContainer(
-    odx_link_id=OdxLinkId("DLC.somersault", doc_frags),
+    odx_id=OdxLinkId("DLC.somersault", doc_frags),
     short_name=dlc_short_name,
     long_name="Collect all saults in the summer",
     description="<p>This contains ECUs which do somersaults &amp; cetera</p>",

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -39,7 +39,7 @@ class AdditionalAudience:
     """
     Corresponds to ADDITIONAL-AUDIENCE.
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -69,13 +69,13 @@ def read_audience_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 def read_additional_audience_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
 
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
 
-    return AdditionalAudience(id=id,
+    return AdditionalAudience(odx_link_id=odx_link_id,
                               short_name=short_name,
                               long_name=long_name,
                               description=description)

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -39,7 +39,7 @@ class AdditionalAudience:
     """
     Corresponds to ADDITIONAL-AUDIENCE.
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -69,13 +69,13 @@ def read_audience_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 def read_additional_audience_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
 
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
 
-    return AdditionalAudience(odx_link_id=odx_link_id,
+    return AdditionalAudience(odx_id=odx_id,
                               short_name=short_name,
                               long_name=long_name,
                               description=description)

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -23,7 +23,7 @@ def format_desc(desc, ident=0):
 
 def print_diagnostic_service(service: DiagService, print_params=False, print_pre_condition_states=False,
                              print_state_transitions=False, print_audiences=False, allow_unknown_bit_lengths=False):
-    print(f" {service.short_name} <ID: {service.id}>")
+    print(f" {service.short_name} <ID: {service.odx_link_id}>")
 
     if service.description:
         desc = format_desc(service.description, ident=3)
@@ -75,4 +75,4 @@ def print_diagnostic_service(service: DiagService, print_params=False, print_pre
             or (service.negative_responses and len(service.negative_responses) > 1)):
         # Does this ever happen?
         raise NotImplementedError(
-            f"The diagnostic service {service.id} offers more than one response!")
+            f"The diagnostic service {service.odx_link_id} offers more than one response!")

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -23,7 +23,7 @@ def format_desc(desc, ident=0):
 
 def print_diagnostic_service(service: DiagService, print_params=False, print_pre_condition_states=False,
                              print_state_transitions=False, print_audiences=False, allow_unknown_bit_lengths=False):
-    print(f" {service.short_name} <ID: {service.odx_link_id}>")
+    print(f" {service.short_name} <ID: {service.odx_id}>")
 
     if service.description:
         desc = format_desc(service.description, ident=3)
@@ -75,4 +75,4 @@ def print_diagnostic_service(service: DiagService, print_params=False, print_pre
             or (service.negative_responses and len(service.negative_responses) > 1)):
         # Does this ever happen?
         raise NotImplementedError(
-            f"The diagnostic service {service.odx_link_id} offers more than one response!")
+            f"The diagnostic service {service.odx_id} offers more than one response!")

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -78,7 +78,7 @@ def print_summary(odxdb: Database,
                                      print_state_transitions=True,
                                      print_audiences=True)
         elif isinstance(service, SingleEcuJob):
-            print(f"SingleEcuJob: {service.odx_link_id}")
+            print(f"SingleEcuJob: {service.odx_id}")
         else:
             print(f"Unknown service: {service}")
 

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -78,7 +78,7 @@ def print_summary(odxdb: Database,
                                      print_state_transitions=True,
                                      print_audiences=True)
         elif isinstance(service, SingleEcuJob):
-            print(f"SingleEcuJob: {service.id}")
+            print(f"SingleEcuJob: {service.odx_link_id}")
         else:
             print(f"Unknown service: {service}")
 

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -79,7 +79,7 @@ def print_summary(odxdb: Database,
                             allow_unknown_bit_lengths=allow_unknown_bit_lengths
                         )
                     elif isinstance(service, SingleEcuJob):
-                        print(f" Single ECU job: {service.odx_link_id}")
+                        print(f" Single ECU job: {service.odx_id}")
                     else:
                         print(f" Unidentifiable service: {service}")
 

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -79,7 +79,7 @@ def print_summary(odxdb: Database,
                             allow_unknown_bit_lengths=allow_unknown_bit_lengths
                         )
                     elif isinstance(service, SingleEcuJob):
-                        print(f" Single ECU job: {service.id}")
+                        print(f" Single ECU job: {service.odx_link_id}")
                     else:
                         print(f" Unidentifiable service: {service}")
 

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -32,7 +32,7 @@ class CompanySpecificInfo:
 
 @dataclass()
 class TeamMember:
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -47,7 +47,7 @@ class TeamMember:
 
 @dataclass()
 class CompanyData:
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -56,12 +56,12 @@ class CompanyData:
     company_specific_info: Optional[CompanySpecificInfo] = None
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result = { self.odx_link_id: self }
+        result = { self.odx_id: self }
 
         # team members
         if self.team_members is not None:
             for tm in self.team_members:
-                result[tm.odx_link_id] = tm
+                result[tm.odx_id] = tm
 
         return result
 
@@ -121,8 +121,8 @@ def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     cdl = NamedItemList(short_name_as_id) # type: ignore
 
     for cd in et_element.iterfind("COMPANY-DATA"):
-        odx_link_id = OdxLinkId.from_et(cd, doc_frags)
-        assert odx_link_id is not None
+        odx_id = OdxLinkId.from_et(cd, doc_frags)
+        assert odx_id is not None
         short_name = cd.find("SHORT-NAME").text
 
         long_name = cd.find("LONG-NAME")
@@ -194,7 +194,7 @@ def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
                 if tm_email is not None:
                     tm_email = tm_email.text
 
-                tml.append(TeamMember(odx_link_id=tm_id,
+                tml.append(TeamMember(odx_id=tm_id,
                                       short_name=tm_short_name,
                                       long_name=tm_long_name,
                                       description=tm_description,
@@ -231,7 +231,7 @@ def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
             company_specific_info = CompanySpecificInfo(related_docs=related_docs)
 
-        cdl.append(CompanyData(odx_link_id=odx_link_id,
+        cdl.append(CompanyData(odx_id=odx_id,
                                short_name=short_name,
                                long_name=long_name,
                                description=description,

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -32,7 +32,7 @@ class CompanySpecificInfo:
 
 @dataclass()
 class TeamMember:
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -47,7 +47,7 @@ class TeamMember:
 
 @dataclass()
 class CompanyData:
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -56,12 +56,12 @@ class CompanyData:
     company_specific_info: Optional[CompanySpecificInfo] = None
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result = { self.id: self }
+        result = { self.odx_link_id: self }
 
         # team members
         if self.team_members is not None:
             for tm in self.team_members:
-                result[tm.id] = tm
+                result[tm.odx_link_id] = tm
 
         return result
 
@@ -121,8 +121,8 @@ def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     cdl = NamedItemList(short_name_as_id) # type: ignore
 
     for cd in et_element.iterfind("COMPANY-DATA"):
-        id = OdxLinkId.from_et(cd, doc_frags)
-        assert id is not None
+        odx_link_id = OdxLinkId.from_et(cd, doc_frags)
+        assert odx_link_id is not None
         short_name = cd.find("SHORT-NAME").text
 
         long_name = cd.find("LONG-NAME")
@@ -194,7 +194,7 @@ def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
                 if tm_email is not None:
                     tm_email = tm_email.text
 
-                tml.append(TeamMember(id=tm_id,
+                tml.append(TeamMember(odx_link_id=tm_id,
                                       short_name=tm_short_name,
                                       long_name=tm_long_name,
                                       description=tm_description,
@@ -231,7 +231,7 @@ def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
             company_specific_info = CompanySpecificInfo(related_docs=related_docs)
 
-        cdl.append(CompanyData(id=id,
+        cdl.append(CompanyData(odx_link_id=odx_link_id,
                                short_name=short_name,
                                long_name=long_name,
                                description=description,

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -94,7 +94,7 @@ class Database:
 
     @property
     def odxlinks(self) -> dict:
-        """A map from odx_link_id to object"""
+        """A map from odx_id to object"""
         return self._odxlinks
 
     @property

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -94,7 +94,7 @@ class Database:
 
     @property
     def odxlinks(self) -> dict:
-        """A map from id to object"""
+        """A map from odx_link_id to object"""
         return self._odxlinks
 
     @property

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -5,6 +5,7 @@ import abc
 from typing import List, Dict, Optional, Any, Union
 from dataclasses import dataclass
 
+from .utils import read_description_from_odx
 from .physicaltype import PhysicalType, read_physical_type_from_odx
 from .globals import logger
 from .compumethods import CompuMethod, read_compu_method_from_odx
@@ -306,9 +307,8 @@ def read_data_object_property_from_odx(et_element, doc_frags: List[OdxDocFragmen
     id = OdxLinkId.from_et(et_element, doc_frags)
     assert id is not None
     short_name = et_element.find("SHORT-NAME").text
-    long_name = et_element.find("LONG-NAME").text
-    description = et_element.find("DESCRIPTION").text if et_element.find(
-        "DESCRIPTION") is not None else None
+    long_name = et_element.findtext("LONG-NAME")
+    description = read_description_from_odx(et_element.find("DESC"))
     logger.debug('Parsing DOP ' + short_name)
 
     diag_coded_type = read_diag_coded_type_from_odx(

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -23,12 +23,12 @@ class DopBase(abc.ABC):
     """
 
     def __init__(self,
-                 odx_link_id,
+                 odx_id,
                  short_name,
                  long_name=None,
                  description=None,
                  is_visible=True):
-        self.odx_link_id = odx_link_id
+        self.odx_id = odx_id
         self.short_name = short_name
         self.long_name = long_name
         self.description = description
@@ -49,7 +49,7 @@ class DataObjectProperty(DopBase):
     """This class represents a DATA-OBJECT-PROP."""
 
     def __init__(self,
-                 odx_link_id: OdxLinkId,
+                 odx_id: OdxLinkId,
                  short_name: str,
                  diag_coded_type: DiagCodedType,
                  physical_type: PhysicalType,
@@ -58,7 +58,7 @@ class DataObjectProperty(DopBase):
                  long_name: Optional[str] = None,
                  description: Optional[str] = None
                  ):
-        super().__init__(odx_link_id=odx_link_id,
+        super().__init__(odx_id=odx_id,
                          short_name=short_name,
                          long_name=long_name,
                          description=description)
@@ -149,7 +149,7 @@ class DataObjectProperty(DopBase):
 @dataclass
 class DiagnosticTroubleCode:
     trouble_code: int
-    odx_link_id: Optional[OdxLinkId] = None
+    odx_id: Optional[OdxLinkId] = None
     short_name: Optional[str] = None
     text: Optional[str] = None
     display_trouble_code: Optional[str] = None
@@ -168,8 +168,8 @@ class DtcRef:
         self.dtc: Optional[DiagnosticTroubleCode] = None
 
     @property
-    def odx_link_id(self):
-        return self.dtc.odx_link_id
+    def odx_id(self):
+        return self.dtc.odx_id
 
     @property
     def short_name(self):
@@ -206,7 +206,7 @@ class DtcDop(DataObjectProperty):
     """ A DOP describing a diagnostic trouble code """
 
     def __init__(self,
-                 odx_link_id: OdxLinkId,
+                 odx_id: OdxLinkId,
                  short_name: str,
                  diag_coded_type: DiagCodedType,
                  physical_type: PhysicalType,
@@ -217,7 +217,7 @@ class DtcDop(DataObjectProperty):
                  long_name: str = None,
                  description: str = None
                  ):
-        super().__init__(odx_link_id=odx_link_id,
+        super().__init__(odx_id=odx_id,
                          short_name=short_name,
                          long_name=long_name,
                          description=description,
@@ -269,11 +269,11 @@ class DtcDop(DataObjectProperty):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks: Dict[OdxLinkId, Any] = {}
-        odxlinks[self.odx_link_id] = self
+        odxlinks[self.odx_id] = self
         for dtc in self.dtcs:
             if isinstance(dtc, DiagnosticTroubleCode):
-                assert dtc.odx_link_id is not None
-                odxlinks[dtc.odx_link_id] = dtc
+                assert dtc.odx_id is not None
+                odxlinks[dtc.odx_id] = dtc
         return odxlinks
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
@@ -293,7 +293,7 @@ def read_dtc_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     else:
         level = None
 
-    return DiagnosticTroubleCode(odx_link_id=OdxLinkId.from_et(et_element, doc_frags),
+    return DiagnosticTroubleCode(odx_id=OdxLinkId.from_et(et_element, doc_frags),
                                  short_name=et_element.find("SHORT-NAME").text,
                                  trouble_code=int(
                                      et_element.find("TROUBLE-CODE").text),
@@ -305,8 +305,8 @@ def read_dtc_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 def read_data_object_property_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> DataObjectProperty:
     """Reads a DATA-OBJECT-PROP or a DTC-DOP."""
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
@@ -322,7 +322,7 @@ def read_data_object_property_from_odx(et_element, doc_frags: List[OdxDocFragmen
 
     if et_element.tag == "DATA-OBJECT-PROP":
         unit_ref = OdxLinkRef.from_et(et_element.find("UNIT-REF"), doc_frags)
-        dop = DataObjectProperty(odx_link_id,
+        dop = DataObjectProperty(odx_id,
                                  short_name,
                                  diag_coded_type,
                                  physical_type,
@@ -337,7 +337,7 @@ def read_data_object_property_from_odx(et_element, doc_frags: List[OdxDocFragmen
                  for el in et_element.iterfind("DTCS/DTC-REF")]
 
         is_visible = et_element.get("IS-VISIBLE") == "true"
-        dop = DtcDop(odx_link_id,
+        dop = DtcDop(odx_id,
                      short_name,
                      diag_coded_type,
                      physical_type,

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -229,8 +229,9 @@ class DtcDop(DataObjectProperty):
         self.linked_dtc_dops = linked_dtc_dops
 
     def convert_bytes_to_physical(self, decode_state, bit_position: int = 0):
-        trouble_code, next_byte = super().convert_bytes_to_physical(decode_state,
-                                                                    bit_position=bit_position)
+        trouble_code, next_byte = \
+            super().convert_bytes_to_physical(decode_state,
+                                              bit_position=bit_position)
 
         dtcs = [ x for x in self.dtcs if x.trouble_code == trouble_code ]
 

--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -447,12 +447,12 @@ class ParamLengthInfoType(DiagCodedType):
             # if isinstance(param_value.parameter, LengthKeyParameter) would be prettier,
             # but leads to cyclic import...
             if parameter.parameter_type == "LENGTH-KEY" \
-                    and parameter.id == self.length_key_id: # type: ignore
+                    and parameter.odx_link_id == self.length_key_id: # type: ignore
                 # The bit length of the parameter to be extracted is given by the length key.
                 bit_length = value
                 break
 
-        assert bit_length is not None, f"Did not find any length key with ID {self.length_key_id}"
+        assert bit_length is not None, f"Dodx_link_id not find any length key with ID {self.length_key_id}"
 
         # Extract the internal value and return.
         return self._extract_internal(decode_state.coded_message,

--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -447,7 +447,7 @@ class ParamLengthInfoType(DiagCodedType):
             # if isinstance(param_value.parameter, LengthKeyParameter) would be prettier,
             # but leads to cyclic import...
             if parameter.parameter_type == "LENGTH-KEY" \
-                    and parameter.odx_link_id == self.length_key_id: # type: ignore
+                    and parameter.odx_id == self.length_key_id: # type: ignore
                 # The bit length of the parameter to be extracted is given by the length key.
                 assert isinstance(value, int)
                 bit_length = value

--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -3,7 +3,7 @@
 
 import abc
 import math
-from typing import Any, Union, List
+from typing import Any, Optional, Union, List
 
 from .odxtypes import DataType
 from .exceptions import DecodeError, EncodeError
@@ -38,13 +38,13 @@ class DiagCodedType(abc.ABC):
         self.is_highlow_byte_order = is_highlow_byte_order
 
     def _extract_internal(self,
-                          coded_message,
-                          byte_position,
-                          bit_position,
-                          bit_length,
+                          coded_message: bytes,
+                          byte_position: int,
+                          bit_position: int,
+                          bit_length: int,
                           base_data_type: DataType,
-                          is_highlow_byte_order,
-                          bit_mask=None):
+                          is_highlow_byte_order: bool,
+                          bit_mask: Optional[int] = None):
         """Extract the internal value.
 
         Helper method for `DiagCodedType.convert_bytes_to_internal`.
@@ -442,17 +442,18 @@ class ParamLengthInfoType(DiagCodedType):
 
     def convert_bytes_to_internal(self, decode_state: DecodeState, bit_position: int = 0):
         # Find length key with matching ID.
-        bit_length = None
+        bit_length = 0
         for parameter, value in decode_state.parameter_value_pairs:
             # if isinstance(param_value.parameter, LengthKeyParameter) would be prettier,
             # but leads to cyclic import...
             if parameter.parameter_type == "LENGTH-KEY" \
                     and parameter.odx_link_id == self.length_key_id: # type: ignore
                 # The bit length of the parameter to be extracted is given by the length key.
+                assert isinstance(value, int)
                 bit_length = value
                 break
 
-        assert bit_length is not None, f"Dodx_link_id not find any length key with ID {self.length_key_id}"
+        assert bit_length is not None, f"Did not find any length key with ID {self.length_key_id}"
 
         # Extract the internal value and return.
         return self._extract_internal(decode_state.coded_message,

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -99,7 +99,7 @@ class DiagDataDictionarySpec:
         for obj in chain(
             self.data_object_props, self.structures, self.end_of_pdu_fields, self.tables
         ):
-            odxlinks[obj.odx_link_id] = obj
+            odxlinks[obj.odx_id] = obj
 
         for table in self.tables:
             odxlinks.update(table._build_odxlinks())

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -217,7 +217,7 @@ def read_diag_data_dictionary_spec_from_odx(et_element, doc_frags: List[OdxDocFr
     ]:
         num = len(list(et_element.iterfind(path)))
         if num > 0:
-            logger.info(f"Not implemented: Dodx_link_id not parse {num} {name}.")
+            logger.info(f"Not implemented: Did not parse {num} {name}.")
 
     return DiagDataDictionarySpec(
         data_object_props=NamedItemList(short_name_as_id, data_object_props),

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -99,7 +99,7 @@ class DiagDataDictionarySpec:
         for obj in chain(
             self.data_object_props, self.structures, self.end_of_pdu_fields, self.tables
         ):
-            odxlinks[obj.id] = obj
+            odxlinks[obj.odx_link_id] = obj
 
         for table in self.tables:
             odxlinks.update(table._build_odxlinks())
@@ -217,7 +217,7 @@ def read_diag_data_dictionary_spec_from_odx(et_element, doc_frags: List[OdxDocFr
     ]:
         num = len(list(et_element.iterfind(path)))
         if num > 0:
-            logger.info(f"Not implemented: Did not parse {num} {name}.")
+            logger.info(f"Not implemented: Dodx_link_id not parse {num} {name}.")
 
     return DiagDataDictionarySpec(
         data_object_props=NamedItemList(short_name_as_id, data_object_props),

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -66,7 +66,7 @@ class DiagLayer:
             else:
                 assert isinstance(parent, DiagLayer)
 
-                self.parent_ref = OdxLinkRef.from_id(parent.odx_link_id)
+                self.parent_ref = OdxLinkRef.from_id(parent.odx_id)
                 self.parent_diag_layer = parent
             self.not_inherited_diag_comms = not_inherited_diag_comms
             self.not_inherited_dops = not_inherited_dops
@@ -93,7 +93,7 @@ class DiagLayer:
 
     def __init__(self,
                  variant_type,
-                 odx_link_id,
+                 odx_id,
                  short_name,
                  long_name=None,
                  description=None,
@@ -118,7 +118,7 @@ class DiagLayer:
         logger.info(f"Initializing variant type {variant_type}")
         self.variant_type = variant_type
 
-        self.odx_link_id = odx_link_id
+        self.odx_id = odx_id
         self.short_name = short_name
         self.long_name = long_name
         self.description = description
@@ -203,7 +203,7 @@ class DiagLayer:
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         """Construct a mapping from IDs to all objects that are contained in this diagnostic layer."""
-        logger.info(f"Adding {self.odx_link_id} to odxlinks.")
+        logger.info(f"Adding {self.odx_id} to odxlinks.")
 
         odxlinks = {}
 
@@ -216,14 +216,14 @@ class DiagLayer:
                          self.functional_classes,
                          self.states,
                          self.state_transitions):
-            odxlinks[obj.odx_link_id] = obj
+            odxlinks[obj.odx_id] = obj
 
         if self.local_diag_data_dictionary_spec:
             odxlinks.update(
                 self.local_diag_data_dictionary_spec._build_odxlinks()
             )
 
-        odxlinks[self.odx_link_id] = self
+        odxlinks[self.odx_id] = self
         return odxlinks
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
@@ -534,7 +534,7 @@ class DiagLayer:
 
     def __repr__(self) -> str:
         return f"""DiagLayer(variant_type={self.variant_type},
-          odx_link_id={repr(self.odx_link_id)},
+          odx_id={repr(self.odx_id)},
           short_name={repr(self.short_name)},
           long_name={repr(self.long_name)},
           description={repr(self.description)},
@@ -589,7 +589,7 @@ def read_diag_layer_from_odx(et_element,
     doc_frags = copy(doc_frags)
     doc_frags.append(OdxDocFragment(short_name, "LAYER"))
 
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
 
     # Parse DiagServices
     services = [read_diag_service_from_odx(service, doc_frags)
@@ -661,7 +661,7 @@ def read_diag_layer_from_odx(et_element,
 
     # Create DiagLayer
     dl = DiagLayer(variant_type,
-                   odx_link_id,
+                   odx_id,
                    short_name,
                    long_name=long_name,
                    description=description,
@@ -687,7 +687,7 @@ def read_diag_layer_from_odx(et_element,
 
 class DiagLayerContainer:
     def __init__(self,
-                 odx_link_id,
+                 odx_id,
                  short_name,
                  long_name=None,
                  description=None,
@@ -699,7 +699,7 @@ class DiagLayerContainer:
                  base_variants=[],
                  ecu_variants=[]
                  ):
-        self.odx_link_id = odx_link_id
+        self.odx_id = odx_id
         self.short_name = short_name
         self.long_name = long_name
         self.description = description
@@ -718,7 +718,7 @@ class DiagLayerContainer:
 
     def _build_odxlinks(self):
         result = {}
-        result[self.odx_link_id] = self
+        result[self.odx_id] = self
 
         if self.admin_data is not None:
             result.update(self.admin_data._build_odxlinks())
@@ -761,8 +761,8 @@ def read_diag_layer_container_from_odx(et_element, enable_candela_workarounds=Tr
     # current document for references and IDs)
     doc_frags = [ OdxDocFragment(short_name, "CONTAINER") ]
 
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     description = read_description_from_odx(et_element.find("DESC"))
     admin_data = read_admin_data_from_odx(et_element.find("ADMIN-DATA"), doc_frags)
     company_datas = read_company_datas_from_odx(et_element.find("COMPANY-DATAS"), doc_frags)
@@ -787,7 +787,7 @@ def read_diag_layer_container_from_odx(et_element, enable_candela_workarounds=Tr
                                              enable_candela_workarounds=enable_candela_workarounds)
                     for dl_element in et_element.iterfind("ECU-VARIANTS/ECU-VARIANT")]
 
-    return DiagLayerContainer(odx_link_id,
+    return DiagLayerContainer(odx_id,
                               short_name,
                               long_name=long_name,
                               description=description,

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -56,7 +56,7 @@ class EndOfPduField(DopBase):
     def convert_physical_to_internal(self, physical_value):
         return self.structure.convert_physical_to_internal(physical_value)
 
-    def convert_physical_to_bytes(self, physical_value: Union[dict, List[dict]], encode_state: EncodeState, bit_position=0):
+    def convert_physical_to_bytes(self, physical_value: Union[dict, List[dict]], encode_state: EncodeState, bit_position: int = 0):
         assert bit_position == 0, "End of PDU field must be byte aligned. Is there an error in reading the .odx?"
         if isinstance(physical_value, dict):
             # If the value is given as a dict, the End of PDU field behaves like the underlying structure.
@@ -70,7 +70,7 @@ class EndOfPduField(DopBase):
                 coded_rpc += self.structure.convert_physical_to_bytes(value, encode_state)
             return coded_rpc
 
-    def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position=0):
+    def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
         next_byte_position = decode_state.next_byte_position
         byte_code = decode_state.coded_message
 

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -18,7 +18,7 @@ class EndOfPduField(DopBase):
     """ End of PDU fields are structures that are repeated until the end of the PDU """
 
     def __init__(self,
-                 odx_link_id,
+                 odx_id,
                  short_name,
                  structure=None,
                  structure_ref=None,
@@ -28,7 +28,7 @@ class EndOfPduField(DopBase):
                  is_visible=False,
                  long_name=None,
                  description=None):
-        super().__init__(odx_link_id, short_name, long_name=long_name,
+        super().__init__(odx_id, short_name, long_name=long_name,
                          description=description, is_visible=is_visible)
 
         self.structure_snref = structure_snref
@@ -36,7 +36,7 @@ class EndOfPduField(DopBase):
 
         self._structure = structure
         if structure:
-            self.structure_ref = OdxLinkRef.from_id(structure.odx_link_id)
+            self.structure_ref = OdxLinkRef.from_id(structure.odx_id)
         assert self.structure_ref or self.structure_snref
 
         self.min_number_of_items = min_number_of_items
@@ -100,11 +100,11 @@ class EndOfPduField(DopBase):
             self._structure = parent_dl.data_object_properties[self.structure_snref]
 
     def __repr__(self) -> str:
-        return f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_link_id}')"
+        return f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_id}')"
 
     def __str__(self):
         return "\n".join([
-            f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_link_id}')"
+            f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_id}')"
         ] + [
             " " + str(self.structure).replace("\n", "\n ")
         ])
@@ -112,8 +112,8 @@ class EndOfPduField(DopBase):
 
 def read_end_of_pdu_field_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> EndOfPduField:
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
@@ -152,7 +152,7 @@ def read_end_of_pdu_field_from_odx(et_element, doc_frags: List[OdxDocFragment]) 
         is_visible = is_visible == "true"
     else:
         is_visible = False
-    eopf = EndOfPduField(odx_link_id,
+    eopf = EndOfPduField(odx_id,
                          short_name,
                          long_name=long_name,
                          description=description,

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -18,7 +18,7 @@ class EndOfPduField(DopBase):
     """ End of PDU fields are structures that are repeated until the end of the PDU """
 
     def __init__(self,
-                 id,
+                 odx_link_id,
                  short_name,
                  structure=None,
                  structure_ref=None,
@@ -28,7 +28,7 @@ class EndOfPduField(DopBase):
                  is_visible=False,
                  long_name=None,
                  description=None):
-        super().__init__(id, short_name, long_name=long_name,
+        super().__init__(odx_link_id, short_name, long_name=long_name,
                          description=description, is_visible=is_visible)
 
         self.structure_snref = structure_snref
@@ -36,7 +36,7 @@ class EndOfPduField(DopBase):
 
         self._structure = structure
         if structure:
-            self.structure_ref = OdxLinkRef.from_id(structure.id)
+            self.structure_ref = OdxLinkRef.from_id(structure.odx_link_id)
         assert self.structure_ref or self.structure_snref
 
         self.min_number_of_items = min_number_of_items
@@ -100,11 +100,11 @@ class EndOfPduField(DopBase):
             self._structure = parent_dl.data_object_properties[self.structure_snref]
 
     def __repr__(self) -> str:
-        return f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.id}')"
+        return f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_link_id}')"
 
     def __str__(self):
         return "\n".join([
-            f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.id}')"
+            f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_link_id}')"
         ] + [
             " " + str(self.structure).replace("\n", "\n ")
         ])
@@ -112,8 +112,8 @@ class EndOfPduField(DopBase):
 
 def read_end_of_pdu_field_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> EndOfPduField:
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
@@ -152,7 +152,7 @@ def read_end_of_pdu_field_from_odx(et_element, doc_frags: List[OdxDocFragment]) 
         is_visible = is_visible == "true"
     else:
         is_visible = False
-    eopf = EndOfPduField(id,
+    eopf = EndOfPduField(odx_link_id,
                          short_name,
                          long_name=long_name,
                          description=description,

--- a/odxtools/envdata.py
+++ b/odxtools/envdata.py
@@ -16,24 +16,24 @@ class EnvironmentData(BasicStructure):
 
     def __init__(
         self,
-        odx_link_id,
+        odx_id,
         short_name,
         parameters,
         long_name=None,
         description=None,
     ):
         super().__init__(
-            odx_link_id, short_name, parameters, long_name=long_name, description=description
+            odx_id, short_name, parameters, long_name=long_name, description=description
         )
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        odxlinks = {self.odx_link_id: self}
+        odxlinks = {self.odx_id: self}
         return odxlinks
 
     def __repr__(self) -> str:
         return (
             f"EnvironmentData('{self.short_name}', "
-            + ", ".join([f"odx_link_id='{self.odx_link_id}'", f"parameters='{self.parameters}'"])
+            + ", ".join([f"odx_id='{self.odx_id}'", f"parameters='{self.parameters}'"])
             + ")"
         )
 
@@ -41,7 +41,7 @@ class EnvironmentData(BasicStructure):
 def read_env_data_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> EnvironmentData:
     """Reads Environment Data from Diag Layer."""
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.find("LONG-NAME")
     if long_name is not None:
@@ -54,7 +54,7 @@ def read_env_data_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     logger.debug("Parsing ENV-DATA " + short_name)
 
     env_data = EnvironmentData(
-        odx_link_id,
+        odx_id,
         short_name,
         parameters=parameters,
         long_name=long_name,

--- a/odxtools/envdata.py
+++ b/odxtools/envdata.py
@@ -16,24 +16,24 @@ class EnvironmentData(BasicStructure):
 
     def __init__(
         self,
-        id,
+        odx_link_id,
         short_name,
         parameters,
         long_name=None,
         description=None,
     ):
         super().__init__(
-            id, short_name, parameters, long_name=long_name, description=description
+            odx_link_id, short_name, parameters, long_name=long_name, description=description
         )
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        odxlinks = {self.id: self}
+        odxlinks = {self.odx_link_id: self}
         return odxlinks
 
     def __repr__(self) -> str:
         return (
             f"EnvironmentData('{self.short_name}', "
-            + ", ".join([f"id='{self.id}'", f"parameters='{self.parameters}'"])
+            + ", ".join([f"odx_link_id='{self.odx_link_id}'", f"parameters='{self.parameters}'"])
             + ")"
         )
 
@@ -41,7 +41,7 @@ class EnvironmentData(BasicStructure):
 def read_env_data_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> EnvironmentData:
     """Reads Environment Data from Diag Layer."""
-    id = OdxLinkId.from_et(et_element, doc_frags)
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.find("LONG-NAME")
     if long_name is not None:
@@ -54,7 +54,7 @@ def read_env_data_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     logger.debug("Parsing ENV-DATA " + short_name)
 
     env_data = EnvironmentData(
-        id,
+        odx_link_id,
         short_name,
         parameters=parameters,
         long_name=long_name,

--- a/odxtools/envdatadesc.py
+++ b/odxtools/envdatadesc.py
@@ -35,7 +35,7 @@ class EnvironmentDataDescription(DopBase):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
-        odxlinks[self.odx_link_id] = self
+        odxlinks[self.odx_id] = self
 
         for ed in self.env_datas:
             odxlinks.update(ed._build_odxlinks())
@@ -47,7 +47,7 @@ class EnvironmentDataDescription(DopBase):
             f"EnvironmentDataDescription('{self.short_name}', "
             + ", ".join(
                 [
-                    f"odx_link_id='{self.odx_link_id}'",
+                    f"odx_id='{self.odx_id}'",
                     f"param_snref='{self.param_snref}'",
                     f"param_snpathref='{self.param_snpathref}'",
                     f"env_data_refs='{self.env_data_refs}'",
@@ -76,8 +76,8 @@ class EnvironmentDataDescription(DopBase):
 def read_env_data_desc_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> EnvironmentDataDescription:
     """Reads Environment Data Description from Diag Layer."""
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.find("LONG-NAME").text
     param_snref = None
@@ -101,7 +101,7 @@ def read_env_data_desc_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     logger.debug("Parsing ENV-DATA-DESC " + short_name)
 
     return EnvironmentDataDescription(
-        odx_link_id=odx_link_id,
+        odx_id=odx_id,
         short_name=short_name,
         long_name=long_name,
         param_snref=param_snref,

--- a/odxtools/envdatadesc.py
+++ b/odxtools/envdatadesc.py
@@ -35,7 +35,7 @@ class EnvironmentDataDescription(DopBase):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
-        odxlinks[self.id] = self
+        odxlinks[self.odx_link_id] = self
 
         for ed in self.env_datas:
             odxlinks.update(ed._build_odxlinks())
@@ -47,7 +47,7 @@ class EnvironmentDataDescription(DopBase):
             f"EnvironmentDataDescription('{self.short_name}', "
             + ", ".join(
                 [
-                    f"id='{self.id}'",
+                    f"odx_link_id='{self.odx_link_id}'",
                     f"param_snref='{self.param_snref}'",
                     f"param_snpathref='{self.param_snpathref}'",
                     f"env_data_refs='{self.env_data_refs}'",
@@ -76,8 +76,8 @@ class EnvironmentDataDescription(DopBase):
 def read_env_data_desc_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> EnvironmentDataDescription:
     """Reads Environment Data Description from Diag Layer."""
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.find("LONG-NAME").text
     param_snref = None
@@ -101,7 +101,7 @@ def read_env_data_desc_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     logger.debug("Parsing ENV-DATA-DESC " + short_name)
 
     return EnvironmentDataDescription(
-        id=id,
+        odx_link_id=odx_link_id,
         short_name=short_name,
         long_name=long_name,
         param_snref=param_snref,

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -13,7 +13,7 @@ class FunctionalClass:
     """
     Corresponds to FUNCT-CLASS.
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -21,14 +21,14 @@ class FunctionalClass:
 
 def read_functional_class_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
 
     long_name = et_element.find(
         "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
     description = read_description_from_odx(et_element.find("DESC"))
 
-    return FunctionalClass(odx_link_id=odx_link_id,
+    return FunctionalClass(odx_id=odx_id,
                            short_name=short_name,
                            long_name=long_name,
                            description=description)

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -13,7 +13,7 @@ class FunctionalClass:
     """
     Corresponds to FUNCT-CLASS.
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -21,14 +21,14 @@ class FunctionalClass:
 
 def read_functional_class_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
 
     long_name = et_element.find(
         "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
     description = read_description_from_odx(et_element.find("DESC"))
 
-    return FunctionalClass(id=id,
+    return FunctionalClass(odx_link_id=odx_link_id,
                            short_name=short_name,
                            long_name=long_name,
                            description=description)

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -314,11 +314,11 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
         super().on_consecutive_frame(telegram_idx, segment_idx, frame_payload)
 
 
-    def _send_can_message(self, odx_link_id, payload):
+    def _send_can_message(self, can_tx_id, payload):
         if len(payload) < self._padding_size:
             payload = bytes(payload)+bytes([self._padding_value]*(self._padding_size - len(payload)))
 
-        msg = can.Message(arbitration_id=odx_link_id,
+        msg = can.Message(arbitration_id=can_tx_id,
                           data=payload,
                           is_extended_id=False)
 

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -314,11 +314,11 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
         super().on_consecutive_frame(telegram_idx, segment_idx, frame_payload)
 
 
-    def _send_can_message(self, id, payload):
+    def _send_can_message(self, odx_link_id, payload):
         if len(payload) < self._padding_size:
             payload = bytes(payload)+bytes([self._padding_value]*(self._padding_size - len(payload)))
 
-        msg = can.Message(arbitration_id=id,
+        msg = can.Message(arbitration_id=odx_link_id,
                           data=payload,
                           is_extended_id=False)
 

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -116,7 +116,7 @@ class Multiplexer(DopBase):
     """This class represents a Multiplexer (MUX) which are used to interpret data stream depending on the value
     of a switch-key (similar to switch-case statements in programming languages like C or Java)."""
 
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: str
     byte_position: int
@@ -234,7 +234,7 @@ class Multiplexer(DopBase):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
-        odxlinks.update({self.odx_link_id: self})
+        odxlinks.update({self.odx_id: self})
         return odxlinks
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
@@ -250,7 +250,7 @@ class Multiplexer(DopBase):
             f"Multiplexer('{self.short_name}', "
             + ", ".join(
                 [
-                    f"odx_link_id='{self.odx_link_id}'",
+                    f"odx_id='{self.odx_id}'",
                     f"byte_position='{self.byte_position}'",
                     f"switch_key='{self.switch_key}'",
                     f"default_case='{self.default_case}'",
@@ -316,8 +316,8 @@ def read_case_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 def read_mux_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> Multiplexer:
     """Reads a Multiplexer from Diag Layer."""
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
     byte_position = int(et_element.findtext("BYTE-POSITION", "0"))
@@ -338,7 +338,7 @@ def read_mux_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     logger.debug("Parsing MUX " + short_name)
 
     return Multiplexer(
-        odx_link_id=odx_link_id,
+        odx_id=odx_id,
         short_name=short_name,
         long_name=long_name,
         byte_position=byte_position,

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -156,8 +156,10 @@ class Multiplexer(DopBase):
                     case_bytes = bytes()
                 
                 key_value, _ = self._get_case_limits(case)
+                sk_bit_position = self.switch_key.bit_position
+                sk_bit_position = sk_bit_position if sk_bit_position is not None else 0
                 key_bytes = self.switch_key._dop.convert_physical_to_bytes(
-                    key_value, encode_state, self.switch_key.bit_position)
+                    key_value, encode_state, sk_bit_position)
 
                 mux_len = max(
                     len(key_bytes) + key_pos,

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -110,7 +110,7 @@ class Multiplexer(DopBase):
     """This class represents a Multiplexer (MUX) which are used to interpret data stream depending on the value
     of a switch-key (similar to switch-case statements in programming languages like C or Java)."""
 
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: str
     byte_position: int
@@ -227,7 +227,7 @@ class Multiplexer(DopBase):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
-        odxlinks.update({self.id: self})
+        odxlinks.update({self.odx_link_id: self})
         return odxlinks
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
@@ -243,7 +243,7 @@ class Multiplexer(DopBase):
             f"Multiplexer('{self.short_name}', "
             + ", ".join(
                 [
-                    f"id='{self.id}'",
+                    f"odx_link_id='{self.odx_link_id}'",
                     f"byte_position='{self.byte_position}'",
                     f"switch_key='{self.switch_key}'",
                     f"default_case='{self.default_case}'",
@@ -307,8 +307,8 @@ def read_case_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 def read_mux_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     -> Multiplexer:
     """Reads a Multiplexer from Diag Layer."""
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
     byte_position = int(et_element.findtext("BYTE-POSITION", "0"))
@@ -329,7 +329,7 @@ def read_mux_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
     logger.debug("Parsing MUX " + short_name)
 
     return Multiplexer(
-        id=id,
+        odx_link_id=odx_link_id,
         short_name=short_name,
         long_name=long_name,
         byte_position=byte_position,

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -79,12 +79,6 @@ class MultiplexerSwitchKey:
     bit_position: Optional[int]
     dop_ref: OdxLinkRef
 
-    @property
-    def bit_position_int(self) -> int:
-        if self.bit_position is None:
-            return 0
-        return self.bit_position
-
     def __post_init__(self):
         self._dop: DataObjectProperty = None # type: ignore
 
@@ -193,9 +187,10 @@ class Multiplexer(DopBase):
             parameter_value_pairs=[],
             next_byte_position=0
         )
+        bit_position_int = self.switch_key.bit_position if self.switch_key.bit_position is not None else 0
         key_value, key_next_byte = \
             self.switch_key._dop.convert_bytes_to_physical(key_decode_state,
-                                                           bit_position=self.switch_key.bit_position_int)
+                                                           bit_position=bit_position_int)
 
         case_decode_state = DecodeState(
             coded_message=byte_code[self.byte_position:],

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -130,18 +130,18 @@ class OdxLinkRef:
         """
         return OdxLinkRef(odxid.local_id, odxid.doc_fragments)
 
-    def __contains__(self, id: OdxLinkId) -> bool:
+    def __contains__(self, odx_link_id: OdxLinkId) -> bool:
         """
         Returns true iff a given OdxLinkId object is referenced.
         """
 
         # we must reference at to at least of the ID's document
         # fragments
-        if not any([ref_doc in id.doc_fragments for ref_doc in self.ref_docs]):
+        if not any([ref_doc in odx_link_id.doc_fragments for ref_doc in self.ref_docs]):
             return False
 
         # the local ID of the reference and the object ID must match
-        return id.local_id == self.ref_id
+        return odx_link_id.local_id == self.ref_id
 
 class OdxLinkDatabase:
     """

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -130,18 +130,18 @@ class OdxLinkRef:
         """
         return OdxLinkRef(odxid.local_id, odxid.doc_fragments)
 
-    def __contains__(self, odx_link_id: OdxLinkId) -> bool:
+    def __contains__(self, odx_id: OdxLinkId) -> bool:
         """
         Returns true iff a given OdxLinkId object is referenced.
         """
 
         # we must reference at to at least of the ID's document
         # fragments
-        if not any([ref_doc in odx_link_id.doc_fragments for ref_doc in self.ref_docs]):
+        if not any([ref_doc in odx_id.doc_fragments for ref_doc in self.ref_docs]):
             return False
 
         # the local ID of the reference and the object ID must match
-        return odx_link_id.local_id == self.ref_id
+        return odx_id.local_id == self.ref_id
 
 class OdxLinkDatabase:
     """
@@ -162,7 +162,7 @@ class OdxLinkDatabase:
         """
         assert isinstance(ref, OdxLinkRef)
 
-        odx_link_id = OdxLinkId(ref.ref_id, ref.ref_docs)
+        odx_id = OdxLinkId(ref.ref_id, ref.ref_docs)
         for ref_frag in reversed(ref.ref_docs):
             doc_frag_db = self._db.get(ref_frag)
             if doc_frag_db is None:
@@ -173,7 +173,7 @@ class OdxLinkDatabase:
                               f"when resolving reference {ref}", OdxWarning)
                 continue
 
-            obj = doc_frag_db.get(odx_link_id)
+            obj = doc_frag_db.get(odx_id)
             if obj is not None:
                 return obj
 
@@ -189,7 +189,7 @@ class OdxLinkDatabase:
         """
         assert isinstance(ref, OdxLinkRef)
 
-        odx_link_id = OdxLinkId(ref.ref_id, ref.ref_docs)
+        odx_id = OdxLinkId(ref.ref_id, ref.ref_docs)
         for ref_frag in reversed(ref.ref_docs):
             doc_frag_db = self._db.get(ref_frag)
             if doc_frag_db is None:
@@ -200,7 +200,7 @@ class OdxLinkDatabase:
                               f"when resolving reference {ref}", OdxWarning)
                 continue
 
-            obj = doc_frag_db.get(odx_link_id)
+            obj = doc_frag_db.get(odx_id)
             if obj is not None:
                 return obj
 
@@ -215,9 +215,9 @@ class OdxLinkDatabase:
 
         # put all new objects into the databases for the document
         # fragments which it specifies
-        for odx_link_id, obj in new_entries.items():
-            for doc_frag in odx_link_id.doc_fragments:
+        for odx_id, obj in new_entries.items():
+            for doc_frag in odx_id.doc_fragments:
                 if doc_frag not in self._db:
                     self._db[doc_frag] = dict()
 
-                self._db[doc_frag][odx_link_id] = obj
+                self._db[doc_frag][odx_id] = obj

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -45,7 +45,9 @@ class CodedConstParameter(Parameter):
                 and encode_state.parameter_values[self.short_name] != self.coded_value:
             raise TypeError(f"The parameter '{self.short_name}' is constant {self._coded_value_str}"
                             " and thus can not be changed.")
-        return self.diag_coded_type.convert_internal_to_bytes(self.coded_value, encode_state, bit_position=self.bit_position)
+        return self.diag_coded_type.convert_internal_to_bytes(self.coded_value,
+                                                              encode_state=encode_state,
+                                                              bit_position=self.bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
@@ -54,8 +56,9 @@ class CodedConstParameter(Parameter):
                 next_byte_position=self.byte_position)
 
         # Extract coded values
-        coded_val, next_byte_position = self.diag_coded_type.convert_bytes_to_internal(decode_state,
-                                                                                       bit_position=self.bit_position)
+        coded_val, next_byte_position = \
+            self.diag_coded_type.convert_bytes_to_internal(decode_state,
+                                                           bit_position=self.bit_position_int)
 
         # Check if the coded value in the message is correct.
         if self.coded_value != coded_val:
@@ -80,9 +83,9 @@ class CodedConstParameter(Parameter):
         if self.long_name is not None:
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
-            repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
-            repr_str += f", bit_position='{self.bit_position}'"
+            repr_str += f", byte_position={self.byte_position}"
+        if self.bit_position is not None:
+            repr_str += f", bit_position={self.bit_position}"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"
         repr_str += f", diag_coded_type={repr(self.diag_coded_type)}"

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -45,9 +45,10 @@ class CodedConstParameter(Parameter):
                 and encode_state.parameter_values[self.short_name] != self.coded_value:
             raise TypeError(f"The parameter '{self.short_name}' is constant {self._coded_value_str}"
                             " and thus can not be changed.")
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         return self.diag_coded_type.convert_internal_to_bytes(self.coded_value,
                                                               encode_state=encode_state,
-                                                              bit_position=self.bit_position_int)
+                                                              bit_position=bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
@@ -56,9 +57,10 @@ class CodedConstParameter(Parameter):
                 next_byte_position=self.byte_position)
 
         # Extract coded values
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         coded_val, next_byte_position = \
             self.diag_coded_type.convert_bytes_to_internal(decode_state,
-                                                           bit_position=self.bit_position_int)
+                                                           bit_position=bit_position_int)
 
         # Check if the coded value in the message is correct.
         if self.coded_value != coded_val:

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -10,7 +10,7 @@ class DynamicParameter(Parameter):
                  short_name,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         super().__init__(
@@ -49,7 +49,7 @@ class DynamicParameter(Parameter):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -24,7 +24,7 @@ class LengthKeyParameter(ParameterWithDOP):
                  dop_snref=None,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         super().__init__(short_name,

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -13,13 +13,13 @@ class LengthKeyParameter(ParameterWithDOP):
     The other parameter references the length key parameter using a ParamLengthInfoType as .diag_coded_type.
 
     LengthKeyParameters are decoded the same as ValueParameters.
-    The main difference to ValueParameters is that a LengthKeyParameter has an `.odx_link_id` attribute
+    The main difference to ValueParameters is that a LengthKeyParameter has an `.odx_id` attribute
     and its DOP must be a simple DOP with PHYSICAL-TYPE/BASE-DATA-TYPE="A_UINT32".
     """
 
     def __init__(self,
                  short_name,
-                 odx_link_id,
+                 odx_id,
                  dop_ref=None,
                  dop_snref=None,
                  long_name=None,
@@ -36,7 +36,7 @@ class LengthKeyParameter(ParameterWithDOP):
                          bit_position=bit_position,
                          semantic=semantic,
                          description=description)
-        self.odx_link_id = odx_link_id
+        self.odx_id = odx_id
 
     def is_required(self):
         return False
@@ -52,6 +52,6 @@ class LengthKeyParameter(ParameterWithDOP):
                             f" must be specified.")
 
         # Set the value of the length key in the length key dict.
-        encode_state.length_keys[self.odx_link_id] = physical_value
+        encode_state.length_keys[self.odx_id] = physical_value
 
         return super(ParameterWithDOP, self).encode_into_pdu(encode_state)

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -13,13 +13,13 @@ class LengthKeyParameter(ParameterWithDOP):
     The other parameter references the length key parameter using a ParamLengthInfoType as .diag_coded_type.
 
     LengthKeyParameters are decoded the same as ValueParameters.
-    The main difference to ValueParameters is that a LengthKeyParameter has an `.id` attribute
+    The main difference to ValueParameters is that a LengthKeyParameter has an `.odx_link_id` attribute
     and its DOP must be a simple DOP with PHYSICAL-TYPE/BASE-DATA-TYPE="A_UINT32".
     """
 
     def __init__(self,
                  short_name,
-                 id,
+                 odx_link_id,
                  dop_ref=None,
                  dop_snref=None,
                  long_name=None,
@@ -36,7 +36,7 @@ class LengthKeyParameter(ParameterWithDOP):
                          bit_position=bit_position,
                          semantic=semantic,
                          description=description)
-        self.id = id
+        self.odx_link_id = odx_link_id
 
     def is_required(self):
         return False
@@ -52,6 +52,6 @@ class LengthKeyParameter(ParameterWithDOP):
                             f" must be specified.")
 
         # Set the value of the length key in the length key dict.
-        encode_state.length_keys[self.id] = physical_value
+        encode_state.length_keys[self.odx_link_id] = physical_value
 
         return super(ParameterWithDOP, self).encode_into_pdu(encode_state)

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -47,8 +47,9 @@ class MatchingRequestParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         byte_position = self.byte_position if self.byte_position is not None else decode_state.next_byte_position
-        byte_length = (self.bit_length + self.bit_position + 7) // 8
-        val_as_bytes = decode_state.coded_message[byte_position:byte_position+byte_length]
+        byte_length = (self.bit_length + self.bit_position_int + 7) // 8
+        val_as_bytes = decode_state.coded_message[byte_position:
+                                                  byte_position+byte_length]
 
         return val_as_bytes, byte_position + byte_length
 
@@ -58,7 +59,7 @@ class MatchingRequestParameter(Parameter):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -47,7 +47,8 @@ class MatchingRequestParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         byte_position = self.byte_position if self.byte_position is not None else decode_state.next_byte_position
-        byte_length = (self.bit_length + self.bit_position_int + 7) // 8
+        bit_position = self.bit_position if self.bit_position is not None else 0
+        byte_length = (self.bit_length + bit_position + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:
                                                   byte_position+byte_length]
 

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -63,7 +63,10 @@ class NrcConstParameter(Parameter):
             # If the user does not select one, just select any.
             # I think it does not matter ...
             coded_value = self.coded_values[0]
-        return self.diag_coded_type.convert_internal_to_bytes(coded_value, encode_state, bit_position=self.bit_position)
+
+        return self.diag_coded_type.convert_internal_to_bytes(coded_value,
+                                                              encode_state,
+                                                              bit_position=self.bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
@@ -72,8 +75,9 @@ class NrcConstParameter(Parameter):
                 next_byte_position=self.byte_position)
 
         # Extract coded values
-        coded_value, next_byte_position = self.diag_coded_type.convert_bytes_to_internal(decode_state,
-                                                                                         bit_position=self.bit_position)
+        coded_value, next_byte_position = \
+            self.diag_coded_type.convert_bytes_to_internal(decode_state,
+                                                           bit_position=self.bit_position_int)
 
         # Check if the coded value in the message is correct.
         if coded_value not in self.coded_values:
@@ -99,7 +103,7 @@ class NrcConstParameter(Parameter):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -64,9 +64,10 @@ class NrcConstParameter(Parameter):
             # I think it does not matter ...
             coded_value = self.coded_values[0]
 
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         return self.diag_coded_type.convert_internal_to_bytes(coded_value,
                                                               encode_state,
-                                                              bit_position=self.bit_position_int)
+                                                              bit_position=bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
@@ -75,9 +76,10 @@ class NrcConstParameter(Parameter):
                 next_byte_position=self.byte_position)
 
         # Extract coded values
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         coded_value, next_byte_position = \
             self.diag_coded_type.convert_bytes_to_internal(decode_state,
-                                                           bit_position=self.bit_position_int)
+                                                           bit_position=bit_position_int)
 
         # Check if the coded value in the message is correct.
         if coded_value not in self.coded_values:

--- a/odxtools/parameters/parameterbase.py
+++ b/odxtools/parameters/parameterbase.py
@@ -18,16 +18,28 @@ class Parameter(abc.ABC):
                  parameter_type,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         self.short_name: str = short_name
         self.long_name: Optional[str] = long_name
         self.byte_position: Optional[int] = byte_position
-        self.bit_position: int = bit_position
+        self.bit_position: Optional[int] = bit_position
         self.parameter_type: str = parameter_type
         self.semantic: Optional[str] = semantic
         self.description: Optional[str] = description
+
+    @property
+    def byte_position_int(self) -> int:
+        if self.byte_position is None:
+            return 0
+        return self.byte_position
+
+    @property
+    def bit_position_int(self) -> int:
+        if self.bit_position is None:
+            return 0
+        return self.bit_position
 
     @property
     def bit_length(self) -> Optional[int]:
@@ -143,7 +155,7 @@ class Parameter(abc.ABC):
         }
         if self.byte_position is not None:
             d['byte_position'] = self.byte_position
-        if self.bit_position:
+        if self.bit_position is not None:
             d['bit_position'] = self.bit_position
         return d
 
@@ -153,7 +165,7 @@ class Parameter(abc.ABC):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"

--- a/odxtools/parameters/parameterbase.py
+++ b/odxtools/parameters/parameterbase.py
@@ -30,18 +30,6 @@ class Parameter(abc.ABC):
         self.description: Optional[str] = description
 
     @property
-    def byte_position_int(self) -> int:
-        if self.byte_position is None:
-            return 0
-        return self.byte_position
-
-    @property
-    def bit_position_int(self) -> int:
-        if self.bit_position is None:
-            return 0
-        return self.bit_position
-
-    @property
     def bit_length(self) -> Optional[int]:
         return None
 

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -85,9 +85,10 @@ class ParameterWithDOP(Parameter):
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         assert self.dop is not None, "Reference to DOP is not resolved"
         physical_value = encode_state.parameter_values[self.short_name]
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         return self.dop.convert_physical_to_bytes(physical_value,
                                                   encode_state,
-                                                  bit_position=self.bit_position_int)
+                                                  bit_position=bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         assert self.dop is not None, "Reference to DOP is not resolved"
@@ -96,9 +97,10 @@ class ParameterWithDOP(Parameter):
                 next_byte_position=self.byte_position)
 
         # Use DOP to decode
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         phys_val, next_byte_position = \
             self.dop.convert_bytes_to_physical(decode_state,
-                                               bit_position=self.bit_position_int)
+                                               bit_position=bit_position_int)
 
         return phys_val, next_byte_position
 

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -28,7 +28,7 @@ class ParameterWithDOP(Parameter):
 
         self._dop = dop
         if dop and not dop_ref and not dop_snref:
-            self.dop_ref = OdxLinkRef.from_id(dop.odx_link_id)
+            self.dop_ref = OdxLinkRef.from_id(dop.odx_id)
         assert self.dop_ref or self.dop_snref
 
     @property
@@ -40,7 +40,7 @@ class ParameterWithDOP(Parameter):
     def dop(self, dop: DopBase):
         self._dop = dop
         if not self.dop_snref:
-            self.dop_ref = OdxLinkRef.from_id(dop.odx_link_id)
+            self.dop_ref = OdxLinkRef.from_id(dop.odx_id)
         else:
             self.dop_snref = dop.short_name
 
@@ -107,7 +107,7 @@ class ParameterWithDOP(Parameter):
         if self.dop is not None:
             if self.bit_length is not None:
                 d["bit_length"] = self.bit_length
-            d["dop_ref"] = OdxLinkRef.from_id(self.dop.odx_link_id)
+            d["dop_ref"] = OdxLinkRef.from_id(self.dop.odx_id)
         elif self.dop_ref is not None:
             d["dop_ref"] = self.dop_ref
         elif self.dop_snref is not None:

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -85,7 +85,9 @@ class ParameterWithDOP(Parameter):
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         assert self.dop is not None, "Reference to DOP is not resolved"
         physical_value = encode_state.parameter_values[self.short_name]
-        return self.dop.convert_physical_to_bytes(physical_value, encode_state, bit_position=self.bit_position)
+        return self.dop.convert_physical_to_bytes(physical_value,
+                                                  encode_state,
+                                                  bit_position=self.bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         assert self.dop is not None, "Reference to DOP is not resolved"
@@ -94,8 +96,9 @@ class ParameterWithDOP(Parameter):
                 next_byte_position=self.byte_position)
 
         # Use DOP to decode
-        phys_val, next_byte_position = self.dop.convert_bytes_to_physical(
-            decode_state, bit_position=self.bit_position)
+        phys_val, next_byte_position = \
+            self.dop.convert_bytes_to_physical(decode_state,
+                                               bit_position=self.bit_position_int)
 
         return phys_val, next_byte_position
 

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -28,7 +28,7 @@ class ParameterWithDOP(Parameter):
 
         self._dop = dop
         if dop and not dop_ref and not dop_snref:
-            self.dop_ref = OdxLinkRef.from_id(dop.id)
+            self.dop_ref = OdxLinkRef.from_id(dop.odx_link_id)
         assert self.dop_ref or self.dop_snref
 
     @property
@@ -40,7 +40,7 @@ class ParameterWithDOP(Parameter):
     def dop(self, dop: DopBase):
         self._dop = dop
         if not self.dop_snref:
-            self.dop_ref = OdxLinkRef.from_id(dop.id)
+            self.dop_ref = OdxLinkRef.from_id(dop.odx_link_id)
         else:
             self.dop_snref = dop.short_name
 
@@ -104,7 +104,7 @@ class ParameterWithDOP(Parameter):
         if self.dop is not None:
             if self.bit_length is not None:
                 d["bit_length"] = self.bit_length
-            d["dop_ref"] = OdxLinkRef.from_id(self.dop.id)
+            d["dop_ref"] = OdxLinkRef.from_id(self.dop.odx_link_id)
         elif self.dop_ref is not None:
             d["dop_ref"] = self.dop_ref
         elif self.dop_snref is not None:

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -39,7 +39,10 @@ class PhysicalConstantParameter(ParameterWithDOP):
                 and encode_state.parameter_values[self.short_name] != self.physical_constant_value:
             raise TypeError(f"The parameter '{self.short_name}' is constant {self.physical_constant_value}"
                             " and thus can not be changed.")
-        return self.dop.convert_physical_to_bytes(self.physical_constant_value, encode_state, bit_position=self.bit_position)
+
+        return self.dop.convert_physical_to_bytes(self.physical_constant_value,
+                                                  encode_state,
+                                                  bit_position=self.bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         # Decode value
@@ -61,7 +64,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -40,9 +40,10 @@ class PhysicalConstantParameter(ParameterWithDOP):
             raise TypeError(f"The parameter '{self.short_name}' is constant {self.physical_constant_value}"
                             " and thus can not be changed.")
 
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
         return self.dop.convert_physical_to_bytes(self.physical_constant_value,
                                                   encode_state,
-                                                  bit_position=self.bit_position_int)
+                                                  bit_position=bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):
         # Decode value

--- a/odxtools/parameters/readparameter.py
+++ b/odxtools/parameters/readparameter.py
@@ -5,7 +5,7 @@ from typing import List
 
 from ..diagcodedtypes import read_diag_coded_type_from_odx
 from ..globals import xsi
-from ..utils import read_element_id
+from ..utils import read_description_from_odx
 from ..odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment
 
 from .codedconstparameter import CodedConstParameter
@@ -22,19 +22,13 @@ from .tablestructparameter import TableStructParameter
 from .valueparameter import ValueParameter
 
 
-def read_parameter_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    element_id = read_element_id(et_element)
-    short_name = element_id["short_name"]
-    long_name = element_id.get("long_name")
-    description = element_id.get("description")
-
+def read_parameter_from_odx(et_element, doc_frags):
+    short_name = et_element.find("SHORT-NAME").text
+    long_name = et_element.findtext("LONG-NAME")
+    description = read_description_from_odx(et_element.find("DESC"))
     semantic = et_element.get("SEMANTIC")
-
-    byte_position = int(et_element.find(
-        "BYTE-POSITION").text) if et_element.find("BYTE-POSITION") is not None else None
-    bit_position = int(et_element.find(
-        "BIT-POSITION").text) if et_element.find("BIT-POSITION") is not None else 0
-
+    byte_position = int(et_element.findtext("BYTE-POSITION", "0"))
+    bit_position = int(et_element.findtext("BIT-POSITION", "0"))
     parameter_type = et_element.get(f"{xsi}type")
 
     # Which attributes are set depends on the type of the parameter.

--- a/odxtools/parameters/readparameter.py
+++ b/odxtools/parameters/readparameter.py
@@ -138,10 +138,10 @@ def read_parameter_from_odx(et_element, doc_frags):
                                description=description)
 
     elif parameter_type == "LENGTH-KEY":
-        odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
 
         return LengthKeyParameter(short_name=short_name,
-                                  odx_link_id=odx_link_id,
+                                  odx_id=odx_id,
                                   long_name=long_name,
                                   semantic=semantic,
                                   byte_position=byte_position,
@@ -188,7 +188,7 @@ def read_parameter_from_odx(et_element, doc_frags):
                                  table_snref=table_snref,
                                  table_row_snref=row_snref,
                                  table_row_ref=row_ref,
-                                 odx_link_id=parameter_id,
+                                 odx_id=parameter_id,
                                  long_name=long_name,
                                  byte_position=byte_position,
                                  bit_position=bit_position,

--- a/odxtools/parameters/readparameter.py
+++ b/odxtools/parameters/readparameter.py
@@ -27,8 +27,10 @@ def read_parameter_from_odx(et_element, doc_frags):
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
     semantic = et_element.get("SEMANTIC")
-    byte_position = int(et_element.findtext("BYTE-POSITION", "0"))
-    bit_position = int(et_element.findtext("BIT-POSITION", "0"))
+    byte_position_str = et_element.findtext("BYTE-POSITION")
+    byte_position = int(byte_position_str) if byte_position_str is not None else None
+    bit_position_str = et_element.findtext("BIT-POSITION")
+    bit_position = int(bit_position_str) if bit_position_str is not None else None
     parameter_type = et_element.get(f"{xsi}type")
 
     # Which attributes are set depends on the type of the parameter.

--- a/odxtools/parameters/readparameter.py
+++ b/odxtools/parameters/readparameter.py
@@ -136,10 +136,10 @@ def read_parameter_from_odx(et_element, doc_frags):
                                description=description)
 
     elif parameter_type == "LENGTH-KEY":
-        id = OdxLinkId.from_et(et_element, doc_frags)
+        odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
 
         return LengthKeyParameter(short_name=short_name,
-                                  id=id,
+                                  odx_link_id=odx_link_id,
                                   long_name=long_name,
                                   semantic=semantic,
                                   byte_position=byte_position,
@@ -186,7 +186,7 @@ def read_parameter_from_odx(et_element, doc_frags):
                                  table_snref=table_snref,
                                  table_row_snref=row_snref,
                                  table_row_ref=row_ref,
-                                 id=parameter_id,
+                                 odx_link_id=parameter_id,
                                  long_name=long_name,
                                  byte_position=byte_position,
                                  bit_position=bit_position,

--- a/odxtools/parameters/readparameter.py
+++ b/odxtools/parameters/readparameter.py
@@ -30,7 +30,9 @@ def read_parameter_from_odx(et_element, doc_frags):
     byte_position_str = et_element.findtext("BYTE-POSITION")
     byte_position = int(byte_position_str) if byte_position_str is not None else None
     bit_position_str = et_element.findtext("BIT-POSITION")
-    bit_position = int(bit_position_str) if bit_position_str is not None else None
+    bit_position = None
+    if bit_position_str is not None:
+        bit_position = int(bit_position_str)
     parameter_type = et_element.get(f"{xsi}type")
 
     # Which attributes are set depends on the type of the parameter.

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -32,24 +32,24 @@ class ReservedParameter(Parameter):
         return 0
 
     def get_coded_value_as_bytes(self, encode_state):
-        return int(0).to_bytes((self.bit_length + self.bit_position + 7) // 8, "big")
+        return int(0).to_bytes((self.bit_length + self.bit_position_int + 7) // 8, "big")
 
     def decode_from_pdu(self, decode_state: DecodeState):
         byte_position = self.byte_position if self.byte_position is not None else decode_state.next_byte_position
-        byte_length = (self.bit_length + self.bit_position + 7) // 8
+        byte_length = (self.bit_length + self.bit_position_int + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:byte_position+byte_length]
         next_byte_position = byte_position + byte_length
 
         # Check that reserved bits are 0
-        expected = sum(2**i for i in range(self.bit_position,
-                       self.bit_position + self.bit_length))
+        expected = sum(2**i for i in range(self.bit_position_int,
+                       self.bit_position_int + self.bit_length))
         actual = int.from_bytes(val_as_bytes, "big")
 
         # Bit-wise compare if reserved bits are 0.
         if expected & actual != 0:
             raise DecodeError(
                 f"Reserved bits must be Zero! "
-                f"The parameter {self.short_name} expected {self.bit_length} bits to be Zero starting at bit position {self.bit_position} "
+                f"The parameter {self.short_name} expected {self.bit_length} bits to be Zero starting at bit position {self.bit_position_int} "
                 f"at byte position {byte_position} "
                 f"in coded message {decode_state.coded_message.hex()}."
             )
@@ -62,7 +62,7 @@ class ReservedParameter(Parameter):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.bit_length is not None:
             repr_str += f", bit_length='{self.bit_length}'"

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -32,24 +32,26 @@ class ReservedParameter(Parameter):
         return 0
 
     def get_coded_value_as_bytes(self, encode_state):
-        return int(0).to_bytes((self.bit_length + self.bit_position_int + 7) // 8, "big")
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
+        return int(0).to_bytes((self.bit_length + bit_position_int + 7) // 8, "big")
 
     def decode_from_pdu(self, decode_state: DecodeState):
         byte_position = self.byte_position if self.byte_position is not None else decode_state.next_byte_position
-        byte_length = (self.bit_length + self.bit_position_int + 7) // 8
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
+        byte_length = (self.bit_length + bit_position_int + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:byte_position+byte_length]
         next_byte_position = byte_position + byte_length
 
         # Check that reserved bits are 0
-        expected = sum(2**i for i in range(self.bit_position_int,
-                       self.bit_position_int + self.bit_length))
+        expected = sum(2**i for i in range(bit_position_int,
+                                           bit_position_int + self.bit_length))
         actual = int.from_bytes(val_as_bytes, "big")
 
         # Bit-wise compare if reserved bits are 0.
         if expected & actual != 0:
             raise DecodeError(
                 f"Reserved bits must be Zero! "
-                f"The parameter {self.short_name} expected {self.bit_length} bits to be Zero starting at bit position {self.bit_position_int} "
+                f"The parameter {self.short_name} expected {self.bit_length} bits to be Zero starting at bit position {bit_position_int} "
                 f"at byte position {byte_position} "
                 f"in coded message {decode_state.coded_message.hex()}."
             )

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -13,7 +13,7 @@ class SystemParameter(ParameterWithDOP):
                  dop_snref=None,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         super().__init__(short_name,
@@ -52,9 +52,9 @@ class SystemParameter(ParameterWithDOP):
         if self.long_name is not None:
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
-            repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
-            repr_str += f", bit_position='{self.bit_position}'"
+            repr_str += f", byte_position={self.byte_position}"
+        if self.bit_position is not None:
+            repr_str += f", bit_position={self.bit_position}"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"
         if self.dop_ref is not None:

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -11,7 +11,7 @@ class TableEntryParameter(Parameter):
                  table_row_ref,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         super().__init__(

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -16,7 +16,7 @@ class TableKeyParameter(Parameter):
                  table_snref=None,
                  table_row_snref=None,
                  table_row_ref=None,
-                 id=None,
+                 odx_link_id=None,
                  long_name=None,
                  byte_position=None,
                  bit_position=0,
@@ -46,7 +46,7 @@ class TableKeyParameter(Parameter):
         else:
             raise ValueError(
                 "Either table_key_ref or table_key_snref must be defined.")
-        self.id = id
+        self.odx_link_id = odx_link_id
 
     def is_required(self):
         raise NotImplementedError(

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -16,7 +16,7 @@ class TableKeyParameter(Parameter):
                  table_snref=None,
                  table_row_snref=None,
                  table_row_ref=None,
-                 odx_link_id=None,
+                 odx_id=None,
                  long_name=None,
                  byte_position=None,
                  bit_position=None,
@@ -46,7 +46,7 @@ class TableKeyParameter(Parameter):
         else:
             raise ValueError(
                 "Either table_key_ref or table_key_snref must be defined.")
-        self.odx_link_id = odx_link_id
+        self.odx_id = odx_id
 
     def is_required(self):
         raise NotImplementedError(

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -19,7 +19,7 @@ class TableKeyParameter(Parameter):
                  odx_link_id=None,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         super().__init__(

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -12,7 +12,7 @@ class TableStructParameter(Parameter):
                  table_key_snref=None,
                  long_name=None,
                  byte_position=None,
-                 bit_position=0,
+                 bit_position=None,
                  semantic=None,
                  description=None):
         super().__init__(

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -49,7 +49,8 @@ class ValueParameter(ParameterWithDOP):
             raise TypeError(f"A value for parameter '{self.short_name}' must be specified"
                             f" as the parameter does not exhibit a default.")
         assert self.dop is not None, f"Param {self.short_name} does not have a DOP. Maybe resolving references failed?"
-        return self.dop.convert_physical_to_bytes(physical_value, encode_state=encode_state, bit_position=self.bit_position)
+
+        return self.dop.convert_physical_to_bytes(physical_value, encode_state=encode_state, bit_position=self.bit_position_int)
 
     def get_valid_physical_values(self):
         if isinstance(self.dop, DataObjectProperty):
@@ -61,7 +62,7 @@ class ValueParameter(ParameterWithDOP):
             repr_str += f", long_name='{self.long_name}'"
         if self.byte_position is not None:
             repr_str += f", byte_position='{self.byte_position}'"
-        if self.bit_position:
+        if self.bit_position is not None:
             repr_str += f", bit_position='{self.bit_position}'"
         if self.semantic is not None:
             repr_str += f", semantic='{self.semantic}'"

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -50,7 +50,10 @@ class ValueParameter(ParameterWithDOP):
                             f" as the parameter does not exhibit a default.")
         assert self.dop is not None, f"Param {self.short_name} does not have a DOP. Maybe resolving references failed?"
 
-        return self.dop.convert_physical_to_bytes(physical_value, encode_state=encode_state, bit_position=self.bit_position_int)
+        bit_position_int = self.bit_position if self.bit_position is not None else 0
+        return self.dop.convert_physical_to_bytes(physical_value,
+                                                  encode_state=encode_state,
+                                                  bit_position=bit_position_int)
 
     def get_valid_physical_values(self):
         if isinstance(self.dop, DataObjectProperty):

--- a/odxtools/pdx_stub/diag_layer_container.odx-d.tpl
+++ b/odxtools/pdx_stub/diag_layer_container.odx-d.tpl
@@ -11,7 +11,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
  <!-- Written by the odxtools python module, version {{odxtools_version}} -->
- <DIAG-LAYER-CONTAINER ID="{{dlc.odx_link_id}}">
+ <DIAG-LAYER-CONTAINER ID="{{dlc.odx_id}}">
   <SHORT-NAME>{{dlc.short_name}}</SHORT-NAME>
 {%- if dlc.long_name %}
   <LONG-NAME>{{dlc.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/diag_layer_container.odx-d.tpl
+++ b/odxtools/pdx_stub/diag_layer_container.odx-d.tpl
@@ -11,7 +11,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
  <!-- Written by the odxtools python module, version {{odxtools_version}} -->
- <DIAG-LAYER-CONTAINER ID="{{dlc.id}}">
+ <DIAG-LAYER-CONTAINER ID="{{dlc.odx_link_id}}">
   <SHORT-NAME>{{dlc.short_name}}</SHORT-NAME>
 {%- if dlc.long_name %}
   <LONG-NAME>{{dlc.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printAudience.tpl
+++ b/odxtools/pdx_stub/macros/printAudience.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printAdditionalAudience(audience) -%}
-<ADDITIONAL-AUDIENCE ID="{{audience.odx_link_id.local_id}}">
+<ADDITIONAL-AUDIENCE ID="{{audience.odx_id.local_id}}">
  <SHORT-NAME>{{audience.short_name}}</SHORT-NAME>
 {%- if audience.long_name %}
  <LONG-NAME>{{audience.long_name}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printAudience.tpl
+++ b/odxtools/pdx_stub/macros/printAudience.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printAdditionalAudience(audience) -%}
-<ADDITIONAL-AUDIENCE ID="{{audience.id.local_id}}">
+<ADDITIONAL-AUDIENCE ID="{{audience.odx_link_id.local_id}}">
  <SHORT-NAME>{{audience.short_name}}</SHORT-NAME>
 {%- if audience.long_name %}
  <LONG-NAME>{{audience.long_name}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printCompanyData.tpl
+++ b/odxtools/pdx_stub/macros/printCompanyData.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printCompanyData(company_data) -%}
-<COMPANY-DATA ID="{{company_data.id.local_id}}">
+<COMPANY-DATA ID="{{company_data.odx_link_id.local_id}}">
  <SHORT-NAME>{{company_data.short_name|e}}</SHORT-NAME>
  {%- if company_data.long_name is not none %}
  <LONG-NAME>{{company_data.long_name|e}}</LONG-NAME>
@@ -25,7 +25,7 @@
  {%- if company_data.team_members is not none %}
  <TEAM-MEMBERS>
   {%- for team_member in company_data.team_members %}
-  <TEAM-MEMBER ID="{{team_member.id.local_id}}">
+  <TEAM-MEMBER ID="{{team_member.odx_link_id.local_id}}">
    <SHORT-NAME>{{team_member.short_name|e}}</SHORT-NAME>
    {%- if company_data.long_name is not none %}
    <LONG-NAME>{{team_member.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printCompanyData.tpl
+++ b/odxtools/pdx_stub/macros/printCompanyData.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printCompanyData(company_data) -%}
-<COMPANY-DATA ID="{{company_data.odx_link_id.local_id}}">
+<COMPANY-DATA ID="{{company_data.odx_id.local_id}}">
  <SHORT-NAME>{{company_data.short_name|e}}</SHORT-NAME>
  {%- if company_data.long_name is not none %}
  <LONG-NAME>{{company_data.long_name|e}}</LONG-NAME>
@@ -25,7 +25,7 @@
  {%- if company_data.team_members is not none %}
  <TEAM-MEMBERS>
   {%- for team_member in company_data.team_members %}
-  <TEAM-MEMBER ID="{{team_member.odx_link_id.local_id}}">
+  <TEAM-MEMBER ID="{{team_member.odx_id.local_id}}">
    <SHORT-NAME>{{team_member.short_name|e}}</SHORT-NAME>
    {%- if company_data.long_name is not none %}
    <LONG-NAME>{{team_member.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printDOP.tpl
+++ b/odxtools/pdx_stub/macros/printDOP.tpl
@@ -156,7 +156,7 @@
 
 
 {%- macro printDOP(dop, tag_name) %}
-<{{tag_name}} ID="{{dop.id.local_id}}">
+<{{tag_name}} ID="{{dop.odx_link_id.local_id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name|e}}</LONG-NAME>
 {%- if dop.compu_method is defined %}
@@ -174,7 +174,7 @@
 
 
 {%- macro printDTCDOP(dop) %}
-<DTC-DOP ID="{{dop.id.local_id}}">
+<DTC-DOP ID="{{dop.odx_link_id.local_id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name}}</LONG-NAME>
  {{ printDiagCodedType(dop.diag_coded_type)|indent(1) -}}
@@ -185,7 +185,7 @@
  {%- if dtc.dtc_id is defined   %}
   <DTC-REF ID-REF="{{dop.dtc_id.ref_id}}" />
  {%- else %}
-  <DTC ID="{{dtc.id.local_id}}">
+  <DTC ID="{{dtc.odx_link_id.local_id}}">
    <SHORT-NAME>{{dtc.short_name}}</SHORT-NAME>
    <TROUBLE-CODE>{{dtc.trouble_code}}</TROUBLE-CODE>
   {%- if dtc.display_trouble_code is not none   %}

--- a/odxtools/pdx_stub/macros/printDOP.tpl
+++ b/odxtools/pdx_stub/macros/printDOP.tpl
@@ -156,7 +156,7 @@
 
 
 {%- macro printDOP(dop, tag_name) %}
-<{{tag_name}} ID="{{dop.odx_link_id.local_id}}">
+<{{tag_name}} ID="{{dop.odx_id.local_id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name|e}}</LONG-NAME>
 {%- if dop.compu_method is defined %}
@@ -174,7 +174,7 @@
 
 
 {%- macro printDTCDOP(dop) %}
-<DTC-DOP ID="{{dop.odx_link_id.local_id}}">
+<DTC-DOP ID="{{dop.odx_id.local_id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name}}</LONG-NAME>
  {{ printDiagCodedType(dop.diag_coded_type)|indent(1) -}}
@@ -185,7 +185,7 @@
  {%- if dtc.dtc_id is defined   %}
   <DTC-REF ID-REF="{{dop.dtc_id.ref_id}}" />
  {%- else %}
-  <DTC ID="{{dtc.odx_link_id.local_id}}">
+  <DTC ID="{{dtc.odx_id.local_id}}">
    <SHORT-NAME>{{dtc.short_name}}</SHORT-NAME>
    <TROUBLE-CODE>{{dtc.trouble_code}}</TROUBLE-CODE>
   {%- if dtc.display_trouble_code is not none   %}

--- a/odxtools/pdx_stub/macros/printDiagnosticTroubleCode.tpl
+++ b/odxtools/pdx_stub/macros/printDiagnosticTroubleCode.tpl
@@ -7,7 +7,7 @@
 {#- TODO: function classes
 
 {%- macro printDTC_DOP(dop) -%}
-<DTC-DOP ID="{{dop.odx_link_id.local_id}}">
+<DTC-DOP ID="{{dop.odx_id.local_id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name|e}}</LONG-NAME>
 </DTC-DOP>

--- a/odxtools/pdx_stub/macros/printDiagnosticTroubleCode.tpl
+++ b/odxtools/pdx_stub/macros/printDiagnosticTroubleCode.tpl
@@ -7,7 +7,7 @@
 {#- TODO: function classes
 
 {%- macro printDTC_DOP(dop) -%}
-<DTC-DOP ID="{{dop.id.local_id}}">
+<DTC-DOP ID="{{dop.odx_link_id.local_id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name|e}}</LONG-NAME>
 </DTC-DOP>

--- a/odxtools/pdx_stub/macros/printEndOfPdu.tpl
+++ b/odxtools/pdx_stub/macros/printEndOfPdu.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printEndOfPdu(eopdu) -%}
-<END-OF-PDU-FIELD ID="{{eopdu.id.local_id}}">
+<END-OF-PDU-FIELD ID="{{eopdu.odx_link_id.local_id}}">
  <SHORT-NAME>{{eopdu.short_name}}</SHORT-NAME>
  <LONG-NAME>{{eopdu.long_name|e}}</LONG-NAME>
  <BASIC-STRUCTURE-REF ID-REF="{{eopdu.structure_ref.ref_id}}" />

--- a/odxtools/pdx_stub/macros/printEndOfPdu.tpl
+++ b/odxtools/pdx_stub/macros/printEndOfPdu.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printEndOfPdu(eopdu) -%}
-<END-OF-PDU-FIELD ID="{{eopdu.odx_link_id.local_id}}">
+<END-OF-PDU-FIELD ID="{{eopdu.odx_id.local_id}}">
  <SHORT-NAME>{{eopdu.short_name}}</SHORT-NAME>
  <LONG-NAME>{{eopdu.long_name|e}}</LONG-NAME>
  <BASIC-STRUCTURE-REF ID-REF="{{eopdu.structure_ref.ref_id}}" />

--- a/odxtools/pdx_stub/macros/printEnvData.tpl
+++ b/odxtools/pdx_stub/macros/printEnvData.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printEnvData(env_data) %}
-<ENV-DATA ID="{{env_data.id.local_id}}">
+<ENV-DATA ID="{{env_data.odx_link_id.local_id}}">
     <SHORT-NAME>{{env_data.short_name}}</SHORT-NAME>
     <LONG-NAME>{{env_data.long_name}}</LONG-NAME>
     <PARAMS>

--- a/odxtools/pdx_stub/macros/printEnvData.tpl
+++ b/odxtools/pdx_stub/macros/printEnvData.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printEnvData(env_data) %}
-<ENV-DATA ID="{{env_data.odx_link_id.local_id}}">
+<ENV-DATA ID="{{env_data.odx_id.local_id}}">
     <SHORT-NAME>{{env_data.short_name}}</SHORT-NAME>
     <LONG-NAME>{{env_data.long_name}}</LONG-NAME>
     <PARAMS>

--- a/odxtools/pdx_stub/macros/printEnvDataDesc.tpl
+++ b/odxtools/pdx_stub/macros/printEnvDataDesc.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printEnvDataDesc(env_data_desc) %}
-<ENV-DATA-DESC ID="{{env_data_desc.odx_link_id.local_id}}">
+<ENV-DATA-DESC ID="{{env_data_desc.odx_id.local_id}}">
   <SHORT-NAME>{{env_data_desc.short_name}}</SHORT-NAME>
   <LONG-NAME>{{env_data_desc.long_name}}</LONG-NAME>
   <PARAM-SNREF SHORT-NAME="{{env_data_desc.param_snref}}"/>

--- a/odxtools/pdx_stub/macros/printEnvDataDesc.tpl
+++ b/odxtools/pdx_stub/macros/printEnvDataDesc.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printEnvDataDesc(env_data_desc) %}
-<ENV-DATA-DESC ID="{{env_data_desc.id.local_id}}">
+<ENV-DATA-DESC ID="{{env_data_desc.odx_link_id.local_id}}">
   <SHORT-NAME>{{env_data_desc.short_name}}</SHORT-NAME>
   <LONG-NAME>{{env_data_desc.long_name}}</LONG-NAME>
   <PARAM-SNREF SHORT-NAME="{{env_data_desc.param_snref}}"/>

--- a/odxtools/pdx_stub/macros/printFunctionalClass.tpl
+++ b/odxtools/pdx_stub/macros/printFunctionalClass.tpl
@@ -6,7 +6,7 @@
 -#}
 
 {%- macro printFunctionalClass(fc) -%}
-<FUNCT-CLASS ID="{{fc.id.local_id}}">
+<FUNCT-CLASS ID="{{fc.odx_link_id.local_id}}">
  <SHORT-NAME>{{fc.short_name}}</SHORT-NAME>
 {%- if fc.long_name is string and fc.long_name.strip() %}
  <LONG-NAME>{{fc.long_name}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printFunctionalClass.tpl
+++ b/odxtools/pdx_stub/macros/printFunctionalClass.tpl
@@ -6,7 +6,7 @@
 -#}
 
 {%- macro printFunctionalClass(fc) -%}
-<FUNCT-CLASS ID="{{fc.odx_link_id.local_id}}">
+<FUNCT-CLASS ID="{{fc.odx_id.local_id}}">
  <SHORT-NAME>{{fc.short_name}}</SHORT-NAME>
 {%- if fc.long_name is string and fc.long_name.strip() %}
  <LONG-NAME>{{fc.long_name}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printMux.tpl
+++ b/odxtools/pdx_stub/macros/printMux.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printMux(mux) %}
-<MUX ID="{{mux.odx_link_id.local_id}}">
+<MUX ID="{{mux.odx_id.local_id}}">
   <SHORT-NAME>{{mux.short_name}}</SHORT-NAME>
   <LONG-NAME>{{mux.long_name|e}}</LONG-NAME>
   <BYTE-POSITION>{{mux.byte_position}}</BYTE-POSITION>

--- a/odxtools/pdx_stub/macros/printMux.tpl
+++ b/odxtools/pdx_stub/macros/printMux.tpl
@@ -11,7 +11,9 @@
   <BYTE-POSITION>{{mux.byte_position}}</BYTE-POSITION>
   <SWITCH-KEY>
     <BYTE-POSITION>{{mux.switch_key.byte_position}}</BYTE-POSITION>
+    {%- if mux.switch_key.bit_position is not none %}
     <BIT-POSITION>{{mux.switch_key.bit_position}}</BIT-POSITION>
+    {%- endif %}
     <DATA-OBJECT-PROP-REF ID-REF="{{mux.switch_key.dop_ref.ref_id}}"/>
   </SWITCH-KEY>
   <DEFAULT-CASE>

--- a/odxtools/pdx_stub/macros/printMux.tpl
+++ b/odxtools/pdx_stub/macros/printMux.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printMux(mux) %}
-<MUX ID="{{mux.id.local_id}}">
+<MUX ID="{{mux.odx_link_id.local_id}}">
   <SHORT-NAME>{{mux.short_name}}</SHORT-NAME>
   <LONG-NAME>{{mux.long_name|e}}</LONG-NAME>
   <BYTE-POSITION>{{mux.byte_position}}</BYTE-POSITION>

--- a/odxtools/pdx_stub/macros/printParam.tpl
+++ b/odxtools/pdx_stub/macros/printParam.tpl
@@ -12,8 +12,8 @@
 {%- else %}
 {%-  set semattrib = "" -%}
 {%- endif -%}
-{%- if param.parameter_type == "TABLE-KEY" and param.odx_link_id is not none  %}
-<PARAM {{semattrib}} ID="{{param.odx_link_id.local_id}}" xsi:type="{{param.parameter_type}}">
+{%- if param.parameter_type == "TABLE-KEY" and param.odx_id is not none  %}
+<PARAM {{semattrib}} ID="{{param.odx_id.local_id}}" xsi:type="{{param.parameter_type}}">
 {%- elif param.parameter_type == "SYSTEM" %}
 <PARAM SYSPARAM="{{param.sysparam}}" xsi:type="{{param.parameter_type}}">
 {%- else %}

--- a/odxtools/pdx_stub/macros/printParam.tpl
+++ b/odxtools/pdx_stub/macros/printParam.tpl
@@ -28,7 +28,7 @@
 {%- endif %}
 {%- if param.parameter_type == "MATCHING-REQUEST-PARAM" and param.request_byte_position is defined %}
  <REQUEST-BYTE-POS>{{param.request_byte_position}}</REQUEST-BYTE-POS>
-{%- elif param.bit_position != 0 %}
+{%- elif param.bit_position is not none %}
  <BIT-POSITION>{{param.bit_position}}</BIT-POSITION>
 {%- endif %}
 {%- if param.byte_length is defined and param.byte_length is not none %}

--- a/odxtools/pdx_stub/macros/printParam.tpl
+++ b/odxtools/pdx_stub/macros/printParam.tpl
@@ -12,8 +12,8 @@
 {%- else %}
 {%-  set semattrib = "" -%}
 {%- endif -%}
-{%- if param.parameter_type == "TABLE-KEY" and param.id is not none  %}
-<PARAM {{semattrib}} ID="{{param.id.local_id}}" xsi:type="{{param.parameter_type}}">
+{%- if param.parameter_type == "TABLE-KEY" and param.odx_link_id is not none  %}
+<PARAM {{semattrib}} ID="{{param.odx_link_id.local_id}}" xsi:type="{{param.parameter_type}}">
 {%- elif param.parameter_type == "SYSTEM" %}
 <PARAM SYSPARAM="{{param.sysparam}}" xsi:type="{{param.parameter_type}}">
 {%- else %}

--- a/odxtools/pdx_stub/macros/printRequest.tpl
+++ b/odxtools/pdx_stub/macros/printRequest.tpl
@@ -8,7 +8,7 @@
 {%- import('macros/printParam.tpl') as pp %}
 
 {%- macro printRequest(request) -%}
-<REQUEST ID="{{request.odx_link_id.local_id}}">
+<REQUEST ID="{{request.odx_id.local_id}}">
  <SHORT-NAME>{{request.short_name}}</SHORT-NAME>
 {%- if request.long_name %}
  <LONG-NAME>{{request.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printRequest.tpl
+++ b/odxtools/pdx_stub/macros/printRequest.tpl
@@ -8,7 +8,7 @@
 {%- import('macros/printParam.tpl') as pp %}
 
 {%- macro printRequest(request) -%}
-<REQUEST ID="{{request.id.local_id}}">
+<REQUEST ID="{{request.odx_link_id.local_id}}">
  <SHORT-NAME>{{request.short_name}}</SHORT-NAME>
 {%- if request.long_name %}
  <LONG-NAME>{{request.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printResponse.tpl
+++ b/odxtools/pdx_stub/macros/printResponse.tpl
@@ -7,7 +7,7 @@
 {%- import('macros/printParam.tpl') as pp %}
 
 {%- macro printResponse(resp, tag_name="POS-RESPONSE") -%}
-<{{tag_name}} ID="{{resp.odx_link_id.local_id}}">
+<{{tag_name}} ID="{{resp.odx_id.local_id}}">
  <SHORT-NAME>{{resp.short_name}}</SHORT-NAME>
  <LONG-NAME>{{resp.long_name|e}}</LONG-NAME>
 {%- if resp.description and resp.description.strip() %}

--- a/odxtools/pdx_stub/macros/printResponse.tpl
+++ b/odxtools/pdx_stub/macros/printResponse.tpl
@@ -7,7 +7,7 @@
 {%- import('macros/printParam.tpl') as pp %}
 
 {%- macro printResponse(resp, tag_name="POS-RESPONSE") -%}
-<{{tag_name}} ID="{{resp.id.local_id}}">
+<{{tag_name}} ID="{{resp.odx_link_id.local_id}}">
  <SHORT-NAME>{{resp.short_name}}</SHORT-NAME>
  <LONG-NAME>{{resp.long_name|e}}</LONG-NAME>
 {%- if resp.description and resp.description.strip() %}

--- a/odxtools/pdx_stub/macros/printService.tpl
+++ b/odxtools/pdx_stub/macros/printService.tpl
@@ -12,7 +12,7 @@
 {%- else %}
 {%-  set semattrib = " SEMANTIC=\"UNKNOWN\"" -%}
 {%- endif -%}
-<DIAG-SERVICE ID="{{service.id.local_id}}" {{semattrib}}>
+<DIAG-SERVICE ID="{{service.odx_link_id.local_id}}" {{semattrib}}>
  <SHORT-NAME>{{service.short_name}}</SHORT-NAME>
 {%- if service.long_name and service.long_name.strip() %}
  <LONG-NAME>{{service.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printService.tpl
+++ b/odxtools/pdx_stub/macros/printService.tpl
@@ -12,7 +12,7 @@
 {%- else %}
 {%-  set semattrib = " SEMANTIC=\"UNKNOWN\"" -%}
 {%- endif -%}
-<DIAG-SERVICE ID="{{service.odx_link_id.local_id}}" {{semattrib}}>
+<DIAG-SERVICE ID="{{service.odx_id.local_id}}" {{semattrib}}>
  <SHORT-NAME>{{service.short_name}}</SHORT-NAME>
 {%- if service.long_name and service.long_name.strip() %}
  <LONG-NAME>{{service.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printSingleEcuJob.tpl
+++ b/odxtools/pdx_stub/macros/printSingleEcuJob.tpl
@@ -7,7 +7,7 @@
 {%- import('macros/printAudience.tpl') as paud %}
 
 {%- macro printSingleEcuJob(job) -%}
-<SINGLE-ECU-JOB ID="{{job.odx_link_id.local_id}}"
+<SINGLE-ECU-JOB ID="{{job.odx_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if job.oid %}
                 OID="{{job.oid}}"
@@ -124,7 +124,7 @@
 {%- endmacro -%}
 
 {%- macro printOutputParam(param) -%}
-<OUTPUT-PARAM ID="{{param.odx_link_id.local_id}}"
+<OUTPUT-PARAM ID="{{param.odx_id.local_id}}"
 {%- filter odxtools_collapse_xml_attribute %}
   {%- if param.oid %}
              OID="{{param.oid}}"

--- a/odxtools/pdx_stub/macros/printSingleEcuJob.tpl
+++ b/odxtools/pdx_stub/macros/printSingleEcuJob.tpl
@@ -7,7 +7,7 @@
 {%- import('macros/printAudience.tpl') as paud %}
 
 {%- macro printSingleEcuJob(job) -%}
-<SINGLE-ECU-JOB ID="{{job.id.local_id}}"
+<SINGLE-ECU-JOB ID="{{job.odx_link_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if job.oid %}
                 OID="{{job.oid}}"
@@ -124,7 +124,7 @@
 {%- endmacro -%}
 
 {%- macro printOutputParam(param) -%}
-<OUTPUT-PARAM ID="{{param.id.local_id}}"
+<OUTPUT-PARAM ID="{{param.odx_link_id.local_id}}"
 {%- filter odxtools_collapse_xml_attribute %}
   {%- if param.oid %}
              OID="{{param.oid}}"

--- a/odxtools/pdx_stub/macros/printStructure.tpl
+++ b/odxtools/pdx_stub/macros/printStructure.tpl
@@ -7,7 +7,7 @@
 {%- import('macros/printParam.tpl') as pp %}
 
 {%- macro printStructure(st) -%}
-<STRUCTURE ID="{{st.id.local_id}}">
+<STRUCTURE ID="{{st.odx_link_id.local_id}}">
  <SHORT-NAME>{{st.short_name}}</SHORT-NAME>
 {%- if st.long_name %}
  <LONG-NAME>{{st.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printStructure.tpl
+++ b/odxtools/pdx_stub/macros/printStructure.tpl
@@ -7,7 +7,7 @@
 {%- import('macros/printParam.tpl') as pp %}
 
 {%- macro printStructure(st) -%}
-<STRUCTURE ID="{{st.odx_link_id.local_id}}">
+<STRUCTURE ID="{{st.odx_id.local_id}}">
  <SHORT-NAME>{{st.short_name}}</SHORT-NAME>
 {%- if st.long_name %}
  <LONG-NAME>{{st.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printTable.tpl
+++ b/odxtools/pdx_stub/macros/printTable.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printTable(table) %}
-<TABLE ID="{{table.id.local_id}}"
+<TABLE ID="{{table.odx_link_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if table.semantic %}
     SEMANTIC="{{table.semantic}}"
@@ -23,7 +23,7 @@
  <KEY-DOP-REF ID-REF="{{ table.key_dop_ref.ref_id }}" />
 {%- endif %}
 {%- for table_row in table.table_rows %}
- <TABLE-ROW ID="{{table_row.id.local_id}}"
+ <TABLE-ROW ID="{{table_row.odx_link_id.local_id}}"
   {%- filter odxtools_collapse_xml_attribute %}
   {%- if table_row.semantic %}
     SEMANTIC="{{table_row.semantic}}"

--- a/odxtools/pdx_stub/macros/printTable.tpl
+++ b/odxtools/pdx_stub/macros/printTable.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printTable(table) %}
-<TABLE ID="{{table.odx_link_id.local_id}}"
+<TABLE ID="{{table.odx_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if table.semantic %}
     SEMANTIC="{{table.semantic}}"
@@ -23,7 +23,7 @@
  <KEY-DOP-REF ID-REF="{{ table.key_dop_ref.ref_id }}" />
 {%- endif %}
 {%- for table_row in table.table_rows %}
- <TABLE-ROW ID="{{table_row.odx_link_id.local_id}}"
+ <TABLE-ROW ID="{{table_row.odx_id.local_id}}"
   {%- filter odxtools_collapse_xml_attribute %}
   {%- if table_row.semantic %}
     SEMANTIC="{{table_row.semantic}}"

--- a/odxtools/pdx_stub/macros/printUnitSpec.tpl
+++ b/odxtools/pdx_stub/macros/printUnitSpec.tpl
@@ -34,7 +34,7 @@
 
 
 {%- macro printUnit(unit) -%}
-<UNIT ID="{{unit.id.local_id}}"
+<UNIT ID="{{unit.odx_link_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if unit.oid %}
                 OID="{{unit.oid}}"
@@ -69,7 +69,7 @@
 {%- endmacro -%}
 
 {%- macro printPhysicalDimesion(dim) -%}
-<PHYSICAL-DIMENSION ID="{{dim.id.local_id}}"
+<PHYSICAL-DIMENSION ID="{{dim.odx_link_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if dim.oid %}
                 OID="{{dim.oid}}"

--- a/odxtools/pdx_stub/macros/printUnitSpec.tpl
+++ b/odxtools/pdx_stub/macros/printUnitSpec.tpl
@@ -34,7 +34,7 @@
 
 
 {%- macro printUnit(unit) -%}
-<UNIT ID="{{unit.odx_link_id.local_id}}"
+<UNIT ID="{{unit.odx_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if unit.oid %}
                 OID="{{unit.oid}}"
@@ -69,7 +69,7 @@
 {%- endmacro -%}
 
 {%- macro printPhysicalDimesion(dim) -%}
-<PHYSICAL-DIMENSION ID="{{dim.odx_link_id.local_id}}"
+<PHYSICAL-DIMENSION ID="{{dim.odx_id.local_id}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if dim.oid %}
                 OID="{{dim.oid}}"

--- a/odxtools/pdx_stub/macros/printVariant.tpl
+++ b/odxtools/pdx_stub/macros/printVariant.tpl
@@ -22,7 +22,7 @@
 {%- import('macros/printAudience.tpl') as paud %}
 
 {%- macro printVariant(dl, variant_tag) -%}
-<{{variant_tag}} ID="{{dl.odx_link_id.local_id}}">
+<{{variant_tag}} ID="{{dl.odx_id.local_id}}">
  <SHORT-NAME>{{dl.short_name}}</SHORT-NAME>
 {%- if dl.long_name %}
  <LONG-NAME>{{dl.long_name|e}}</LONG-NAME>

--- a/odxtools/pdx_stub/macros/printVariant.tpl
+++ b/odxtools/pdx_stub/macros/printVariant.tpl
@@ -22,7 +22,7 @@
 {%- import('macros/printAudience.tpl') as paud %}
 
 {%- macro printVariant(dl, variant_tag) -%}
-<{{variant_tag}} ID="{{dl.id.local_id}}">
+<{{variant_tag}} ID="{{dl.odx_link_id.local_id}}">
  <SHORT-NAME>{{dl.short_name}}</SHORT-NAME>
 {%- if dl.long_name %}
  <LONG-NAME>{{dl.long_name|e}}</LONG-NAME>

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -19,7 +19,7 @@ from .message import Message
 
 class DiagService:
     def __init__(self,
-                 odx_link_id: OdxLinkId,
+                 odx_id: OdxLinkId,
                  short_name: str,
                  request: Union[OdxLinkRef, Request],
                  positive_responses: Union[Iterable[OdxLinkRef], Iterable[Response]],
@@ -35,7 +35,7 @@ class DiagService:
 
         Parameters:
         ----------
-        odx_link_id: OdxLinkId
+        odx_id: OdxLinkId
         short_name: str
             the short name of this DIAG-SERVICE
         request: OdxLinkRef | Request
@@ -43,7 +43,7 @@ class DiagService:
         positive_responses: List[OdxLinkRef] | List[Response]
         negative_responses: List[OdxLinkRef] | List[Response]
         """
-        self.odx_link_id: OdxLinkId = odx_link_id
+        self.odx_id: OdxLinkId = odx_id
         self.short_name: str = short_name
         self.long_name: Optional[str] = long_name
         self.description: Optional[str] = description
@@ -71,7 +71,7 @@ class DiagService:
             self.request_ref = request
         elif isinstance(request, Request):
             self._request = request
-            self.request_ref = OdxLinkRef.from_id(request.odx_link_id)
+            self.request_ref = OdxLinkRef.from_id(request.odx_id)
         else:
             raise ValueError(
                 "request must be a reference to a request or a Request object")
@@ -82,7 +82,7 @@ class DiagService:
                 NamedItemList[Response](short_name_as_id,
                                         positive_responses)  # type: ignore
             self.pos_res_refs = [
-                OdxLinkRef.from_id(pr.odx_link_id) for pr in positive_responses]  # type: ignore
+                OdxLinkRef.from_id(pr.odx_id) for pr in positive_responses]  # type: ignore
         elif all(isinstance(x, OdxLinkRef) for x in positive_responses):
             self._positive_responses = None
             self.pos_res_refs = positive_responses  # type: ignore
@@ -95,7 +95,7 @@ class DiagService:
                 NamedItemList[Response](short_name_as_id,
                                         negative_responses)  # type: ignore
             self.neg_res_refs = [
-                OdxLinkRef.from_id(nr.odx_link_id) for nr in negative_responses]  # type: ignore
+                OdxLinkRef.from_id(nr.odx_id) for nr in negative_responses]  # type: ignore
         elif all(isinstance(x, OdxLinkRef) for x in negative_responses):
             self._negative_responses = None
             self.neg_res_refs = negative_responses  # type: ignore
@@ -227,24 +227,24 @@ class DiagService:
         return self.encode_request(**params)
 
     def __str__(self):
-        return f"DiagService(odx_link_id={self.odx_link_id}, semantic={self.semantic})"
+        return f"DiagService(odx_id={self.odx_id}, semantic={self.semantic})"
 
     def __repr__(self):
         return self.__str__()
 
     def __hash__(self) -> int:
-        return hash(self.odx_link_id)
+        return hash(self.odx_id)
 
     def __eq__(self, o: object) -> bool:
-        return isinstance(o, DiagService) and self.odx_link_id == o.odx_link_id
+        return isinstance(o, DiagService) and self.odx_id == o.odx_id
 
 
 def read_diag_service_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
     # logger.info(f"Parsing service based on ET DiagService element: {et_element}")
     short_name = et_element.find("SHORT-NAME").text
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
 
     request_ref = OdxLinkRef.from_et(et_element.find("REQUEST-REF"), doc_frags)
     assert request_ref is not None
@@ -288,7 +288,7 @@ def read_diag_service_from_odx(et_element, doc_frags: List[OdxDocFragment]):
         audience = read_audience_from_odx(et_element.find(
             "AUDIENCE"), doc_frags)
 
-    diag_service = DiagService(odx_link_id,
+    diag_service = DiagService(odx_id,
                                short_name,
                                request_ref,
                                pos_res_refs,

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -19,7 +19,7 @@ from .message import Message
 
 class DiagService:
     def __init__(self,
-                 id: OdxLinkId,
+                 odx_link_id: OdxLinkId,
                  short_name: str,
                  request: Union[OdxLinkRef, Request],
                  positive_responses: Union[Iterable[OdxLinkRef], Iterable[Response]],
@@ -35,7 +35,7 @@ class DiagService:
 
         Parameters:
         ----------
-        id: OdxLinkId
+        odx_link_id: OdxLinkId
         short_name: str
             the short name of this DIAG-SERVICE
         request: OdxLinkRef | Request
@@ -43,7 +43,7 @@ class DiagService:
         positive_responses: List[OdxLinkRef] | List[Response]
         negative_responses: List[OdxLinkRef] | List[Response]
         """
-        self.id: OdxLinkId = id
+        self.odx_link_id: OdxLinkId = odx_link_id
         self.short_name: str = short_name
         self.long_name: Optional[str] = long_name
         self.description: Optional[str] = description
@@ -71,7 +71,7 @@ class DiagService:
             self.request_ref = request
         elif isinstance(request, Request):
             self._request = request
-            self.request_ref = OdxLinkRef.from_id(request.id)
+            self.request_ref = OdxLinkRef.from_id(request.odx_link_id)
         else:
             raise ValueError(
                 "request must be a reference to a request or a Request object")
@@ -82,7 +82,7 @@ class DiagService:
                 NamedItemList[Response](short_name_as_id,
                                         positive_responses)  # type: ignore
             self.pos_res_refs = [
-                OdxLinkRef.from_id(pr.id) for pr in positive_responses]  # type: ignore
+                OdxLinkRef.from_id(pr.odx_link_id) for pr in positive_responses]  # type: ignore
         elif all(isinstance(x, OdxLinkRef) for x in positive_responses):
             self._positive_responses = None
             self.pos_res_refs = positive_responses  # type: ignore
@@ -95,7 +95,7 @@ class DiagService:
                 NamedItemList[Response](short_name_as_id,
                                         negative_responses)  # type: ignore
             self.neg_res_refs = [
-                OdxLinkRef.from_id(nr.id) for nr in negative_responses]  # type: ignore
+                OdxLinkRef.from_id(nr.odx_link_id) for nr in negative_responses]  # type: ignore
         elif all(isinstance(x, OdxLinkRef) for x in negative_responses):
             self._negative_responses = None
             self.neg_res_refs = negative_responses  # type: ignore
@@ -227,24 +227,24 @@ class DiagService:
         return self.encode_request(**params)
 
     def __str__(self):
-        return f"DiagService(id={self.id}, semantic={self.semantic})"
+        return f"DiagService(odx_link_id={self.odx_link_id}, semantic={self.semantic})"
 
     def __repr__(self):
         return self.__str__()
 
     def __hash__(self) -> int:
-        return hash(self.id)
+        return hash(self.odx_link_id)
 
     def __eq__(self, o: object) -> bool:
-        return isinstance(o, DiagService) and self.id == o.id
+        return isinstance(o, DiagService) and self.odx_link_id == o.odx_link_id
 
 
 def read_diag_service_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
     # logger.info(f"Parsing service based on ET DiagService element: {et_element}")
     short_name = et_element.find("SHORT-NAME").text
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
 
     request_ref = OdxLinkRef.from_et(et_element.find("REQUEST-REF"), doc_frags)
     assert request_ref is not None
@@ -288,7 +288,7 @@ def read_diag_service_from_odx(et_element, doc_frags: List[OdxDocFragment]):
         audience = read_audience_from_odx(et_element.find(
             "AUDIENCE"), doc_frags)
 
-    diag_service = DiagService(id,
+    diag_service = DiagService(odx_link_id,
                                short_name,
                                request_ref,
                                pos_res_refs,

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -47,7 +47,7 @@ class InputParam:
 
 @dataclass
 class OutputParam:
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     dop_base_ref: OdxLinkRef
     long_name: Optional[str] = None
@@ -121,7 +121,7 @@ class SingleEcuJob:
     TODO: The following xml attributes are not internalized yet:
           ADMIN-DATA, SDGS, PROTOCOL-SNREFS, RELATED-DIAG-COMM-REFS, PRE-CONDITION-STATE-REFS, STATE-TRANSITION-REFS
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     prog_codes: List[ProgCode]
     """Pointers to the code that is executed when calling this job."""
@@ -196,35 +196,35 @@ class SingleEcuJob:
         and only raises an informative error.
         """
         raise DecodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be decoded."
-                          f" You tried to decode a response for the job {self.id}.")
+                          f" You tried to decode a response for the job {self.odx_link_id}.")
 
     def encode_request(self, **params):
         """This function's signature matches `DiagService.encode_request`
         and only raises an informative error.
         """
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to encode a request for the job {self.id}.")
+                          f" You tried to encode a request for the job {self.odx_link_id}.")
 
     def encode_positive_response(self, coded_request, response_index=0, **params):
         """This function's signature matches `DiagService.encode_positive_response`
         and only raises an informative error.
         """
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to encode a response for the job {self.id}.")
+                          f" You tried to encode a response for the job {self.odx_link_id}.")
 
     def encode_negative_response(self, coded_request, response_index=0, **params):
         """This function's signature matches `DiagService.encode_negative_response`
         and only raises an informative error.
         """
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to encode the job {self.id}.")
+                          f" You tried to encode the job {self.odx_link_id}.")
 
     def __call__(self, **params) -> bytes:
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to call the job {self.id}.")
+                          f" You tried to call the job {self.odx_link_id}.")
 
     def __hash__(self) -> int:
-        return hash(self.id)
+        return hash(self.odx_link_id)
 
 
 def read_prog_code_from_odx(et_element, doc_frags: List[OdxDocFragment]):
@@ -277,8 +277,8 @@ def read_input_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 
 def read_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     short_name = et_element.find("SHORT-NAME").text
     assert short_name is not None
     long_name = et_element.findtext("LONG-NAME")
@@ -290,7 +290,7 @@ def read_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     oid = et_element.get("OID")
 
     return OutputParam(
-        id=id,
+        odx_link_id=odx_link_id,
         short_name=short_name,
         long_name=long_name,
         description=description,
@@ -319,8 +319,8 @@ def read_neg_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 def read_single_ecu_job_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     logger.info(
         f"Parsing service based on ET DiagService element: {et_element}")
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     short_name = et_element.find("SHORT-NAME").text
     assert short_name is not None
     long_name = et_element.findtext("LONG-NAME")
@@ -358,7 +358,7 @@ def read_single_ecu_job_from_odx(et_element, doc_frags: List[OdxDocFragment]):
                      else True)
     is_final = True if et_element.get("IS-FINAL") == "true" else False
 
-    diag_service = SingleEcuJob(id=id,
+    diag_service = SingleEcuJob(odx_link_id=odx_link_id,
                                 short_name=short_name,
                                 long_name=long_name,
                                 description=description,

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -47,7 +47,7 @@ class InputParam:
 
 @dataclass
 class OutputParam:
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     dop_base_ref: OdxLinkRef
     long_name: Optional[str] = None
@@ -121,7 +121,7 @@ class SingleEcuJob:
     TODO: The following xml attributes are not internalized yet:
           ADMIN-DATA, SDGS, PROTOCOL-SNREFS, RELATED-DIAG-COMM-REFS, PRE-CONDITION-STATE-REFS, STATE-TRANSITION-REFS
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     prog_codes: List[ProgCode]
     """Pointers to the code that is executed when calling this job."""
@@ -196,35 +196,35 @@ class SingleEcuJob:
         and only raises an informative error.
         """
         raise DecodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be decoded."
-                          f" You tried to decode a response for the job {self.odx_link_id}.")
+                          f" You tried to decode a response for the job {self.odx_id}.")
 
     def encode_request(self, **params):
         """This function's signature matches `DiagService.encode_request`
         and only raises an informative error.
         """
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to encode a request for the job {self.odx_link_id}.")
+                          f" You tried to encode a request for the job {self.odx_id}.")
 
     def encode_positive_response(self, coded_request, response_index=0, **params):
         """This function's signature matches `DiagService.encode_positive_response`
         and only raises an informative error.
         """
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to encode a response for the job {self.odx_link_id}.")
+                          f" You tried to encode a response for the job {self.odx_id}.")
 
     def encode_negative_response(self, coded_request, response_index=0, **params):
         """This function's signature matches `DiagService.encode_negative_response`
         and only raises an informative error.
         """
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to encode the job {self.odx_link_id}.")
+                          f" You tried to encode the job {self.odx_id}.")
 
     def __call__(self, **params) -> bytes:
         raise EncodeError(f"Single ECU jobs are completely executed on the tester and thus cannot be encoded."
-                          f" You tried to call the job {self.odx_link_id}.")
+                          f" You tried to call the job {self.odx_id}.")
 
     def __hash__(self) -> int:
-        return hash(self.odx_link_id)
+        return hash(self.odx_id)
 
 
 def read_prog_code_from_odx(et_element, doc_frags: List[OdxDocFragment]):
@@ -277,8 +277,8 @@ def read_input_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 
 def read_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     short_name = et_element.find("SHORT-NAME").text
     assert short_name is not None
     long_name = et_element.findtext("LONG-NAME")
@@ -290,7 +290,7 @@ def read_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     oid = et_element.get("OID")
 
     return OutputParam(
-        odx_link_id=odx_link_id,
+        odx_id=odx_id,
         short_name=short_name,
         long_name=long_name,
         description=description,
@@ -319,8 +319,8 @@ def read_neg_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 def read_single_ecu_job_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     logger.info(
         f"Parsing service based on ET DiagService element: {et_element}")
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     short_name = et_element.find("SHORT-NAME").text
     assert short_name is not None
     long_name = et_element.findtext("LONG-NAME")
@@ -358,7 +358,7 @@ def read_single_ecu_job_from_odx(et_element, doc_frags: List[OdxDocFragment]):
                      else True)
     is_final = True if et_element.get("IS-FINAL") == "true" else False
 
-    diag_service = SingleEcuJob(odx_link_id=odx_link_id,
+    diag_service = SingleEcuJob(odx_id=odx_id,
                                 short_name=short_name,
                                 long_name=long_name,
                                 description=description,

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -8,7 +8,7 @@ from .utils import short_name_as_id
 from .dataobjectproperty import DopBase
 from .audience import Audience, read_audience_from_odx
 from .functionalclass import FunctionalClass
-from .utils import read_element_id
+from .utils import read_description_from_odx
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
 from .nameditemlist import NamedItemList
 from .globals import logger
@@ -254,16 +254,21 @@ def read_prog_code_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 
 def read_input_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    element_id = read_element_id(et_element)
+    short_name = et_element.findtext("SHORT-NAME")
+    assert short_name is not None
+    long_name = et_element.findtext("LONG-NAME")
+    description = read_description_from_odx(et_element.find("DESC"))
     dop_base_ref = OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags)
     assert dop_base_ref is not None
     physical_default_value = et_element.findtext("PHYSICAL-DEFAULT-VALUE")
 
-    # optional attributes
     semantic = et_element.get("SEMANTIC")
     oid = et_element.get("OID")
+
     return InputParam(
-        **element_id, # type: ignore
+        short_name=short_name,
+        long_name=long_name,
+        description=description,
         dop_base_ref=dop_base_ref,
         physical_default_value=physical_default_value,
         semantic=semantic,
@@ -274,16 +279,21 @@ def read_input_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 def read_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     id = OdxLinkId.from_et(et_element, doc_frags)
     assert id is not None
-    element_id = read_element_id(et_element)
+    short_name = et_element.find("SHORT-NAME").text
+    assert short_name is not None
+    long_name = et_element.findtext("LONG-NAME")
+    description = read_description_from_odx(et_element.find("DESC"))
     dop_base_ref = OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags)
     assert dop_base_ref is not None
 
-    # optional attributes
     semantic = et_element.get("SEMANTIC")
     oid = et_element.get("OID")
+
     return OutputParam(
         id=id,
-        **element_id, # type: ignore
+        short_name=short_name,
+        long_name=long_name,
+        description=description,
         dop_base_ref=dop_base_ref,
         semantic=semantic,
         oid=oid
@@ -291,12 +301,17 @@ def read_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 
 def read_neg_output_param_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    element_id = read_element_id(et_element)
+    short_name = et_element.find("SHORT-NAME").text
+    assert short_name is not None
+    long_name = et_element.findtext("LONG-NAME")
+    description = read_description_from_odx(et_element.find("DESC"))
     dop_base_ref = OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags)
     assert dop_base_ref is not None
 
     return NegOutputParam(
-        **element_id, # type: ignore
+        short_name=short_name,
+        long_name=long_name,
+        description=description,
         dop_base_ref=dop_base_ref
     )
 
@@ -306,7 +321,10 @@ def read_single_ecu_job_from_odx(et_element, doc_frags: List[OdxDocFragment]):
         f"Parsing service based on ET DiagService element: {et_element}")
     id = OdxLinkId.from_et(et_element, doc_frags)
     assert id is not None
-    element_id = read_element_id(et_element)
+    short_name = et_element.find("SHORT-NAME").text
+    assert short_name is not None
+    long_name = et_element.findtext("LONG-NAME")
+    description = read_description_from_odx(et_element.find("DESC"))
     semantic = et_element.get("SEMANTIC")
 
     functional_class_refs = []
@@ -340,8 +358,10 @@ def read_single_ecu_job_from_odx(et_element, doc_frags: List[OdxDocFragment]):
                      else True)
     is_final = True if et_element.get("IS-FINAL") == "true" else False
 
-    diag_service = SingleEcuJob(id,
-                                **element_id, # type: ignore
+    diag_service = SingleEcuJob(id=id,
+                                short_name=short_name,
+                                long_name=long_name,
+                                description=description,
                                 prog_codes=prog_codes,
                                 semantic=semantic,
                                 audience=audience,

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -12,7 +12,7 @@ class State:
     """
     Corresponds to STATE.
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -20,14 +20,14 @@ class State:
 
 def read_state_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
 
     long_name = et_element.find(
         "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
     description = read_description_from_odx(et_element.find("DESC"))
 
-    return State(id=id,
+    return State(odx_link_id=odx_link_id,
                  short_name=short_name,
                  long_name=long_name,
                  description=description)

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -12,7 +12,7 @@ class State:
     """
     Corresponds to STATE.
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     description: Optional[str] = None
@@ -20,14 +20,14 @@ class State:
 
 def read_state_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
 
     long_name = et_element.find(
         "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
     description = read_description_from_odx(et_element.find("DESC"))
 
-    return State(odx_link_id=odx_link_id,
+    return State(odx_id=odx_id,
                  short_name=short_name,
                  long_name=long_name,
                  description=description)

--- a/odxtools/state_transition.py
+++ b/odxtools/state_transition.py
@@ -11,7 +11,7 @@ class StateTransition:
     """
     Corresponds to STATE.
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     source_short_name: Optional[str] = None
@@ -20,15 +20,15 @@ class StateTransition:
 
 def read_state_transition_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
 
     long_name = et_element.find(
         "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
     source_short_name = et_element.find("SOURCE-SNREF").attrib["SHORT-NAME"] if et_element.find("SOURCE-SNREF") is not None else None
     target_short_name = et_element.find("TARGET-SNREF").attrib["SHORT-NAME"] if et_element.find("TARGET-SNREF") is not None else None
 
-    return StateTransition(id=id,
+    return StateTransition(odx_link_id=odx_link_id,
                            short_name=short_name,
                            long_name=long_name,
                            source_short_name=source_short_name,

--- a/odxtools/state_transition.py
+++ b/odxtools/state_transition.py
@@ -11,7 +11,7 @@ class StateTransition:
     """
     Corresponds to STATE.
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: Optional[str] = None
     source_short_name: Optional[str] = None
@@ -20,15 +20,15 @@ class StateTransition:
 
 def read_state_transition_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     short_name = et_element.find("SHORT-NAME").text
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
 
     long_name = et_element.find(
         "LONG-NAME").text if et_element.find("LONG-NAME") is not None else None
     source_short_name = et_element.find("SOURCE-SNREF").attrib["SHORT-NAME"] if et_element.find("SOURCE-SNREF") is not None else None
     target_short_name = et_element.find("TARGET-SNREF").attrib["SHORT-NAME"] if et_element.find("TARGET-SNREF") is not None else None
 
-    return StateTransition(odx_link_id=odx_link_id,
+    return StateTransition(odx_id=odx_id,
                            short_name=short_name,
                            long_name=long_name,
                            source_short_name=source_short_name,

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -25,13 +25,13 @@ if TYPE_CHECKING:
 
 class BasicStructure(DopBase):
     def __init__(self,
-                 odx_link_id,
+                 odx_id,
                  short_name,
                  parameters: Iterable[Union[Parameter, "EndOfPduField"]],
                  long_name=None,
                  byte_size=None,
                  description=None):
-        super().__init__(odx_link_id, short_name, long_name=long_name, description=description)
+        super().__init__(odx_id, short_name, long_name=long_name, description=description)
         self.parameters : NamedItemList[Union[Parameter, "EndOfPduField"]] = NamedItemList(short_name_as_id, parameters)
         self._byte_size = byte_size
 
@@ -146,7 +146,7 @@ class BasicStructure(DopBase):
 
             if implicit_length_encoding:
                 # Undo length_keys changes
-                encode_state.length_keys.pop(param.odx_link_id)
+                encode_state.length_keys.pop(param.odx_id)
 
         if self._byte_size is not None and len(coded_rpc) < self._byte_size:
             # Padding bytes needed
@@ -154,7 +154,7 @@ class BasicStructure(DopBase):
 
         for (param, encode_state) in length_encodings:
             # Same as previous, but all bytes as 0.
-            param_value = encode_state.length_keys[param.odx_link_id]
+            param_value = encode_state.length_keys[param.odx_id]
             state = encode_state._replace(
                 coded_message=bytearray(len(encode_state.coded_message)),
                 parameter_values={param.short_name: param_value},
@@ -447,12 +447,12 @@ class BasicStructure(DopBase):
 
 
 class Structure(BasicStructure):
-    def __init__(self, odx_link_id, short_name, parameters, long_name=None, byte_size=None, description=None):
-        super().__init__(odx_link_id, short_name, parameters,
+    def __init__(self, odx_id, short_name, parameters, long_name=None, byte_size=None, description=None):
+        super().__init__(odx_id, short_name, parameters,
                          long_name=long_name, description=description)
 
         self.parameters = parameters
-        self.basic_structure = BasicStructure(odx_link_id, short_name, parameters,
+        self.basic_structure = BasicStructure(odx_id, short_name, parameters,
                                               long_name=long_name, byte_size=byte_size, description=description)
 
     def __repr__(self) -> str:
@@ -469,8 +469,8 @@ class Structure(BasicStructure):
 
 
 class Request(BasicStructure):
-    def __init__(self, odx_link_id, short_name, parameters, long_name=None, description=None):
-        super().__init__(odx_link_id, short_name, parameters,
+    def __init__(self, odx_id, short_name, parameters, long_name=None, description=None):
+        super().__init__(odx_id, short_name, parameters,
                          long_name=long_name, description=description)
 
     def __repr__(self) -> str:
@@ -481,8 +481,8 @@ class Request(BasicStructure):
 
 
 class Response(BasicStructure):
-    def __init__(self, odx_link_id, short_name, parameters, long_name=None, response_type=None, description=None):
-        super().__init__(odx_link_id, short_name, parameters,
+    def __init__(self, odx_id, short_name, parameters, long_name=None, response_type=None, description=None):
+        super().__init__(odx_id, short_name, parameters,
                          long_name=long_name, description=description)
         self.response_type = "POS-RESPONSE" if response_type == "POS-RESPONSE" else "NEG-RESPONSE"
 
@@ -510,7 +510,7 @@ class Response(BasicStructure):
 
 
 def read_structure_from_odx(et_element, doc_frags: List[OdxDocFragment]) -> Union[Structure, Request, Response, None]:
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
     description = read_description_from_odx(et_element.find("DESC"))
@@ -520,7 +520,7 @@ def read_structure_from_odx(et_element, doc_frags: List[OdxDocFragment]) -> Unio
     res: Union[Structure, Request, Response, None]
     if et_element.tag == "REQUEST":
         res = Request(
-            odx_link_id,
+            odx_id,
             short_name,
             parameters=parameters,
             long_name=long_name,
@@ -528,7 +528,7 @@ def read_structure_from_odx(et_element, doc_frags: List[OdxDocFragment]) -> Unio
         )
     elif et_element.tag in ["POS-RESPONSE", "NEG-RESPONSE"]:
         res = Response(
-            odx_link_id,
+            odx_id,
             short_name,
             response_type=et_element.tag,
             parameters=parameters,
@@ -539,7 +539,7 @@ def read_structure_from_odx(et_element, doc_frags: List[OdxDocFragment]) -> Unio
         byte_size = int(et_element.find(
             "BYTE-SIZE").text) if et_element.find("BYTE-SIZE") is not None else None
         res = Structure(
-            odx_link_id,
+            odx_id,
             short_name,
             parameters=parameters,
             byte_size=byte_size,

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -15,8 +15,8 @@ from .globals import logger
 class TableBase(abc.ABC):
     """ Base class for all Tables."""
 
-    def __init__(self, id: OdxLinkId, short_name: str, long_name=None):
-        self.id = id
+    def __init__(self, odx_link_id: OdxLinkId, short_name: str, long_name=None):
+        self.odx_link_id = odx_link_id
         self.short_name = short_name
         self.long_name = long_name
 
@@ -25,7 +25,7 @@ class TableBase(abc.ABC):
 class TableRow:
     """This class represents a TABLE-ROW."""
 
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     long_name: str
     key: int
@@ -72,7 +72,7 @@ class Table(TableBase):
 
     def __init__(
         self,
-        id: OdxLinkId,
+        odx_link_id: OdxLinkId,
         short_name: str,
         table_rows: List[TableRow],
         table_row_refs: Optional[List[OdxLinkRef]] = None,
@@ -82,7 +82,7 @@ class Table(TableBase):
         semantic: Optional[str] = None,
     ):
         super().__init__(
-            id=id, short_name=short_name, long_name=long_name
+            odx_link_id=odx_link_id, short_name=short_name, long_name=long_name
         )
         self._local_table_rows = table_rows
         self._ref_table_rows: List[TableRow] = []
@@ -104,7 +104,7 @@ class Table(TableBase):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
-        odxlinks.update({table_row.id: table_row for table_row in self.table_rows})
+        odxlinks.update({table_row.odx_link_id: table_row for table_row in self.table_rows})
         return odxlinks
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
@@ -133,7 +133,7 @@ class Table(TableBase):
 def _get_common_props(et_element, doc_frags: List[OdxDocFragment]):
     description = read_description_from_odx(et_element.find("DESC"))
     return dict(
-        id=OdxLinkId.from_et(et_element, doc_frags),
+        odx_link_id=OdxLinkId.from_et(et_element, doc_frags),
         short_name=et_element.findtext("SHORT-NAME"),
         long_name=et_element.findtext("LONG-NAME"),
         semantic=et_element.get("SEMANTIC"),

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -15,8 +15,8 @@ from .globals import logger
 class TableBase(abc.ABC):
     """ Base class for all Tables."""
 
-    def __init__(self, odx_link_id: OdxLinkId, short_name: str, long_name=None):
-        self.odx_link_id = odx_link_id
+    def __init__(self, odx_id: OdxLinkId, short_name: str, long_name=None):
+        self.odx_id = odx_id
         self.short_name = short_name
         self.long_name = long_name
 
@@ -25,7 +25,7 @@ class TableBase(abc.ABC):
 class TableRow:
     """This class represents a TABLE-ROW."""
 
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     long_name: str
     key: int
@@ -72,7 +72,7 @@ class Table(TableBase):
 
     def __init__(
         self,
-        odx_link_id: OdxLinkId,
+        odx_id: OdxLinkId,
         short_name: str,
         table_rows: List[TableRow],
         table_row_refs: Optional[List[OdxLinkRef]] = None,
@@ -82,7 +82,7 @@ class Table(TableBase):
         semantic: Optional[str] = None,
     ):
         super().__init__(
-            odx_link_id=odx_link_id, short_name=short_name, long_name=long_name
+            odx_id=odx_id, short_name=short_name, long_name=long_name
         )
         self._local_table_rows = table_rows
         self._ref_table_rows: List[TableRow] = []
@@ -104,7 +104,7 @@ class Table(TableBase):
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
-        odxlinks.update({table_row.odx_link_id: table_row for table_row in self.table_rows})
+        odxlinks.update({table_row.odx_id: table_row for table_row in self.table_rows})
         return odxlinks
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
@@ -133,7 +133,7 @@ class Table(TableBase):
 def _get_common_props(et_element, doc_frags: List[OdxDocFragment]):
     description = read_description_from_odx(et_element.find("DESC"))
     return dict(
-        odx_link_id=OdxLinkId.from_et(et_element, doc_frags),
+        odx_id=OdxLinkId.from_et(et_element, doc_frags),
         short_name=et_element.findtext("SHORT-NAME"),
         long_name=et_element.findtext("LONG-NAME"),
         semantic=et_element.get("SEMANTIC"),

--- a/odxtools/units.py
+++ b/odxtools/units.py
@@ -37,14 +37,14 @@ class PhysicalDimension:
     The unit `m/s` (or `m**1 * s**(-1)`) can be represented as
     ```
     PhysicalDimension(
-        id="velocity",
+        odx_link_id="velocity",
         short_name="metre_per_second",
         length_exp=1,
         time_exp=-1
     )
     ```
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     oid: Optional[str] = None
     long_name: Optional[str] = None
@@ -78,7 +78,7 @@ class Unit:
 
     ```
     Unit(
-        id="kilometre",
+        odx_link_id="kilometre",
         short_name="kilometre",
         display_name="km"
     )
@@ -88,7 +88,7 @@ class Unit:
 
     ```
     Unit(
-        id=OdxLinkId("ID.kilometre", doc_frags),
+        odx_link_id=OdxLinkId("ID.kilometre", doc_frags),
         short_name="Kilometre",
         display_name="km",
         physical_dimension_ref=OdxLinkRef("ID.metre", doc_frags),
@@ -96,10 +96,10 @@ class Unit:
         offset_si_to_unit=0
     )
     # where the physical_dimension_ref references, e.g.:
-    PhysicalDimension(id=OdxLinkId("ID.metre", doc_frags), short_name="metre", length_exp=1)
+    PhysicalDimension(odx_link_id=OdxLinkId("ID.metre", doc_frags), short_name="metre", length_exp=1)
     ```
     """
-    id: OdxLinkId
+    odx_link_id: OdxLinkId
     short_name: str
     display_name: str
     oid: Optional[str] = None
@@ -186,10 +186,10 @@ class UnitSpec:
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
         odxlinks.update({
-            unit.id: unit for unit in self.units
+            unit.odx_link_id: unit for unit in self.units
         })
         odxlinks.update({
-            dim.id: dim for dim in self.physical_dimensions
+            dim.odx_link_id: dim for dim in self.physical_dimensions
         })
         return odxlinks
 
@@ -201,8 +201,8 @@ class UnitSpec:
 
 
 def read_unit_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     oid = et_element.get("OID")
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
@@ -219,7 +219,7 @@ def read_unit_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     physical_dimension_ref = OdxLinkRef.from_et(et_element.find("PHYSICAL-DIMENSION-REF"), doc_frags)
 
     return Unit(
-        id=id,
+        odx_link_id=odx_link_id,
         short_name=short_name,
         display_name=display_name,
         oid=oid,
@@ -232,8 +232,8 @@ def read_unit_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 
 def read_physical_dimension_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    id = OdxLinkId.from_et(et_element, doc_frags)
-    assert id is not None
+    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_link_id is not None
     oid = et_element.get("OID")
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
@@ -255,7 +255,7 @@ def read_physical_dimension_from_odx(et_element, doc_frags: List[OdxDocFragment]
                                                "LUMINOUS-INTENSITY-EXP")
 
     return PhysicalDimension(
-        id=id,
+        odx_link_id=odx_link_id,
         short_name=short_name,
         oid=oid,
         long_name=long_name,

--- a/odxtools/units.py
+++ b/odxtools/units.py
@@ -37,14 +37,14 @@ class PhysicalDimension:
     The unit `m/s` (or `m**1 * s**(-1)`) can be represented as
     ```
     PhysicalDimension(
-        odx_link_id="velocity",
+        odx_id="velocity",
         short_name="metre_per_second",
         length_exp=1,
         time_exp=-1
     )
     ```
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     oid: Optional[str] = None
     long_name: Optional[str] = None
@@ -78,7 +78,7 @@ class Unit:
 
     ```
     Unit(
-        odx_link_id="kilometre",
+        odx_id="kilometre",
         short_name="kilometre",
         display_name="km"
     )
@@ -88,7 +88,7 @@ class Unit:
 
     ```
     Unit(
-        odx_link_id=OdxLinkId("ID.kilometre", doc_frags),
+        odx_id=OdxLinkId("ID.kilometre", doc_frags),
         short_name="Kilometre",
         display_name="km",
         physical_dimension_ref=OdxLinkRef("ID.metre", doc_frags),
@@ -96,10 +96,10 @@ class Unit:
         offset_si_to_unit=0
     )
     # where the physical_dimension_ref references, e.g.:
-    PhysicalDimension(odx_link_id=OdxLinkId("ID.metre", doc_frags), short_name="metre", length_exp=1)
+    PhysicalDimension(odx_id=OdxLinkId("ID.metre", doc_frags), short_name="metre", length_exp=1)
     ```
     """
-    odx_link_id: OdxLinkId
+    odx_id: OdxLinkId
     short_name: str
     display_name: str
     oid: Optional[str] = None
@@ -186,10 +186,10 @@ class UnitSpec:
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {}
         odxlinks.update({
-            unit.odx_link_id: unit for unit in self.units
+            unit.odx_id: unit for unit in self.units
         })
         odxlinks.update({
-            dim.odx_link_id: dim for dim in self.physical_dimensions
+            dim.odx_id: dim for dim in self.physical_dimensions
         })
         return odxlinks
 
@@ -201,8 +201,8 @@ class UnitSpec:
 
 
 def read_unit_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     oid = et_element.get("OID")
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
@@ -219,7 +219,7 @@ def read_unit_from_odx(et_element, doc_frags: List[OdxDocFragment]):
     physical_dimension_ref = OdxLinkRef.from_et(et_element.find("PHYSICAL-DIMENSION-REF"), doc_frags)
 
     return Unit(
-        odx_link_id=odx_link_id,
+        odx_id=odx_id,
         short_name=short_name,
         display_name=display_name,
         oid=oid,
@@ -232,8 +232,8 @@ def read_unit_from_odx(et_element, doc_frags: List[OdxDocFragment]):
 
 
 def read_physical_dimension_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    odx_link_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_link_id is not None
+    odx_id = OdxLinkId.from_et(et_element, doc_frags)
+    assert odx_id is not None
     oid = et_element.get("OID")
     short_name = et_element.find("SHORT-NAME").text
     long_name = et_element.findtext("LONG-NAME")
@@ -255,7 +255,7 @@ def read_physical_dimension_from_odx(et_element, doc_frags: List[OdxDocFragment]
                                                "LUMINOUS-INTENSITY-EXP")
 
     return PhysicalDimension(
-        odx_link_id=odx_link_id,
+        odx_id=odx_id,
         short_name=short_name,
         oid=oid,
         long_name=long_name,

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -6,12 +6,20 @@ from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment
 
-def read_description_from_odx(et_element: Optional[ElementTree.Element]):
-    """Read a DESCRIPTION element. The element usually has the name DESC."""
+def read_description_from_odx(et_element: Optional[ElementTree.Element]) \
+ -> Optional[str]:
+    """Read a description of an XML element.
+
+    The description is located underneath the DESC sub-tag."""
+
     # TODO: Invent a better representation of a DESC element.
     #       This just represents it as XHTML string.
     if et_element is None:
         return None
+
+    if et_element.tag != "DESC":
+        raise TypeError(f"Attempted to extract ODX desctiption from "
+                        f"{et_element.tag} XML node. (Must be a DESC node!)")
 
     raw_string = et_element.text or ''
     for e in et_element:
@@ -19,38 +27,6 @@ def read_description_from_odx(et_element: Optional[ElementTree.Element]):
 
     return raw_string.strip()
 
-
-def read_element_id(et_element) -> Dict[Literal["short_name", "long_name", "description"], str]:
-    """Read the elements "SHORT-NAME", "LONG-NAME" and "DESCRIPTION".
-
-    Returns the dict
-    ```python
-    {
-        "short_name": et_element.find("SHORT-NAME"),
-        "long_name": et_element.find("LONG-NAME"),
-        "description": read_description_from_odx(et_element.find("DESC"))
-    }
-    ```
-    If `et_element` does not contain the elements "LONG-NAME" and "DESC",
-    the returned dict does not contain the correspondig keys.
-
-    A typical use for this function is reading an odx element
-    that contains the group "ELEMENT-ID", e.g.,
-    ```python
-    def read_type_with_element_id_from_odx(et_element):
-        element_id = read_element_id(et_element)
-        return TypeWithElementID(**element_id)
-    ```
-
-    """
-    d: Dict[Literal["short_name", "long_name", "description"], str] = {
-        "short_name": et_element.findtext("SHORT-NAME")
-    }
-    if et_element.find("LONG-NAME") is not None:
-        d["long_name"] = et_element.findtext("LONG-NAME")
-    if et_element.find("DESC") is not None:
-        d["description"] = read_description_from_odx(et_element.find("DESC"))
-    return d
 
 def short_name_as_id(obj: Any) -> str:
     """Retrieve an object's `short_name` attribute into a valid python identifier.

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -8,19 +8,19 @@ from .odxlink import OdxDocFragment
 
 def read_description_from_odx(et_element: Optional[ElementTree.Element]) \
  -> Optional[str]:
-    """Read a description of an XML element.
+    """Read a description tag.
 
-    The description is located underneath the DESC sub-tag."""
+    The description is located underneath the DESC tag of an an ODX
+    element."""
 
-    # TODO: Invent a better representation of a DESC element.
-    #       This just represents it as XHTML string.
     if et_element is None:
         return None
 
     if et_element.tag != "DESC":
-        raise TypeError(f"Attempted to extract ODX desctiption from "
-                        f"{et_element.tag} XML node. (Must be a DESC node!)")
+        raise TypeError(f"Attempted to extract an ODX description from a "
+                        f"'{et_element.tag}' XML node. (Must be a 'DESC' node!)")
 
+    # Extract the contents of the tag as a XHTML string.
     raw_string = et_element.text or ''
     for e in et_element:
         raw_string += ElementTree.tostring(e, encoding='unicode')

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -30,8 +30,8 @@ class TestIdentifyingService(unittest.TestCase):
             "coded_const_parameter_2", diag_coded_type, coded_value=0xab, byte_position=1)
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.id: req})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
                               request=req,
                               positive_responses=[],
@@ -40,22 +40,22 @@ class TestIdentifyingService(unittest.TestCase):
         req2_param2 = CodedConstParameter(
             "coded_const_parameter_3", diag_coded_type_2, coded_value=0xcde)
         req2 = Request(OdxLinkId("request_id2", doc_frags), "request_sn2", [req_param1, req2_param2])
-        odxlinks.update({req2.id: req2})
+        odxlinks.update({req2.odx_link_id: req2})
 
         resp2_param2 = CodedConstParameter(
             "coded_const_parameter_4", diag_coded_type_2, coded_value=0xc86)
         resp2 = Response(OdxLinkId("response_id2", doc_frags), "response_sn2",
                          [req_param1, resp2_param2])
-        odxlinks.update({resp2.id: resp2})
+        odxlinks.update({resp2.odx_link_id: resp2})
 
-        service2 = DiagService(id=OdxLinkId("service_id2", doc_frags),
+        service2 = DiagService(odx_link_id=OdxLinkId("service_id2", doc_frags),
                                short_name="service_sn2",
                                request=req2,
                                positive_responses=[resp2],
                                negative_responses=[])
 
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service, service2],
                                requests=[req, req2],
@@ -83,14 +83,14 @@ class TestDecoding(unittest.TestCase):
                       [req_param1, req_param2])
 
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.id: req})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.id),
+                              request=OdxLinkRef.from_id(req.odx_link_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -126,14 +126,14 @@ class TestDecoding(unittest.TestCase):
                       req_param1, req_param2, req_param3, req_param4])
 
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.id: req})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.id),
+                              request=OdxLinkRef.from_id(req.odx_link_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -161,12 +161,12 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type_4 = StandardLengthType("A_UINT32", 4)
 
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
-        dop = DataObjectProperty(OdxLinkId("dop.id", doc_frags),
+        dop = DataObjectProperty(OdxLinkId("dop.odx_link_id", doc_frags),
                                  "dop_sn",
                                  diag_coded_type_4,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
-        odxlinks.update({dop.id: dop})
+        odxlinks.update({dop.odx_link_id: dop})
 
         req_param1 = CodedConstParameter("SID",
                                          diag_coded_type,
@@ -179,19 +179,19 @@ class TestDecoding(unittest.TestCase):
             "struct_param_2", dop=dop, byte_position=0, bit_position=4)
         struct = Structure(OdxLinkId("struct_id", doc_frags), "struct", [
                            struct_param1, struct_param2])
-        odxlinks.update({struct.id: struct})
+        odxlinks.update({struct.odx_link_id: struct})
         req_param2 = ValueParameter("structured_param", dop=struct)
 
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
                       req_param1, req_param2])
-        odxlinks.update({req.id: req})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.id),
+                              request=OdxLinkRef.from_id(req.odx_link_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -216,12 +216,12 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type_4 = StandardLengthType("A_UINT32", 4)
 
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
-        dop = DataObjectProperty(OdxLinkId("dop.id", doc_frags),
+        dop = DataObjectProperty(OdxLinkId("dop.odx_link_id", doc_frags),
                                  "dop_sn",
                                  diag_coded_type_4,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
-        odxlinks.update({dop.id: dop})
+        odxlinks.update({dop.odx_link_id: dop})
 
         req_param1 = CodedConstParameter("SID",
                                          diag_coded_type,
@@ -234,24 +234,24 @@ class TestDecoding(unittest.TestCase):
             "struct_param_2", dop=dop, byte_position=0, bit_position=4)
         struct = Structure(OdxLinkId("struct_id", doc_frags), "struct", [
                            struct_param1, struct_param2])
-        odxlinks.update({struct.id: struct})
+        odxlinks.update({struct.odx_link_id: struct})
         eopf = EndOfPduField(OdxLinkId("eopf_id", doc_frags), "eopf_sn",
                              structure=struct,
                              is_visible=True)
-        odxlinks.update({eopf.id: eopf})
+        odxlinks.update({eopf.odx_link_id: eopf})
 
         req_param2 = ValueParameter("eopf_param", dop=eopf)
 
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
                       req_param1, req_param2])
-        odxlinks.update({req.id: req})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.id),
+                              request=OdxLinkRef.from_id(req.odx_link_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -275,12 +275,12 @@ class TestDecoding(unittest.TestCase):
 
         compu_method = LinearCompuMethod(1, 5, "A_INT32", "A_INT32")
         diag_coded_type = StandardLengthType("A_UINT32", 8)
-        dop = DataObjectProperty(OdxLinkId("linear.dop.id", doc_frags),
+        dop = DataObjectProperty(OdxLinkId("linear.dop.odx_link_id", doc_frags),
                                  "linear.dop.sn",
                                  diag_coded_type,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
-        odxlinks.update({dop.id: dop})
+        odxlinks.update({dop.odx_link_id: dop})
         req_param1 = CodedConstParameter("SID",
                                          diag_coded_type,
                                          coded_value=0x7d,
@@ -290,14 +290,14 @@ class TestDecoding(unittest.TestCase):
                                     byte_position=1)
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
 
-        odxlinks.update({req.id: req})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.id),
+                              request=OdxLinkRef.from_id(req.odx_link_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -344,16 +344,16 @@ class TestDecoding(unittest.TestCase):
                                 resp_param1, resp_param2])
 
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.id: req,
-                          pos_response.id: pos_response,
-                          neg_response.id: neg_response})
-        service = DiagService(id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_link_id: req,
+                         pos_response.odx_link_id: pos_response,
+                         neg_response.odx_link_id: neg_response})
+        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.id),
-                              positive_responses=[OdxLinkRef.from_id(pos_response.id)],
-                              negative_responses=[OdxLinkRef.from_id(neg_response.id)])
+                              request=OdxLinkRef.from_id(req.odx_link_id),
+                              positive_responses=[OdxLinkRef.from_id(pos_response.odx_link_id)],
+                              negative_responses=[OdxLinkRef.from_id(neg_response.odx_link_id)])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               id=OdxLinkId("dl_id", doc_frags),
+                               odx_link_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -379,25 +379,26 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
 
-        dtc1 = DiagnosticTroubleCode(id=OdxLinkId("dtcID1", doc_frags),
+        dtc1 = DiagnosticTroubleCode(odx_link_id=OdxLinkId("dtcID1", doc_frags),
                                      short_name="P34_sn",
                                      trouble_code=0x34,
                                      text="Error encountered",
                                      display_trouble_code="P34")
-        dtc2 = DiagnosticTroubleCode(id=OdxLinkId("dtcID2", doc_frags),
+
+        dtc2 = DiagnosticTroubleCode(odx_link_id=OdxLinkId("dtcID2", doc_frags),
                                      short_name="P56_sn",
                                      trouble_code=0x56,
                                      text="Crashed into wall",
                                      display_trouble_code="P56")
         dtcs = [dtc1, dtc2]
-        dop = DtcDop(OdxLinkId("dtc.dop.id", doc_frags),
+        dop = DtcDop(OdxLinkId("dtc.dop.odx_link_id", doc_frags),
                      "dtc_dop_sn",
                      diag_coded_type,
                      physical_type=PhysicalType(DataType.A_UINT32),
                      compu_method=compu_method,
                      dtcs=dtcs,
                      is_visible=True)
-        odxlinks[dop.id] = dop
+        odxlinks[dop.odx_link_id] = dop
         resp_param1 = CodedConstParameter(
             "SID", diag_coded_type, coded_value=0x12, byte_position=0)
         resp_param2 = ValueParameter(
@@ -414,17 +415,17 @@ class TestDecoding(unittest.TestCase):
 class TestDecodingAndEncoding(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.dop_bytes_termination_end_of_pdu = DataObjectProperty(
-            id=OdxLinkId("DOP_ID", doc_frags),
-            short_name="DOP",
-            diag_coded_type=MinMaxLengthType(
-                DataType.A_BYTEFIELD, min_length=0, termination='END-OF-PDU'),
-            physical_type=PhysicalType(DataType.A_BYTEFIELD),
-            compu_method=IdenticalCompuMethod(
-                internal_type=DataType.A_BYTEFIELD,
-                physical_type=DataType.A_BYTEFIELD
+        self.dop_bytes_termination_end_of_pdu = \
+            DataObjectProperty(
+                odx_link_id=OdxLinkId("DOP_ID", doc_frags),
+                short_name="DOP",
+                diag_coded_type=MinMaxLengthType(DataType.A_BYTEFIELD,
+                                                 min_length=0,
+                                                 termination='END-OF-PDU'),
+                physical_type=PhysicalType(DataType.A_BYTEFIELD),
+                compu_method=IdenticalCompuMethod(internal_type=DataType.A_BYTEFIELD,
+                                                  physical_type=DataType.A_BYTEFIELD)
             )
-        )
         self.parameter_termination_end_of_pdu = ValueParameter(
             short_name="min_max_parameter",
             dop=self.dop_bytes_termination_end_of_pdu
@@ -440,14 +441,12 @@ class TestDecodingAndEncoding(unittest.TestCase):
     def test_min_max_length_type_end_of_pdu(self):
         req_param1 = self.parameter_sid
         req_param2 = self.parameter_termination_end_of_pdu
-        request = Request(
-            id=OdxLinkId("request", doc_frags),
-            short_name="Request",
-            parameters=[
-                req_param1,
-                req_param2
-            ]
-        )
+        request = Request(odx_link_id=OdxLinkId("request", doc_frags),
+                          short_name="Request",
+                          parameters=[
+                              req_param1,
+                              req_param2
+                          ])
         expected_coded_message = bytes([0x12, 0x34])
         expected_param_dict = {
             "SID": 0x12,
@@ -464,7 +463,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         struct_param = self.parameter_termination_end_of_pdu
 
         structure = Structure(
-            id=OdxLinkId("structure_id", doc_frags),
+            odx_link_id=OdxLinkId("structure_id", doc_frags),
             short_name="Structure_with_End_of_PDU_termination",
             parameters=[
                 struct_param
@@ -478,7 +477,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         )
 
         request = Request(
-            id=OdxLinkId("request", doc_frags),
+            odx_link_id=OdxLinkId("request", doc_frags),
             short_name="Request",
             parameters=[
                 req_param1,
@@ -504,7 +503,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         offset = 0x34
         dop = DataObjectProperty(
-            id=OdxLinkId("DOP_ID", doc_frags),
+            odx_link_id=OdxLinkId("DOP_ID", doc_frags),
             short_name="DOP",
             diag_coded_type=diag_coded_type,
             physical_type=PhysicalType(DataType.A_INT32),
@@ -527,7 +526,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
             dop=dop
         )
         request = Request(
-            id=OdxLinkId("request", doc_frags),
+            odx_link_id=OdxLinkId("request", doc_frags),
             short_name="Request",
             parameters=[
                 req_param1,

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -30,8 +30,8 @@ class TestIdentifyingService(unittest.TestCase):
             "coded_const_parameter_2", diag_coded_type, coded_value=0xab, byte_position=1)
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.odx_link_id: req})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
                               request=req,
                               positive_responses=[],
@@ -40,22 +40,22 @@ class TestIdentifyingService(unittest.TestCase):
         req2_param2 = CodedConstParameter(
             "coded_const_parameter_3", diag_coded_type_2, coded_value=0xcde)
         req2 = Request(OdxLinkId("request_id2", doc_frags), "request_sn2", [req_param1, req2_param2])
-        odxlinks.update({req2.odx_link_id: req2})
+        odxlinks.update({req2.odx_id: req2})
 
         resp2_param2 = CodedConstParameter(
             "coded_const_parameter_4", diag_coded_type_2, coded_value=0xc86)
         resp2 = Response(OdxLinkId("response_id2", doc_frags), "response_sn2",
                          [req_param1, resp2_param2])
-        odxlinks.update({resp2.odx_link_id: resp2})
+        odxlinks.update({resp2.odx_id: resp2})
 
-        service2 = DiagService(odx_link_id=OdxLinkId("service_id2", doc_frags),
+        service2 = DiagService(odx_id=OdxLinkId("service_id2", doc_frags),
                                short_name="service_sn2",
                                request=req2,
                                positive_responses=[resp2],
                                negative_responses=[])
 
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service, service2],
                                requests=[req, req2],
@@ -83,14 +83,14 @@ class TestDecoding(unittest.TestCase):
                       [req_param1, req_param2])
 
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.odx_link_id: req})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.odx_link_id),
+                              request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -126,14 +126,14 @@ class TestDecoding(unittest.TestCase):
                       req_param1, req_param2, req_param3, req_param4])
 
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.odx_link_id: req})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.odx_link_id),
+                              request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -161,12 +161,12 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type_4 = StandardLengthType("A_UINT32", 4)
 
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
-        dop = DataObjectProperty(OdxLinkId("dop.odx_link_id", doc_frags),
+        dop = DataObjectProperty(OdxLinkId("dop.odx_id", doc_frags),
                                  "dop_sn",
                                  diag_coded_type_4,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
-        odxlinks.update({dop.odx_link_id: dop})
+        odxlinks.update({dop.odx_id: dop})
 
         req_param1 = CodedConstParameter("SID",
                                          diag_coded_type,
@@ -179,19 +179,19 @@ class TestDecoding(unittest.TestCase):
             "struct_param_2", dop=dop, byte_position=0, bit_position=4)
         struct = Structure(OdxLinkId("struct_id", doc_frags), "struct", [
                            struct_param1, struct_param2])
-        odxlinks.update({struct.odx_link_id: struct})
+        odxlinks.update({struct.odx_id: struct})
         req_param2 = ValueParameter("structured_param", dop=struct)
 
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
                       req_param1, req_param2])
-        odxlinks.update({req.odx_link_id: req})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.odx_link_id),
+                              request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -216,12 +216,12 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type_4 = StandardLengthType("A_UINT32", 4)
 
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
-        dop = DataObjectProperty(OdxLinkId("dop.odx_link_id", doc_frags),
+        dop = DataObjectProperty(OdxLinkId("dop.odx_id", doc_frags),
                                  "dop_sn",
                                  diag_coded_type_4,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
-        odxlinks.update({dop.odx_link_id: dop})
+        odxlinks.update({dop.odx_id: dop})
 
         req_param1 = CodedConstParameter("SID",
                                          diag_coded_type,
@@ -234,24 +234,24 @@ class TestDecoding(unittest.TestCase):
             "struct_param_2", dop=dop, byte_position=0, bit_position=4)
         struct = Structure(OdxLinkId("struct_id", doc_frags), "struct", [
                            struct_param1, struct_param2])
-        odxlinks.update({struct.odx_link_id: struct})
+        odxlinks.update({struct.odx_id: struct})
         eopf = EndOfPduField(OdxLinkId("eopf_id", doc_frags), "eopf_sn",
                              structure=struct,
                              is_visible=True)
-        odxlinks.update({eopf.odx_link_id: eopf})
+        odxlinks.update({eopf.odx_id: eopf})
 
         req_param2 = ValueParameter("eopf_param", dop=eopf)
 
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
                       req_param1, req_param2])
-        odxlinks.update({req.odx_link_id: req})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.odx_link_id),
+                              request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -275,12 +275,12 @@ class TestDecoding(unittest.TestCase):
 
         compu_method = LinearCompuMethod(1, 5, "A_INT32", "A_INT32")
         diag_coded_type = StandardLengthType("A_UINT32", 8)
-        dop = DataObjectProperty(OdxLinkId("linear.dop.odx_link_id", doc_frags),
+        dop = DataObjectProperty(OdxLinkId("linear.dop.odx_id", doc_frags),
                                  "linear.dop.sn",
                                  diag_coded_type,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
-        odxlinks.update({dop.odx_link_id: dop})
+        odxlinks.update({dop.odx_id: dop})
         req_param1 = CodedConstParameter("SID",
                                          diag_coded_type,
                                          coded_value=0x7d,
@@ -290,14 +290,14 @@ class TestDecoding(unittest.TestCase):
                                     byte_position=1)
         req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
 
-        odxlinks.update({req.odx_link_id: req})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.odx_link_id),
+                              request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -344,16 +344,16 @@ class TestDecoding(unittest.TestCase):
                                 resp_param1, resp_param2])
 
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({req.odx_link_id: req,
-                         pos_response.odx_link_id: pos_response,
-                         neg_response.odx_link_id: neg_response})
-        service = DiagService(odx_link_id=OdxLinkId("service_id", doc_frags),
+        odxlinks.update({req.odx_id: req,
+                         pos_response.odx_id: pos_response,
+                         neg_response.odx_id: neg_response})
+        service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
-                              request=OdxLinkRef.from_id(req.odx_link_id),
-                              positive_responses=[OdxLinkRef.from_id(pos_response.odx_link_id)],
-                              negative_responses=[OdxLinkRef.from_id(neg_response.odx_link_id)])
+                              request=OdxLinkRef.from_id(req.odx_id),
+                              positive_responses=[OdxLinkRef.from_id(pos_response.odx_id)],
+                              negative_responses=[OdxLinkRef.from_id(neg_response.odx_id)])
         diag_layer = DiagLayer("BASE-VARIANT",
-                               odx_link_id=OdxLinkId("dl_id", doc_frags),
+                               odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
                                requests=[req],
@@ -379,26 +379,26 @@ class TestDecoding(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
 
-        dtc1 = DiagnosticTroubleCode(odx_link_id=OdxLinkId("dtcID1", doc_frags),
+        dtc1 = DiagnosticTroubleCode(odx_id=OdxLinkId("dtcID1", doc_frags),
                                      short_name="P34_sn",
                                      trouble_code=0x34,
                                      text="Error encountered",
                                      display_trouble_code="P34")
 
-        dtc2 = DiagnosticTroubleCode(odx_link_id=OdxLinkId("dtcID2", doc_frags),
+        dtc2 = DiagnosticTroubleCode(odx_id=OdxLinkId("dtcID2", doc_frags),
                                      short_name="P56_sn",
                                      trouble_code=0x56,
                                      text="Crashed into wall",
                                      display_trouble_code="P56")
         dtcs = [dtc1, dtc2]
-        dop = DtcDop(OdxLinkId("dtc.dop.odx_link_id", doc_frags),
+        dop = DtcDop(OdxLinkId("dtc.dop.odx_id", doc_frags),
                      "dtc_dop_sn",
                      diag_coded_type,
                      physical_type=PhysicalType(DataType.A_UINT32),
                      compu_method=compu_method,
                      dtcs=dtcs,
                      is_visible=True)
-        odxlinks[dop.odx_link_id] = dop
+        odxlinks[dop.odx_id] = dop
         resp_param1 = CodedConstParameter(
             "SID", diag_coded_type, coded_value=0x12, byte_position=0)
         resp_param2 = ValueParameter(
@@ -417,7 +417,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         super().setUp()
         self.dop_bytes_termination_end_of_pdu = \
             DataObjectProperty(
-                odx_link_id=OdxLinkId("DOP_ID", doc_frags),
+                odx_id=OdxLinkId("DOP_ID", doc_frags),
                 short_name="DOP",
                 diag_coded_type=MinMaxLengthType(DataType.A_BYTEFIELD,
                                                  min_length=0,
@@ -441,7 +441,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
     def test_min_max_length_type_end_of_pdu(self):
         req_param1 = self.parameter_sid
         req_param2 = self.parameter_termination_end_of_pdu
-        request = Request(odx_link_id=OdxLinkId("request", doc_frags),
+        request = Request(odx_id=OdxLinkId("request", doc_frags),
                           short_name="Request",
                           parameters=[
                               req_param1,
@@ -463,7 +463,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         struct_param = self.parameter_termination_end_of_pdu
 
         structure = Structure(
-            odx_link_id=OdxLinkId("structure_id", doc_frags),
+            odx_id=OdxLinkId("structure_id", doc_frags),
             short_name="Structure_with_End_of_PDU_termination",
             parameters=[
                 struct_param
@@ -477,7 +477,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         )
 
         request = Request(
-            odx_link_id=OdxLinkId("request", doc_frags),
+            odx_id=OdxLinkId("request", doc_frags),
             short_name="Request",
             parameters=[
                 req_param1,
@@ -503,7 +503,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         offset = 0x34
         dop = DataObjectProperty(
-            odx_link_id=OdxLinkId("DOP_ID", doc_frags),
+            odx_id=OdxLinkId("DOP_ID", doc_frags),
             short_name="DOP",
             diag_coded_type=diag_coded_type,
             physical_type=PhysicalType(DataType.A_INT32),
@@ -526,7 +526,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
             dop=dop
         )
         request = Request(
-            odx_link_id=OdxLinkId("request", doc_frags),
+            odx_id=OdxLinkId("request", doc_frags),
             short_name="Request",
             parameters=[
                 req_param1,

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -131,7 +131,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         dops = {
             "certificateClient":
             DataObjectProperty(
-                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                odx_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["certificateClient"],
                 physical_type=PhysicalType("A_BYTEFIELD"),
@@ -140,7 +140,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         # Request
         request = Request(
-            odx_link_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            odx_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
             short_name="sendCertificate",
             parameters=[
                 CodedConstParameter(
@@ -155,7 +155,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                     description=("The certificate to verify."),
                     byte_position=1,
                     # This DOP references the above parameter lengthOfCertificateClient for the bit length.
-                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_link_id)
+                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_id)
                 ),
             ]
         )
@@ -220,7 +220,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         state = DecodeState(bytes([0x10, 0x12, 0x34, 0x56]),
                             [ParameterValuePair(
                                 parameter=LengthKeyParameter(short_name="length_key",
-                                                             odx_link_id=length_key_id,
+                                                             odx_id=length_key_id,
                                                              dop_ref=OdxLinkRef("some_dop", doc_frags)),
                                 value=16
                             )],
@@ -273,7 +273,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         dops = {
             "uint8_times_8":
             DataObjectProperty(
-                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.uint8_times_8", doc_frags),
+                odx_id=OdxLinkId("BV.dummy_DL.DOP.uint8_times_8", doc_frags),
                 short_name="uint8_times_8",
                 diag_coded_type=diagcodedtypes["uint8"],
                 physical_type=PhysicalType("A_UINT32"),
@@ -281,7 +281,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
             "certificateClient":
             DataObjectProperty(
-                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                odx_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"],
                 physical_type=PhysicalType("A_UINT32"),
@@ -290,7 +290,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
         # Request using LengthKeyParameter and ParamLengthInfoType
         request = Request(
-            odx_link_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            odx_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
             short_name="sendCertificate",
             parameters=[
                 CodedConstParameter(
@@ -303,18 +303,18 @@ class TestParamLengthInfoType(unittest.TestCase):
                 LengthKeyParameter(
                     short_name="lengthOfCertificateClient",
                     # LengthKeyParams have an ID to be referenced by a ParamLengthInfoType (which is a diag coded type)
-                    odx_link_id=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"].length_key_id,
+                    odx_id=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"].length_key_id,
                     description=("Length parameter for certificateClient."),
                     byte_position=1,
                     # The DOP multiplies the coded value by 8, since the length key ref expects the number of bits.
-                    dop_ref=OdxLinkRef.from_id(dops["uint8_times_8"].odx_link_id)
+                    dop_ref=OdxLinkRef.from_id(dops["uint8_times_8"].odx_id)
                 ),
                 ValueParameter(
                     short_name="certificateClient",
                     description=("The certificate to verify."),
                     byte_position=2,
                     # This DOP references the above parameter lengthOfCertificateClient for the bit length.
-                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_link_id)
+                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_id)
                 ),
             ]
         )
@@ -488,7 +488,7 @@ class TestMinMaxLengthType(unittest.TestCase):
         dops = {
             "certificateClient":
             DataObjectProperty(
-                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                odx_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["certificateClient"],
                 physical_type=PhysicalType("A_BYTEFIELD"),
@@ -497,7 +497,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
         # Request
         request = Request(
-            odx_link_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            odx_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
             short_name="sendCertificate",
             parameters=[
                 CodedConstParameter(
@@ -512,7 +512,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                     description=("The certificate to verify."),
                     byte_position=1,
                     # This DOP references the above parameter lengthOfCertificateClient for the bit length.
-                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_link_id)
+                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_id)
                 ),
                 CodedConstParameter(
                     short_name="dummy",

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -131,7 +131,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         dops = {
             "certificateClient":
             DataObjectProperty(
-                id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["certificateClient"],
                 physical_type=PhysicalType("A_BYTEFIELD"),
@@ -140,7 +140,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         # Request
         request = Request(
-            id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            odx_link_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
             short_name="sendCertificate",
             parameters=[
                 CodedConstParameter(
@@ -155,7 +155,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                     description=("The certificate to verify."),
                     byte_position=1,
                     # This DOP references the above parameter lengthOfCertificateClient for the bit length.
-                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].id)
+                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_link_id)
                 ),
             ]
         )
@@ -220,7 +220,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         state = DecodeState(bytes([0x10, 0x12, 0x34, 0x56]),
                             [ParameterValuePair(
                                 parameter=LengthKeyParameter(short_name="length_key",
-                                                             id=length_key_id,
+                                                             odx_link_id=length_key_id,
                                                              dop_ref=OdxLinkRef("some_dop", doc_frags)),
                                 value=16
                             )],
@@ -273,7 +273,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         dops = {
             "uint8_times_8":
             DataObjectProperty(
-                id=OdxLinkId("BV.dummy_DL.DOP.uint8_times_8", doc_frags),
+                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.uint8_times_8", doc_frags),
                 short_name="uint8_times_8",
                 diag_coded_type=diagcodedtypes["uint8"],
                 physical_type=PhysicalType("A_UINT32"),
@@ -281,7 +281,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
             "certificateClient":
             DataObjectProperty(
-                id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"],
                 physical_type=PhysicalType("A_UINT32"),
@@ -290,7 +290,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
         # Request using LengthKeyParameter and ParamLengthInfoType
         request = Request(
-            id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            odx_link_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
             short_name="sendCertificate",
             parameters=[
                 CodedConstParameter(
@@ -303,18 +303,18 @@ class TestParamLengthInfoType(unittest.TestCase):
                 LengthKeyParameter(
                     short_name="lengthOfCertificateClient",
                     # LengthKeyParams have an ID to be referenced by a ParamLengthInfoType (which is a diag coded type)
-                    id=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"].length_key_id,
+                    odx_link_id=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"].length_key_id,
                     description=("Length parameter for certificateClient."),
                     byte_position=1,
                     # The DOP multiplies the coded value by 8, since the length key ref expects the number of bits.
-                    dop_ref=OdxLinkRef.from_id(dops["uint8_times_8"].id)
+                    dop_ref=OdxLinkRef.from_id(dops["uint8_times_8"].odx_link_id)
                 ),
                 ValueParameter(
                     short_name="certificateClient",
                     description=("The certificate to verify."),
                     byte_position=2,
                     # This DOP references the above parameter lengthOfCertificateClient for the bit length.
-                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].id)
+                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_link_id)
                 ),
             ]
         )
@@ -488,7 +488,7 @@ class TestMinMaxLengthType(unittest.TestCase):
         dops = {
             "certificateClient":
             DataObjectProperty(
-                id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                odx_link_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["certificateClient"],
                 physical_type=PhysicalType("A_BYTEFIELD"),
@@ -497,7 +497,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
         # Request
         request = Request(
-            id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            odx_link_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
             short_name="sendCertificate",
             parameters=[
                 CodedConstParameter(
@@ -512,7 +512,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                     description=("The certificate to verify."),
                     byte_position=1,
                     # This DOP references the above parameter lengthOfCertificateClient for the bit length.
-                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].id)
+                    dop_ref=OdxLinkRef.from_id(dops["certificateClient"].odx_link_id)
                 ),
                 CodedConstParameter(
                     short_name="dummy",

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -52,27 +52,27 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                                    compu_method=ident_compu_method)
 
         table = Table(
-                odx_link_id="somersault.table.flip_quality",
+                odx_id="somersault.table.flip_quality",
                 short_name="flip_quality",
                 long_name="Flip Quality",
                 key_dop_ref="",
                 table_rows=[
                     TableRow(
-                        odx_link_id="somersault.table.flip_quality.average",
+                        odx_id="somersault.table.flip_quality.average",
                         short_name="average",
                         long_name="Average",
                         key=3,
                         structure_ref="",
                     ),
                     TableRow(
-                        odx_link_id="somersault.table.flip_quality.good",
+                        odx_id="somersault.table.flip_quality.good",
                         short_name="good",
                         long_name="Good",
                         key=5,
                         structure_ref="",
                     ),
                     TableRow(
-                        odx_link_id="somersault.table.flip_quality.best",
+                        odx_id="somersault.table.flip_quality.best",
                         short_name="best",
                         long_name="Best",
                         key=10,
@@ -82,7 +82,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             )
 
         env_data = EnvironmentData(
-            odx_link_id="somersault.env_data.flip_env_data",
+            odx_id="somersault.env_data.flip_env_data",
             short_name="flip_env_data",
             long_name="Flip Env Data",
             parameters=[
@@ -105,7 +105,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         )
 
         env_data_desc = EnvironmentDataDescription(
-            odx_link_id="somersault.env_data_desc.flip_env_data_desc",
+            odx_id="somersault.env_data_desc.flip_env_data_desc",
             short_name="flip_env_data_desc",
             long_name="Flip Env Data Desc",
             param_snref="flip_speed",
@@ -114,7 +114,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         )
 
         mux = Multiplexer(
-            odx_link_id="somersault.multiplexer.flip_preference",
+            odx_id="somersault.multiplexer.flip_preference",
             short_name="flip_preference",
             long_name="Flip Preference",
             byte_position=0,

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -52,27 +52,27 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                                    compu_method=ident_compu_method)
 
         table = Table(
-                id="somersault.table.flip_quality",
+                odx_link_id="somersault.table.flip_quality",
                 short_name="flip_quality",
                 long_name="Flip Quality",
                 key_dop_ref="",
                 table_rows=[
                     TableRow(
-                        id="somersault.table.flip_quality.average",
+                        odx_link_id="somersault.table.flip_quality.average",
                         short_name="average",
                         long_name="Average",
                         key=3,
                         structure_ref="",
                     ),
                     TableRow(
-                        id="somersault.table.flip_quality.good",
+                        odx_link_id="somersault.table.flip_quality.good",
                         short_name="good",
                         long_name="Good",
                         key=5,
                         structure_ref="",
                     ),
                     TableRow(
-                        id="somersault.table.flip_quality.best",
+                        odx_link_id="somersault.table.flip_quality.best",
                         short_name="best",
                         long_name="Best",
                         key=10,
@@ -82,7 +82,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             )
 
         env_data = EnvironmentData(
-            id="somersault.env_data.flip_env_data",
+            odx_link_id="somersault.env_data.flip_env_data",
             short_name="flip_env_data",
             long_name="Flip Env Data",
             parameters=[
@@ -105,7 +105,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         )
 
         env_data_desc = EnvironmentDataDescription(
-            id="somersault.env_data_desc.flip_env_data_desc",
+            odx_link_id="somersault.env_data_desc.flip_env_data_desc",
             short_name="flip_env_data_desc",
             long_name="Flip Env Data Desc",
             param_snref="flip_speed",
@@ -114,7 +114,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         )
 
         mux = Multiplexer(
-            id="somersault.multiplexer.flip_preference",
+            odx_link_id="somersault.multiplexer.flip_preference",
             short_name="flip_preference",
             long_name="Flip Preference",
             byte_position=0,

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -38,7 +38,7 @@ class TestEncodeRequest(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         # This CompuMethod represents the linear function: decode(x) = 2*x + 8 and encode(x) = (x-8)/2
         compu_method = LinearCompuMethod(8, 2, "A_UINT32", "A_UINT32")
-        dop = DataObjectProperty(OdxLinkId("dop-odx_link_id", doc_frags), "example dop", diag_coded_type,
+        dop = DataObjectProperty(OdxLinkId("dop-odx_id", doc_frags), "example dop", diag_coded_type,
                                  physical_type=PhysicalType("A_UINT32"), compu_method=compu_method)
         param1 = ValueParameter("linear_value_parameter",
                                 dop=dop)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -38,7 +38,7 @@ class TestEncodeRequest(unittest.TestCase):
         diag_coded_type = StandardLengthType("A_UINT32", 8)
         # This CompuMethod represents the linear function: decode(x) = 2*x + 8 and encode(x) = (x-8)/2
         compu_method = LinearCompuMethod(8, 2, "A_UINT32", "A_UINT32")
-        dop = DataObjectProperty(OdxLinkId("dop-id", doc_frags), "example dop", diag_coded_type,
+        dop = DataObjectProperty(OdxLinkId("dop-odx_link_id", doc_frags), "example dop", diag_coded_type,
                                  physical_type=PhysicalType("A_UINT32"), compu_method=compu_method)
         param1 = ValueParameter("linear_value_parameter",
                                 dop=dop)

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -11,7 +11,7 @@ odxdb = load_pdx_file("./examples/somersault.pdx",
 
 # use the diag layer container's document fragments as the default for
 # resolving references
-container_doc_frags = odxdb.diag_layer_containers.somersault.odx_link_id.doc_fragments
+container_doc_frags = odxdb.diag_layer_containers.somersault.odx_id.doc_fragments
 
 class TestDataObjectProperty(unittest.TestCase):
 
@@ -65,14 +65,14 @@ class TestNavigation(unittest.TestCase):
         # make sure that NamedItemLists support slicing
         ecus = odxdb.ecus[-2:]
         self.assertEqual(len(ecus), 2)
-        self.assertEqual(ecus[0].odx_link_id.local_id, "somersault_lazy")
-        self.assertEqual(ecus[1].odx_link_id.local_id, "somersault_assiduous")
+        self.assertEqual(ecus[0].odx_id.local_id, "somersault_lazy")
+        self.assertEqual(ecus[1].odx_id.local_id, "somersault_assiduous")
 
         ecu = odxdb.ecus["somersault_lazy"]
-        self.assertEqual(ecu.odx_link_id.local_id, "somersault_lazy")
+        self.assertEqual(ecu.odx_id.local_id, "somersault_lazy")
 
         ecu = odxdb.ecus[0]
-        self.assertEqual(ecu.odx_link_id.local_id, "somersault_lazy")
+        self.assertEqual(ecu.odx_id.local_id, "somersault_lazy")
 
     def test_find_service_by_name(self):
         ecu = odxdb.ecus["somersault_lazy"]
@@ -86,7 +86,7 @@ class TestNavigation(unittest.TestCase):
         self.assertIn("report_status", service_names)
 
         service = ecu.services.session_start
-        self.assertEqual(service.odx_link_id.local_id, "somersault.service.session_start")
+        self.assertEqual(service.odx_id.local_id, "somersault.service.session_start")
         self.assertEqual(service.semantic, "SESSION")
 
 

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -11,7 +11,7 @@ odxdb = load_pdx_file("./examples/somersault.pdx",
 
 # use the diag layer container's document fragments as the default for
 # resolving references
-container_doc_frags = odxdb.diag_layer_containers.somersault.id.doc_fragments
+container_doc_frags = odxdb.diag_layer_containers.somersault.odx_link_id.doc_fragments
 
 class TestDataObjectProperty(unittest.TestCase):
 
@@ -65,14 +65,14 @@ class TestNavigation(unittest.TestCase):
         # make sure that NamedItemLists support slicing
         ecus = odxdb.ecus[-2:]
         self.assertEqual(len(ecus), 2)
-        self.assertEqual(ecus[0].id.local_id, "somersault_lazy")
-        self.assertEqual(ecus[1].id.local_id, "somersault_assiduous")
+        self.assertEqual(ecus[0].odx_link_id.local_id, "somersault_lazy")
+        self.assertEqual(ecus[1].odx_link_id.local_id, "somersault_assiduous")
 
         ecu = odxdb.ecus["somersault_lazy"]
-        self.assertEqual(ecu.id.local_id, "somersault_lazy")
+        self.assertEqual(ecu.odx_link_id.local_id, "somersault_lazy")
 
         ecu = odxdb.ecus[0]
-        self.assertEqual(ecu.id.local_id, "somersault_lazy")
+        self.assertEqual(ecu.odx_link_id.local_id, "somersault_lazy")
 
     def test_find_service_by_name(self):
         ecu = odxdb.ecus["somersault_lazy"]
@@ -86,7 +86,7 @@ class TestNavigation(unittest.TestCase):
         self.assertIn("report_status", service_names)
 
         service = ecu.services.session_start
-        self.assertEqual(service.id.local_id, "somersault.service.session_start")
+        self.assertEqual(service.odx_link_id.local_id, "somersault.service.session_start")
         self.assertEqual(service.semantic, "SESSION")
 
 

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -47,13 +47,13 @@ class TestSingleEcuJob(unittest.TestCase):
         self.context = Context(
 
             extensiveTask=FunctionalClass(
-                id=OdxLinkId("ID.extensiveTask", doc_frags), short_name="extensiveTask"),
+                odx_link_id=OdxLinkId("ID.extensiveTask", doc_frags), short_name="extensiveTask"),
 
             specialAudience=AdditionalAudience(
-                id=OdxLinkId("ID.specialAudience", doc_frags), short_name="specialAudience"),
+                odx_link_id=OdxLinkId("ID.specialAudience", doc_frags), short_name="specialAudience"),
 
             inputDOP=DataObjectProperty(
-                id=OdxLinkId("ID.inputDOP", doc_frags),
+                odx_link_id=OdxLinkId("ID.inputDOP", doc_frags),
                 short_name="inputDOP",
                 diag_coded_type=StandardLengthType(
                     DataType.A_INT32, bit_length=1),
@@ -70,7 +70,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ),
 
             outputDOP=DataObjectProperty(
-                id=OdxLinkId("ID.outputDOP", doc_frags),
+                odx_link_id=OdxLinkId("ID.outputDOP", doc_frags),
                 short_name="outputDOP",
                 diag_coded_type=StandardLengthType(
                     DataType.A_INT32, bit_length=1),
@@ -80,7 +80,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ),
 
             negOutputDOP=DataObjectProperty(
-                id=OdxLinkId("ID.negOutputDOP", doc_frags),
+                odx_link_id=OdxLinkId("ID.negOutputDOP", doc_frags),
                 short_name="negOutputDOP",
                 diag_coded_type=StandardLengthType(
                     DataType.A_INT32, bit_length=1),
@@ -94,33 +94,33 @@ class TestSingleEcuJob(unittest.TestCase):
             InputParam(
                 short_name="inputParam",
                 physical_default_value="Yes!",
-                dop_base_ref=OdxLinkRef.from_id(self.context.inputDOP.id)
+                dop_base_ref=OdxLinkRef.from_id(self.context.inputDOP.odx_link_id)
             )
         ]
         output_params=[
             OutputParam(
-                id=OdxLinkId("ID.outputParam", doc_frags),
+                odx_link_id=OdxLinkId("ID.outputParam", doc_frags),
                 semantic="DATA",
                 short_name="outputParam",
                 long_name="The Output Param",
                 description="<p>The one and only output of this job.</p>",
-                dop_base_ref=OdxLinkRef.from_id(self.context.outputDOP.id)
+                dop_base_ref=OdxLinkRef.from_id(self.context.outputDOP.odx_link_id)
             )
         ]
         neg_output_params=[
             NegOutputParam(
                 short_name="NegativeOutputParam",
                 description="<p>The one and only output of this job.</p>",
-                dop_base_ref=OdxLinkRef.from_id(self.context.negOutputDOP.id)
+                dop_base_ref=OdxLinkRef.from_id(self.context.negOutputDOP.odx_link_id)
             )
         ]
 
         self.singleecujob_object = SingleEcuJob(
-            id=OdxLinkId("ID.JumpStart", doc_frags),
+            odx_link_id=OdxLinkId("ID.JumpStart", doc_frags),
             short_name="JumpStart",
-            functional_class_refs=[OdxLinkRef.from_id(self.context.extensiveTask.id)],
+            functional_class_refs=[OdxLinkRef.from_id(self.context.extensiveTask.odx_link_id)],
             audience=Audience(
-                enabled_audience_refs=[OdxLinkRef.from_id(self.context.specialAudience.id)]
+                enabled_audience_refs=[OdxLinkRef.from_id(self.context.specialAudience.odx_link_id)]
             ),
             prog_codes=[
                 ProgCode(
@@ -140,7 +140,7 @@ class TestSingleEcuJob(unittest.TestCase):
         )
 
         self.singleecujob_odx = f"""
-            <SINGLE-ECU-JOB ID="{self.singleecujob_object.id.local_id}">
+            <SINGLE-ECU-JOB ID="{self.singleecujob_object.odx_link_id.local_id}">
                 <SHORT-NAME>{self.singleecujob_object.short_name}</SHORT-NAME>
                 <FUNCT-CLASS-REFS>
                     <FUNCT-CLASS-REF ID-REF="{self.singleecujob_object.functional_class_refs[0].ref_id}"/>
@@ -170,7 +170,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     </INPUT-PARAM>
                 </INPUT-PARAMS>
                 <OUTPUT-PARAMS>
-                    <OUTPUT-PARAM ID="{output_params[0].id.local_id}" SEMANTIC="{output_params[0].semantic}">
+                    <OUTPUT-PARAM ID="{output_params[0].odx_link_id.local_id}" SEMANTIC="{output_params[0].semantic}">
                         <SHORT-NAME>{output_params[0].short_name}</SHORT-NAME>
                         <LONG-NAME>{output_params[0].long_name}</LONG-NAME>
                         <DESC>\n{output_params[0].description}\n</DESC>
@@ -234,7 +234,7 @@ class TestSingleEcuJob(unittest.TestCase):
     def test_default_lists(self):
         """Test that empty lists are assigned to list-attributes if no explicit value is passed."""
         sej = SingleEcuJob(
-            id=OdxLinkId("ID.SomeID", doc_frags),
+            odx_link_id=OdxLinkId("ID.SomeID", doc_frags),
             short_name="SN.SomeShortName",
             prog_codes=[
                 ProgCode(
@@ -252,11 +252,11 @@ class TestSingleEcuJob(unittest.TestCase):
 
     def test_resolve_references(self):
         dl = DiagLayer(variant_type="BASE-VARIANT",
-                       id=OdxLinkId("ID.bv", doc_frags),
+                       odx_link_id=OdxLinkId("ID.bv", doc_frags),
                        short_name="bv",
                        single_ecu_jobs=[self.singleecujob_object])
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({val.id: val for val in self.context})
+        odxlinks.update({val.odx_link_id: val for val in self.context})
 
         dl._resolve_references(odxlinks)
 

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -47,13 +47,13 @@ class TestSingleEcuJob(unittest.TestCase):
         self.context = Context(
 
             extensiveTask=FunctionalClass(
-                odx_link_id=OdxLinkId("ID.extensiveTask", doc_frags), short_name="extensiveTask"),
+                odx_id=OdxLinkId("ID.extensiveTask", doc_frags), short_name="extensiveTask"),
 
             specialAudience=AdditionalAudience(
-                odx_link_id=OdxLinkId("ID.specialAudience", doc_frags), short_name="specialAudience"),
+                odx_id=OdxLinkId("ID.specialAudience", doc_frags), short_name="specialAudience"),
 
             inputDOP=DataObjectProperty(
-                odx_link_id=OdxLinkId("ID.inputDOP", doc_frags),
+                odx_id=OdxLinkId("ID.inputDOP", doc_frags),
                 short_name="inputDOP",
                 diag_coded_type=StandardLengthType(
                     DataType.A_INT32, bit_length=1),
@@ -70,7 +70,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ),
 
             outputDOP=DataObjectProperty(
-                odx_link_id=OdxLinkId("ID.outputDOP", doc_frags),
+                odx_id=OdxLinkId("ID.outputDOP", doc_frags),
                 short_name="outputDOP",
                 diag_coded_type=StandardLengthType(
                     DataType.A_INT32, bit_length=1),
@@ -80,7 +80,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ),
 
             negOutputDOP=DataObjectProperty(
-                odx_link_id=OdxLinkId("ID.negOutputDOP", doc_frags),
+                odx_id=OdxLinkId("ID.negOutputDOP", doc_frags),
                 short_name="negOutputDOP",
                 diag_coded_type=StandardLengthType(
                     DataType.A_INT32, bit_length=1),
@@ -94,33 +94,33 @@ class TestSingleEcuJob(unittest.TestCase):
             InputParam(
                 short_name="inputParam",
                 physical_default_value="Yes!",
-                dop_base_ref=OdxLinkRef.from_id(self.context.inputDOP.odx_link_id)
+                dop_base_ref=OdxLinkRef.from_id(self.context.inputDOP.odx_id)
             )
         ]
         output_params=[
             OutputParam(
-                odx_link_id=OdxLinkId("ID.outputParam", doc_frags),
+                odx_id=OdxLinkId("ID.outputParam", doc_frags),
                 semantic="DATA",
                 short_name="outputParam",
                 long_name="The Output Param",
                 description="<p>The one and only output of this job.</p>",
-                dop_base_ref=OdxLinkRef.from_id(self.context.outputDOP.odx_link_id)
+                dop_base_ref=OdxLinkRef.from_id(self.context.outputDOP.odx_id)
             )
         ]
         neg_output_params=[
             NegOutputParam(
                 short_name="NegativeOutputParam",
                 description="<p>The one and only output of this job.</p>",
-                dop_base_ref=OdxLinkRef.from_id(self.context.negOutputDOP.odx_link_id)
+                dop_base_ref=OdxLinkRef.from_id(self.context.negOutputDOP.odx_id)
             )
         ]
 
         self.singleecujob_object = SingleEcuJob(
-            odx_link_id=OdxLinkId("ID.JumpStart", doc_frags),
+            odx_id=OdxLinkId("ID.JumpStart", doc_frags),
             short_name="JumpStart",
-            functional_class_refs=[OdxLinkRef.from_id(self.context.extensiveTask.odx_link_id)],
+            functional_class_refs=[OdxLinkRef.from_id(self.context.extensiveTask.odx_id)],
             audience=Audience(
-                enabled_audience_refs=[OdxLinkRef.from_id(self.context.specialAudience.odx_link_id)]
+                enabled_audience_refs=[OdxLinkRef.from_id(self.context.specialAudience.odx_id)]
             ),
             prog_codes=[
                 ProgCode(
@@ -140,7 +140,7 @@ class TestSingleEcuJob(unittest.TestCase):
         )
 
         self.singleecujob_odx = f"""
-            <SINGLE-ECU-JOB ID="{self.singleecujob_object.odx_link_id.local_id}">
+            <SINGLE-ECU-JOB ID="{self.singleecujob_object.odx_id.local_id}">
                 <SHORT-NAME>{self.singleecujob_object.short_name}</SHORT-NAME>
                 <FUNCT-CLASS-REFS>
                     <FUNCT-CLASS-REF ID-REF="{self.singleecujob_object.functional_class_refs[0].ref_id}"/>
@@ -170,7 +170,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     </INPUT-PARAM>
                 </INPUT-PARAMS>
                 <OUTPUT-PARAMS>
-                    <OUTPUT-PARAM ID="{output_params[0].odx_link_id.local_id}" SEMANTIC="{output_params[0].semantic}">
+                    <OUTPUT-PARAM ID="{output_params[0].odx_id.local_id}" SEMANTIC="{output_params[0].semantic}">
                         <SHORT-NAME>{output_params[0].short_name}</SHORT-NAME>
                         <LONG-NAME>{output_params[0].long_name}</LONG-NAME>
                         <DESC>\n{output_params[0].description}\n</DESC>
@@ -234,7 +234,7 @@ class TestSingleEcuJob(unittest.TestCase):
     def test_default_lists(self):
         """Test that empty lists are assigned to list-attributes if no explicit value is passed."""
         sej = SingleEcuJob(
-            odx_link_id=OdxLinkId("ID.SomeID", doc_frags),
+            odx_id=OdxLinkId("ID.SomeID", doc_frags),
             short_name="SN.SomeShortName",
             prog_codes=[
                 ProgCode(
@@ -252,11 +252,11 @@ class TestSingleEcuJob(unittest.TestCase):
 
     def test_resolve_references(self):
         dl = DiagLayer(variant_type="BASE-VARIANT",
-                       odx_link_id=OdxLinkId("ID.bv", doc_frags),
+                       odx_id=OdxLinkId("ID.bv", doc_frags),
                        short_name="bv",
                        single_ecu_jobs=[self.singleecujob_object])
         odxlinks = OdxLinkDatabase()
-        odxlinks.update({val.odx_link_id: val for val in self.context})
+        odxlinks.update({val.odx_id: val for val in self.context})
 
         dl._resolve_references(odxlinks)
 

--- a/tests/test_somersault.py
+++ b/tests/test_somersault.py
@@ -82,7 +82,7 @@ class TestDatabase(unittest.TestCase):
                          ])
 
         cd = cds.Suncus
-        self.assertEqual(cd.id.local_id, 'CD.Suncus')
+        self.assertEqual(cd.odx_link_id.local_id, 'CD.Suncus')
         self.assertEqual(cd.short_name, 'Suncus')
         self.assertEqual(cd.long_name, 'Circus of the sun')
         self.assertEqual(cd.description, '<p>Prestigious group of performers</p>')
@@ -95,7 +95,7 @@ class TestDatabase(unittest.TestCase):
                          ])
 
         doggy = cd.team_members.Doggy
-        self.assertEqual(doggy.id.local_id, 'TM.Doggy')
+        self.assertEqual(doggy.odx_link_id.local_id, 'TM.Doggy')
         self.assertEqual(doggy.short_name, 'Doggy')
         self.assertEqual(doggy.long_name, 'Doggy the dog')
         self.assertEqual(doggy.description, "<p>Dog is man's best friend</p>")

--- a/tests/test_somersault.py
+++ b/tests/test_somersault.py
@@ -82,7 +82,7 @@ class TestDatabase(unittest.TestCase):
                          ])
 
         cd = cds.Suncus
-        self.assertEqual(cd.odx_link_id.local_id, 'CD.Suncus')
+        self.assertEqual(cd.odx_id.local_id, 'CD.Suncus')
         self.assertEqual(cd.short_name, 'Suncus')
         self.assertEqual(cd.long_name, 'Circus of the sun')
         self.assertEqual(cd.description, '<p>Prestigious group of performers</p>')
@@ -95,7 +95,7 @@ class TestDatabase(unittest.TestCase):
                          ])
 
         doggy = cd.team_members.Doggy
-        self.assertEqual(doggy.odx_link_id.local_id, 'TM.Doggy')
+        self.assertEqual(doggy.odx_id.local_id, 'TM.Doggy')
         self.assertEqual(doggy.short_name, 'Doggy')
         self.assertEqual(doggy.long_name, 'Doggy the dog')
         self.assertEqual(doggy.description, "<p>Dog is man's best friend</p>")

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -24,14 +24,14 @@ class TestUnitSpec(unittest.TestCase):
         expected = UnitSpec(
             physical_dimensions=[
                 PhysicalDimension(
-                    odx_link_id=OdxLinkId("ID.metre", doc_frags),
+                    odx_id=OdxLinkId("ID.metre", doc_frags),
                     short_name="metre",
                     length_exp=1
                 )
             ],
             units=[
                 Unit(
-                    odx_link_id=OdxLinkId("ID.kilometre", doc_frags),
+                    odx_id=OdxLinkId("ID.kilometre", doc_frags),
                     short_name="Kilometre",
                     display_name="km",
                     physical_dimension_ref=OdxLinkRef("ID.metre", doc_frags),
@@ -44,7 +44,7 @@ class TestUnitSpec(unittest.TestCase):
         sample_unit_spec_odx = f"""
             <UNIT-SPEC>
                 <UNITS>
-                    <UNIT ID="{expected.units[0].odx_link_id.local_id}">
+                    <UNIT ID="{expected.units[0].odx_id.local_id}">
                         <SHORT-NAME>{expected.units[0].short_name}</SHORT-NAME>
                         <DISPLAY-NAME>{expected.units[0].display_name}</DISPLAY-NAME>
                         <FACTOR-SI-TO-UNIT>{expected.units[0].factor_si_to_unit}</FACTOR-SI-TO-UNIT>
@@ -53,7 +53,7 @@ class TestUnitSpec(unittest.TestCase):
                     </UNIT>
                 </UNITS>
                 <PHYSICAL-DIMENSIONS>
-                    <PHYSICAL-DIMENSION ID="{expected.physical_dimensions[0].odx_link_id.local_id}">
+                    <PHYSICAL-DIMENSION ID="{expected.physical_dimensions[0].odx_id.local_id}">
                         <SHORT-NAME>{expected.physical_dimensions[0].short_name}</SHORT-NAME>
                         <LENGTH-EXP>{expected.physical_dimensions[0].length_exp}</LENGTH-EXP>
                     </PHYSICAL-DIMENSION>
@@ -80,27 +80,27 @@ class TestUnitSpec(unittest.TestCase):
         )
 
     def test_resolve_references(self):
-        unit = Unit(odx_link_id=OdxLinkId("unit_time_id", doc_frags),
+        unit = Unit(odx_id=OdxLinkId("unit_time_id", doc_frags),
                     short_name="second",
                     display_name="s")
         dct = StandardLengthType("A_UINT32", 8)
         dop = DataObjectProperty(
-            odx_link_id=OdxLinkId("dop_id", doc_frags),
+            odx_id=OdxLinkId("dop_id", doc_frags),
             short_name="dop_sn",
             diag_coded_type=dct,
             physical_type=PhysicalType("A_UINT32"),
             compu_method=IdenticalCompuMethod("A_UINT32", "A_UINT32"),
-            unit_ref=OdxLinkRef.from_id(unit.odx_link_id)
+            unit_ref=OdxLinkRef.from_id(unit.odx_id)
         )
         dl = DiagLayer(
             "BASE-VARIANT",
-            odx_link_id=OdxLinkId("BV_id", doc_frags),
+            odx_id=OdxLinkId("BV_id", doc_frags),
             short_name="BaseVariant",
             requests=[Request(OdxLinkId("rq_id", doc_frags), "rq_sn", [
                 CodedConstParameter(short_name="sid",
                                     diag_coded_type=dct,
                                     coded_value=0x12),
-                ValueParameter("time", dop_ref=OdxLinkRef.from_id(dop.odx_link_id)),
+                ValueParameter("time", dop_ref=OdxLinkRef.from_id(dop.odx_id)),
             ])],
             diag_data_dictionary_spec=DiagDataDictionarySpec(
                 data_object_props=[dop],

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -24,14 +24,14 @@ class TestUnitSpec(unittest.TestCase):
         expected = UnitSpec(
             physical_dimensions=[
                 PhysicalDimension(
-                    id=OdxLinkId("ID.metre", doc_frags),
+                    odx_link_id=OdxLinkId("ID.metre", doc_frags),
                     short_name="metre",
                     length_exp=1
                 )
             ],
             units=[
                 Unit(
-                    id=OdxLinkId("ID.kilometre", doc_frags),
+                    odx_link_id=OdxLinkId("ID.kilometre", doc_frags),
                     short_name="Kilometre",
                     display_name="km",
                     physical_dimension_ref=OdxLinkRef("ID.metre", doc_frags),
@@ -44,7 +44,7 @@ class TestUnitSpec(unittest.TestCase):
         sample_unit_spec_odx = f"""
             <UNIT-SPEC>
                 <UNITS>
-                    <UNIT ID="{expected.units[0].id.local_id}">
+                    <UNIT ID="{expected.units[0].odx_link_id.local_id}">
                         <SHORT-NAME>{expected.units[0].short_name}</SHORT-NAME>
                         <DISPLAY-NAME>{expected.units[0].display_name}</DISPLAY-NAME>
                         <FACTOR-SI-TO-UNIT>{expected.units[0].factor_si_to_unit}</FACTOR-SI-TO-UNIT>
@@ -53,7 +53,7 @@ class TestUnitSpec(unittest.TestCase):
                     </UNIT>
                 </UNITS>
                 <PHYSICAL-DIMENSIONS>
-                    <PHYSICAL-DIMENSION ID="{expected.physical_dimensions[0].id.local_id}">
+                    <PHYSICAL-DIMENSION ID="{expected.physical_dimensions[0].odx_link_id.local_id}">
                         <SHORT-NAME>{expected.physical_dimensions[0].short_name}</SHORT-NAME>
                         <LENGTH-EXP>{expected.physical_dimensions[0].length_exp}</LENGTH-EXP>
                     </PHYSICAL-DIMENSION>
@@ -80,27 +80,27 @@ class TestUnitSpec(unittest.TestCase):
         )
 
     def test_resolve_references(self):
-        unit = Unit(id=OdxLinkId("unit_time_id", doc_frags),
+        unit = Unit(odx_link_id=OdxLinkId("unit_time_id", doc_frags),
                     short_name="second",
                     display_name="s")
         dct = StandardLengthType("A_UINT32", 8)
         dop = DataObjectProperty(
-            id=OdxLinkId("dop_id", doc_frags),
+            odx_link_id=OdxLinkId("dop_id", doc_frags),
             short_name="dop_sn",
             diag_coded_type=dct,
             physical_type=PhysicalType("A_UINT32"),
             compu_method=IdenticalCompuMethod("A_UINT32", "A_UINT32"),
-            unit_ref=OdxLinkRef.from_id(unit.id)
+            unit_ref=OdxLinkRef.from_id(unit.odx_link_id)
         )
         dl = DiagLayer(
             "BASE-VARIANT",
-            id=OdxLinkId("BV_id", doc_frags),
+            odx_link_id=OdxLinkId("BV_id", doc_frags),
             short_name="BaseVariant",
             requests=[Request(OdxLinkId("rq_id", doc_frags), "rq_sn", [
                 CodedConstParameter(short_name="sid",
                                     diag_coded_type=dct,
                                     coded_value=0x12),
-                ValueParameter("time", dop_ref=OdxLinkRef.from_id(dop.id)),
+                ValueParameter("time", dop_ref=OdxLinkRef.from_id(dop.odx_link_id)),
             ])],
             diag_data_dictionary_spec=DiagDataDictionarySpec(
                 data_object_props=[dop],


### PR DESCRIPTION
`id()` is a build-in function and it is terrible style to overwrite it for some contexts!

Besides these large but rather trivial change, the `read_element_id()` utility function is removed: This function was introduced to reduce the amount of duplicated code, but in my experience, the code which `read_element_id()` replaces is rather trivial and the function obfuscates things quite a bit and it does not play nicly with the `mypy` type checker. (Besides that, its name was IMO pretty confusing because it did *not* create an `OdxLinkId`, but parsed the elements featured by the `ELEMENT-ID` XSD     group...)

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)