### PR TITLE
Comparam fixes

### DIFF
--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -49,12 +49,12 @@ def print_summary(odxdb: Database,
             f" num services: {len(all_services)}, num DOPs: {len(data_object_properties)}, num communication parameters: {len(com_params)}."
         )
 
-        for proto_name in odxdb.protocol_names:
-            if (can_rx_id := dl.get_can_receive_id(proto_name)) is not None:
-                print(f"  CAN receive ID for protocol '{proto_name}': 0x{can_rx_id:x}")
+        for proto in dl.protocols:
+            if (can_rx_id := dl.get_can_receive_id(proto.short_name)) is not None:
+                print(f"  CAN receive ID for protocol '{proto.short_name}': 0x{can_rx_id:x}")
 
-            if (can_tx_id := dl.get_can_send_id(proto_name)) is not None:
-                print(f"  CAN send ID for protocol '{proto_name}': 0x{can_tx_id:x}")
+            if (can_tx_id := dl.get_can_send_id(proto.short_name)) is not None:
+                print(f"  CAN send ID for protocol '{proto.short_name}': 0x{can_tx_id:x}")
 
         if dl.description:
             desc = format_desc(dl.description, ident=2)

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -44,22 +44,17 @@ def print_summary(odxdb: Database,
         data_object_properties = dl.data_object_properties
         com_params = dl.communication_parameters
 
-        if (rx_id := dl.get_receive_id()) is not None:
-            recv_id = hex(rx_id)
-        else:
-            recv_id = "None"
-
-        if (tx_id := dl.get_send_id()) is not None:
-            send_id = hex(tx_id)
-        else:
-            send_id = "None"
-
-        print(
-            f"{dl.variant_type.value} '{dl.short_name}' (Receive ID: {recv_id}, Send ID: {send_id})"
-        )
+        print(f"{dl.variant_type} '{dl.short_name}'")
         print(
             f" num services: {len(all_services)}, num DOPs: {len(data_object_properties)}, num communication parameters: {len(com_params)}."
         )
+
+        for proto_name in odxdb.protocol_names:
+            if (can_rx_id := dl.get_can_receive_id(proto_name)) is not None:
+                print(f"  CAN receive ID for protocol '{proto_name}': 0x{can_rx_id:x}")
+
+            if (can_tx_id := dl.get_can_send_id(proto_name)) is not None:
+                print(f"  CAN send ID for protocol '{proto_name}': 0x{can_tx_id:x}")
 
         if dl.description:
             desc = format_desc(dl.description, ident=2)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -145,13 +145,14 @@ class Database:
         return self._comparam_subsets
 
     @property
-    def protocol_names(self) -> Set[str]:
+    def protocols(self) -> NamedItemList[DiagLayer]:
         """
-        The names of all protocols defined for this database
+        Return a list of all protocols defined by this database
         """
-        result = set()
-        for dlc in self.diag_layer_containers:
-            for prot in dlc.protocols:
-                result.add(prot.short_name)
+        result_dict = dict()
+        for dl in self.diag_layers:
+            if dl.variant_type == DIAG_LAYER_TYPE.PROTOCOL:
+                result_dict[dl.short_name]= dl
 
-        return result
+        return NamedItemList(short_name_as_id,
+                             list(result_dict.values()))

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -7,7 +7,7 @@ from itertools import chain
 from typing import cast, Any, Dict, Iterable, Tuple, List, Optional, Union
 from xml.etree import ElementTree
 
-from deprecated import deprecated
+from deprecation import deprecated
 
 from odxtools.diaglayertype import DIAG_LAYER_TYPE
 
@@ -540,7 +540,7 @@ class DiagLayer:
 
         return int(result)
 
-    @deprecated(reason="use get_can_receive_id()")
+    @deprecated(details="use get_can_receive_id()")
     def get_receive_id(self) -> Optional[int]:
         return self.get_can_receive_id()
 
@@ -561,7 +561,7 @@ class DiagLayer:
 
         return int(result)
 
-    @deprecated(reason="use get_can_send_id()")
+    @deprecated(details="use get_can_send_id()")
     def get_send_id(self) -> Optional[int]:
         return self.get_can_send_id()
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -207,6 +207,21 @@ class DiagLayer:
         """All communication parameters including inherited ones."""
         return self._communication_parameters
 
+    @property
+    def protocols(self) -> NamedItemList["DiagLayer"]:
+        """Return the set of all protocols which are applicable for this diagnostic layer"""
+        result_dict: dict[str, DiagLayer] = dict()
+
+        for parent_ref in self._get_parent_refs_sorted_by_priority():
+            for prot in parent_ref.parent_diag_layer.protocols:
+                result_dict[prot.short_name] = prot
+
+        if self.variant_type == DIAG_LAYER_TYPE.PROTOCOL:
+            result_dict[self.short_name] = self
+
+        return NamedItemList(short_name_as_id,
+                             list(result_dict.values()))
+
     def finalize_init(self, odxlinks: Optional[OdxLinkDatabase] = None):
         """Resolves all references.
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -210,7 +210,7 @@ class DiagLayer:
     @property
     def protocols(self) -> NamedItemList["DiagLayer"]:
         """Return the set of all protocols which are applicable for this diagnostic layer"""
-        result_dict: dict[str, DiagLayer] = dict()
+        result_dict: Dict[str, DiagLayer] = dict()
 
         for parent_ref in self._get_parent_refs_sorted_by_priority():
             for prot in parent_ref.parent_diag_layer.protocols:

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -4,7 +4,7 @@
 import warnings
 from copy import copy
 from itertools import chain
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import cast, Any, Dict, Iterable, Tuple, List, Optional, Union
 from xml.etree import ElementTree
 
 from deprecated import deprecated
@@ -84,18 +84,35 @@ class DiagLayer:
         def get_inheritance_priority(self):
             return PRIORITY_OF_DIAG_LAYER_TYPE[self.parent_diag_layer.variant_type]
 
-        def get_inherited_services_by_name(self):
-            services = {service.short_name: service for service in self.parent_diag_layer._services
-                        if service.short_name not in self.not_inherited_diag_comms}
-            return services
+        def get_inherited_services(self) \
+                -> List[Union[DiagService, SingleEcuJob]]:
 
-        def get_inherited_data_object_properties_by_name(self):
-            dops = {dop.short_name: dop for dop in self.parent_diag_layer._data_object_properties
-                    if dop.short_name not in self.not_inherited_dops}
-            return dops
+            if self.parent_diag_layer is None:
+                return []
+
+            services = dict()
+            for service in self.parent_diag_layer._services:
+                assert isinstance(service, (DiagService, SingleEcuJob))
+
+                if service.short_name not in self.not_inherited_diag_comms:
+                    services[service.short_name] = service
+
+            return list(services.values())
+
+        def get_inherited_data_object_properties(self) \
+                -> List[DopBase]:
+            if self.parent_diag_layer is None:
+                return []
+
+            dops = {
+                dop.short_name: dop
+                for dop in self.parent_diag_layer._data_object_properties
+                if dop.short_name not in self.not_inherited_dops
+            }
+            return list(dops.values())
 
         def get_inherited_communication_parameters(self):
-            return list(self.parent_diag_layer._communication_parameters)
+            return self.parent_diag_layer._communication_parameters
 
     def __init__(self,
                  variant_type : DIAG_LAYER_TYPE,
@@ -247,23 +264,23 @@ class DiagLayer:
         for sdg in self.sdgs:
             sdg._resolve_references(odxlinks)
 
-        services = sorted(self._compute_available_services_by_name(odxlinks).values(),
+        services = sorted(self._compute_available_services(odxlinks),
                           key=short_name_as_id)
         self._services = NamedItemList[Union[DiagService, SingleEcuJob]](
             short_name_as_id,
             services)
 
-        dops = sorted(self._compute_available_data_object_properties_by_name().values(),
+        dops = sorted(self._compute_available_data_object_properties(),
                       key=short_name_as_id)
         self._data_object_properties = NamedItemList[DopBase](
             short_name_as_id,
-            dops)
+            dops or [])
         for comparam in self._local_communication_parameters:
             comparam._resolve_references(odxlinks)
 
         self._communication_parameters = NamedItemList[CommunicationParameterRef](
             short_name_as_id,
-             list(self._compute_available_commmunication_parameters())
+            self._compute_available_commmunication_parameters()
         )
 
         # Resolve all other references
@@ -282,63 +299,73 @@ class DiagLayer:
                                                                      odxlinks)
 
 
-    def __local_services_by_name(self, odxlinks: OdxLinkDatabase) -> Dict[str, Union[DiagService, SingleEcuJob]]:
-        services_by_name: Dict[str, Union[DiagService, SingleEcuJob]] = {}
+    def __gather_local_services(self, odxlinks: OdxLinkDatabase) -> List[Union[DiagService, SingleEcuJob]]:
+        diagcomms_by_name: Dict[str, Union[DiagService, SingleEcuJob]] = {}
 
         for ref in self._diag_comm_refs:
             if (obj := odxlinks.resolve_lenient(ref)) is not None:
-                services_by_name[obj.short_name] = obj
+                diagcomms_by_name[obj.short_name] = obj
             else:
                 logger.warning(f"Diag comm ref {ref!r} could not be resolved.")
 
-        services_by_name.update({
+        diagcomms_by_name.update({
             service.short_name: service for service in self._local_services
         })
-        services_by_name.update({
-            service.short_name: service for service in self._local_single_ecu_jobs
+        diagcomms_by_name.update({
+            secuj.short_name: secuj for secuj in self._local_single_ecu_jobs
         })
-        return services_by_name
+        return list(diagcomms_by_name.values())
 
-    def _compute_available_services_by_name(self, odxlinks: OdxLinkDatabase) -> Dict[str, DiagService]:
+    def _compute_available_services(self, odxlinks: OdxLinkDatabase) -> List[Union[DiagService, SingleEcuJob]]:
         """Helper method for initializing the available services.
         This computes the services that are inherited from other diagnostic layers."""
-        services_by_name = {}
+        result_dict = {}
 
-        # Look in parent refs for inherited services
-        # Fetch services from low priority parents first, then update with increasing priority
+        # Look in parent refs for inherited services Fetch services
+        # from low priority parents first, then update with increasing
+        # priority
         for parent_ref in self._get_parent_refs_sorted_by_priority():
-            services_by_name.update(
-                parent_ref.get_inherited_services_by_name())
+            for service in parent_ref.get_inherited_services():
+                result_dict[service.short_name] = service
 
-        services_by_name.update(self.__local_services_by_name(odxlinks))
-        return services_by_name
+        for service in self.__gather_local_services(odxlinks):
+            result_dict[service.short_name] = service
 
-    def _compute_available_data_object_properties_by_name(self) -> Dict[str, DopBase]:
+        return list(result_dict.values())
+
+    def _compute_available_data_object_properties(self) -> List[DopBase]:
         """Returns the locally defined and inherited DOPs."""
-        data_object_properties_by_name = {}
+        result_dict = {}
 
-        # Look in parent refs for inherited services
-        # Fetch services from low priority parents first, then update with increasing priority
+        # Look in parent refs for inherited DOPs. Fetch the DOPs from
+        # low priority parents first, then update with increasing
+        # priority
         for parent_ref in self._get_parent_refs_sorted_by_priority():
-            data_object_properties_by_name.update(
-                parent_ref.get_inherited_data_object_properties_by_name())
+            for dop in parent_ref.get_inherited_data_object_properties():
+                result_dict[dop.short_name] = dop
 
         if self.local_diag_data_dictionary_spec:
-            data_object_properties_by_name.update({
-                d.short_name: d for d in self.local_diag_data_dictionary_spec.all_data_object_properties
-            })
-        return data_object_properties_by_name
+            for dop in self.local_diag_data_dictionary_spec.all_data_object_properties:
+                result_dict[dop.short_name] = dop
+
+        return list(result_dict.values())
 
     def _compute_available_commmunication_parameters(self) -> List[CommunicationParameterRef]:
-        com_params = list()
+        com_params_dict: Dict[Tuple[str, str], CommunicationParameterRef] = dict()
 
-        # Look in parent refs for inherited services
-        # Fetch services from low priority parents first, then update with increasing priority
+        # Look in parent refs for inherited communication
+        # parameters. First fetch the communication parameters from
+        # low priority parents first, then update with increasing
+        # priority.
         for parent_ref in self._get_parent_refs_sorted_by_priority():
-            com_params.extend(parent_ref.get_inherited_communication_parameters())
-        com_params.extend(self._local_communication_parameters)
+            for cp in parent_ref.get_inherited_communication_parameters():
+                com_params_dict[(cp.short_name, cp.protocol_sn_ref)] = cp
 
-        return com_params
+        # finally, handle the locally specified communication parameters
+        for cp in self._local_communication_parameters:
+            com_params_dict[(cp.short_name, cp.protocol_sn_ref)] = cp
+
+        return list(com_params_dict.values())
 
     def _get_parent_refs_sorted_by_priority(self, reverse=False):
         return sorted(self.parent_refs, key=lambda pr: pr.get_inheritance_priority(), reverse=reverse)
@@ -489,7 +516,9 @@ class DiagLayer:
         if com_param is None:
             return None
 
-        result = com_param.get_subvalue("CP_CanPhysReqId")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = com_param.get_subvalue("CP_CanPhysReqId")
         if not result:
             return None
         assert isinstance(result, str)
@@ -508,7 +537,9 @@ class DiagLayer:
         if com_param is None:
             return None
 
-        result = com_param.get_subvalue("CP_CanRespUSDTId")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = com_param.get_subvalue("CP_CanRespUSDTId")
         if not result:
             return None
         assert isinstance(result, str)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires_list = [
     "python-can < 4.0",
     "can-isotp",
     "markdownify",
-    "deprecated",
+    "deprecation",
 ]
 
 version_match = re.search(r"^__version__ = '(.*)'$",


### PR DESCRIPTION
Seems like the comparams are becoming a never-ending story. They got broken by a2c8e0ea: The problem with the simplified approach is that comparameters with the same name that are specified by low-priority parents are not properly overwritten by the higher-priority ones. This could be fixed by simply always taking the last instead of the first of the filtered comparams, but this approach would IMO not very explicit and it would also not get rid of the "multiple definition of comparam Foo" warnings. So let's revert back to building a dictionary as before a2c8e0ea, but we (a) now use a `(comparam.short_name, protocol_short_name)` tuple as the key and (b) treat the dictionary as an internal implementation detail of the function (i.e., we return a plain list).

Besides this, the protocol handling code is improved: It now returns a `NamedItemList` of diag layers instead of a list of short name strings like `Database.protocol_names` did, and we also have a `protocols` property for each individual diag layer.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)