### PR TITLE
Remove misleading kwarg in example section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ python3 -m odxtools list -a "$YOUR_PDX_FILE"
   ```python
   import odxtools
 
-  db = odxtools.load_pdx_file("somersault.pdx", enable_candela_workarounds=False)
+  db = odxtools.load_pdx_file("somersault.pdx")
   ```
 
 - List the names of all available services of the `somersault_lazy` ECU:


### PR DESCRIPTION
This PR removes the keyword argument `enable_candela_workarounds` from the example in the README, since the keyword argument is no longer supported by odxtools.

David Holtz &lt;<david.holtz@mbition.io>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)