### PR TITLE
internalize admin data for comparam subsets

### DIFF
--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -91,9 +91,9 @@ def read_xdoc_from_odx(xdoc):
                 )
 
 def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
-        -> Optional[NamedItemList[CompanyData]]:
+        -> NamedItemList[CompanyData]:
     if et_element is None:
-        return None
+        return NamedItemList(short_name_as_id)
 
     cdl = NamedItemList(short_name_as_id) # type: ignore
 

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -90,7 +90,8 @@ def read_xdoc_from_odx(xdoc):
                 position=position,
                 )
 
-def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]):
+def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
+        -> Optional[NamedItemList[CompanyData]]:
     if et_element is None:
         return None
 

--- a/odxtools/comparam_subset.py
+++ b/odxtools/comparam_subset.py
@@ -58,7 +58,7 @@ class BaseComparam:
 @dataclass()
 class ComplexComparam(BaseComparam):
     comparams: NamedItemList[BaseComparam]
-    allow_multiple_values: bool = False
+    allow_multiple_values: Optional[bool] = None
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         for comparam in self.comparams:
@@ -160,7 +160,8 @@ def read_comparam_from_odx(et_element, doc_frags: List[OdxDocFragment]) -> BaseC
         )
         complex_values = et_element.iterfind("COMPLEX-PHYSICAL-DEFAULT-VALUE/COMPLEX-VALUES/COMPLEX-VALUE")
         comparam.physical_default_value = list(map(read_complex_value_from_odx, complex_values))
-        comparam.allow_multiple_values = et_element.get("ALLOW-MULTIPLE-VALUES", "false") == 'true'
+        tmp = et_element.get("ALLOW-MULTIPLE-VALUES")
+        comparam.allow_multiple_values = (tmp == "true") if tmp is not None else None
     else:
         assert False, f"Failed to parse COMPARAM {short_name}"
 

--- a/odxtools/pdx_stub/diag_layer_container.odx-d.tpl
+++ b/odxtools/pdx_stub/diag_layer_container.odx-d.tpl
@@ -6,7 +6,7 @@
 {%- import('macros/printVariant.tpl') as pv -%}
 {%- import('macros/printAdminData.tpl') as pad -%}
 {%- import('macros/printCompanyData.tpl') as pcd -%}
-
+{#- -#}
 
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">


### PR DESCRIPTION
This internalizes the `COMPANY-DATAS` and `ADMIN-DATA` tags for comparam subsets. Besides this, the `allow_multiple_values` can now be `None` to be able to determine if the XML attribute was set in the input file.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)