### PR TITLE
remove the "CANdela workaround" hacks

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1140,7 +1140,6 @@ somersault_lazy_diaglayer = DiagLayer(
             ],
         )],
     communication_parameters=somersault_communication_parameters,
-    enable_candela_workarounds=False,
     )
 
 ##################
@@ -1163,7 +1162,6 @@ somersault_assiduous_diaglayer = DiagLayer(
             # this variant does everything which the base variant does
         )],
     communication_parameters=somersault_communication_parameters,
-    enable_candela_workarounds=False,
     )
 
 # the assiduous ECU also does headstands...

--- a/odxtools/cli/_parser_utils.py
+++ b/odxtools/cli/_parser_utils.py
@@ -11,18 +11,10 @@ def add_pdx_argument(parser):
         "pdx_file", metavar="PDX_FILE", help="path to the .pdx file")
     #parser.add_argument("pdx_files", metavar="PDX_FILES", nargs="+", help="PDX descriptions of all ECUs which shall be analyzed")
 
-    # do not enable the CANdela workarounds. Note that we disable then
-    # by default because CANdela is by far the most common tool to
-    # work with ODX.
-    # Note that the short option "-c" is reserved for the "--channel" of the snoop command.
-    parser.add_argument("--conformant", default=False, action='store_const', const=True,
-                        required=False, help="The input file fully confirms to the standard, i.e., disable work-arounds for bugs of the CANdela tool")
-
 
 def load_file(args):
     db_file_name = args.pdx_file
     odxdb = None
     if db_file_name is not None:
-        odxdb = _load_file(db_file_name,
-                            enable_candela_workarounds=not args.conformant)
+        odxdb = _load_file(db_file_name)
     return odxdb

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -26,8 +26,7 @@ class Database:
 
     def __init__(self,
                  pdx_zip: Optional[ZipFile] = None,
-                 odx_d_file_name: Optional[str] = None,
-                 enable_candela_workarounds: bool = True):
+                 odx_d_file_name: Optional[str] = None):
 
         if pdx_zip is None and odx_d_file_name is None:
             # create an empty database object
@@ -62,8 +61,7 @@ class Database:
             dlc = root.find("DIAG-LAYER-CONTAINER")
             if dlc is not None:
                 dlcs.append(read_diag_layer_container_from_odx(
-                    dlc,
-                    enable_candela_workarounds=enable_candela_workarounds
+                    dlc
                 ))
             # In ODX 2.0 there was only COMPARAM-SPEC
             # In ODX 2.2 content of COMPARAM-SPEC was renamed to COMPARAM-SUBSET

--- a/odxtools/load_file.py
+++ b/odxtools/load_file.py
@@ -4,10 +4,10 @@
 from .load_pdx_file import load_pdx_file
 from .load_odx_d_file import load_odx_d_file
 
-def load_file(file_name: str, enable_candela_workarounds: bool = True):
+def load_file(file_name: str):
     if file_name.lower().endswith(".pdx"):
-        return load_pdx_file(file_name, enable_candela_workarounds=enable_candela_workarounds)
+        return load_pdx_file(file_name)
     elif file_name.lower().endswith(".odx-d"):
-        return load_odx_d_file(file_name, enable_candela_workarounds=enable_candela_workarounds)
+        return load_odx_d_file(file_name)
     else:
         raise RuntimeError(f"Could not guess the file format of file '{file_name}'!")

--- a/odxtools/load_odx_d_file.py
+++ b/odxtools/load_odx_d_file.py
@@ -4,8 +4,7 @@
 from .database import Database
 from .globals import logger
 
-def load_odx_d_file(odx_d_file_name: str, enable_candela_workarounds: bool = True):
-    container = Database(odx_d_file_name=odx_d_file_name,
-                         enable_candela_workarounds=enable_candela_workarounds)
+def load_odx_d_file(odx_d_file_name: str):
+    container = Database(odx_d_file_name=odx_d_file_name)
     logger.info(f"--- --- --- Done with parsing --- --- ---")
     return container

--- a/odxtools/load_pdx_file.py
+++ b/odxtools/load_pdx_file.py
@@ -6,8 +6,8 @@ from zipfile import ZipFile
 from .database import Database
 from .globals import logger
 
-def load_pdx_file(pdx_file: str, enable_candela_workarounds: bool = True):
+def load_pdx_file(pdx_file: str):
     u = ZipFile(pdx_file)
-    container = Database(pdx_zip=u, enable_candela_workarounds=enable_candela_workarounds)
+    container = Database(pdx_zip=u)
     logger.info(f"--- --- --- Done with parsing --- --- ---")
     return container

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -6,8 +6,7 @@ import unittest
 from odxtools.load_pdx_file import load_pdx_file
 from odxtools.odxlink import OdxLinkRef, OdxDocFragment
 
-odxdb = load_pdx_file("./examples/somersault.pdx",
-                      enable_candela_workarounds=False)
+odxdb = load_pdx_file("./examples/somersault.pdx")
 
 # use the diag layer container's document fragments as the default for
 # resolving references

--- a/tests/test_somersault.py
+++ b/tests/test_somersault.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from io import StringIO
 
-odxdb = load_pdx_file("./examples/somersault.pdx", enable_candela_workarounds=False)
+odxdb = load_pdx_file("./examples/somersault.pdx")
 
 class TestDatabase(unittest.TestCase):
 


### PR DESCRIPTION
The reason for these were that CANdela uses different communication parameter specifications than the ones specified by the `odx-cs` files that are shipped with the ODX standard. This resulted in a different ordering for some of the complex communication parameters (albeit with all required fields being present). Fortunately, with #92 merged, this became unnecessary.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)