### PR TITLE
Allow ignoring non-critical decoding errors

### DIFF
--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -9,7 +9,7 @@ class OdxError(Exception):
 class EncodeError(OdxError):
     """Encoding of a message to raw data failed."""
 
-class DecodeError(OdxError):
+class DecodeError(Warning, OdxError):
     """Decoding raw data failed."""
 
 class OdxWarning(Warning):

--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
+import warnings
+
 class OdxError(Exception):
     """Any error that happens during interacting with diagnostic objects."""
 
@@ -12,3 +14,6 @@ class DecodeError(OdxError):
 
 class OdxWarning(Warning):
     """Any warning that happens during interacting with diagnostic objects."""
+
+# Mark DecodeError warnings as errors by default
+warnings.simplefilter('error', DecodeError)

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
+import warnings
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..diagcodedtypes import DiagCodedType
@@ -64,14 +65,15 @@ class CodedConstParameter(Parameter):
 
         # Check if the coded value in the message is correct.
         if self.coded_value != coded_val:
-            raise DecodeError(
+            warnings.warn(
                 f"Coded constant parameter does not match! "
                 f"The parameter {self.short_name} expected coded value {self._coded_value_str} but got {coded_val} "
                 f"at byte position {decode_state.next_byte_position} "
-                f"in coded message {decode_state.coded_message.hex()}."
+                f"in coded message {decode_state.coded_message.hex()}.",
+                DecodeError
             )
 
-        return self.coded_value, next_byte_position
+        return coded_val, next_byte_position
 
     def _as_dict(self):
         d = super()._as_dict()

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 from typing import List
+import warnings
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..diagcodedtypes import DiagCodedType
@@ -83,12 +84,12 @@ class NrcConstParameter(Parameter):
 
         # Check if the coded value in the message is correct.
         if coded_value not in self.coded_values:
-            raise DecodeError(
+            warnings.warn(
                 f"Coded constant parameter does not match! "
                 f"The parameter {self.short_name} expected a coded value in {self.coded_values} but got {coded_value} "
                 f"at byte position {decode_state.next_byte_position} "
                 f"in coded message {decode_state.coded_message.hex()}."
-            )
+            , DecodeError)
 
         return coded_value, next_byte_position
 

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 
+import warnings
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError
@@ -51,11 +52,12 @@ class PhysicalConstantParameter(ParameterWithDOP):
 
         # Check if decoded value matches expected value
         if phys_val != self.physical_constant_value:
-            raise DecodeError(
+            warnings.warn(
                 f"Physical constant parameter does not match! "
                 f"The parameter {self.short_name} expected physical value {self.physical_constant_value!r} but got {phys_val!r} "
                 f"at byte position {next_byte_position} "
-                f"in coded message {decode_state.coded_message.hex()}."
+                f"in coded message {decode_state.coded_message.hex()}.",
+                DecodeError
             )
         return phys_val, next_byte_position
 

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 
+import warnings
 from ..decodestate import DecodeState
 from ..exceptions import DecodeError
 
@@ -49,11 +50,12 @@ class ReservedParameter(Parameter):
 
         # Bit-wise compare if reserved bits are 0.
         if expected & actual != 0:
-            raise DecodeError(
+            warnings.warn(
                 f"Reserved bits must be Zero! "
                 f"The parameter {self.short_name} expected {self.bit_length} bits to be Zero starting at bit position {bit_position_int} "
                 f"at byte position {byte_position} "
-                f"in coded message {decode_state.coded_message.hex()}."
+                f"in coded message {decode_state.coded_message.hex()}.",
+                DecodeError
             )
 
         return None, next_byte_position

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -272,8 +272,11 @@ class BasicStructure(DopBase):
         param_values, next_byte_position = self.convert_bytes_to_physical(
             decode_state)
         if len(message) != next_byte_position:
-            raise DecodeError(
-                f"The message {message.hex()} is longer than could be parsed. Expected {next_byte_position} but got {len(message)}.")
+            warnings.warn(
+                f"The message {message.hex()} is longer than could be parsed."
+                f" Expected {next_byte_position} but got {len(message)}.",
+                DecodeError
+            )
         return param_values
 
     def parameter_dict(self) -> ParameterDict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error::odxtools.exceptions.DecodeError",
+]


### PR DESCRIPTION
# Use case
During ECU development some constants gets added to list of coded_values or a previously reserved byte gets assigned a meaning or a struct gets added a new parameter in a backward compatible way.

Those kind of decoding errors could be tolerated if needed.

This PR change those errors to warnings, but still do raise them by default as errors through `warnings.simplefilter('error', DecodeError)`
