### PR TITLE
use named constructors for constructing objects from XML where it makes sense

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -17,7 +17,7 @@ from odxtools.audience import AdditionalAudience, Audience
 from odxtools.communicationparameter import CommunicationParameterRef
 from odxtools.companydata import (CompanyData, CompanySpecificInfo, RelatedDoc,
                                   TeamMember, XDoc)
-from odxtools.comparam_subset import read_comparam_subset_from_odx
+from odxtools.comparam_subset import ComparamSubset
 from odxtools.compumethods import (CompuScale, IdenticalCompuMethod, Limit,
                                    TexttableCompuMethod)
 from odxtools.database import Database
@@ -1285,7 +1285,7 @@ for odx_cs_filename in ("ISO_11898_2_DWCAN.odx-cs",
     odx_cs_root = ElementTree.parse(odx_cs_dir/odx_cs_filename).getroot()
     subset = odx_cs_root.find("COMPARAM-SUBSET")
     if subset is not None:
-        comparam_subsets.append(read_comparam_subset_from_odx(subset))
+        comparam_subsets.append(ComparamSubset.from_et(subset))
 
 # create a database object
 database = Database()

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -19,6 +19,31 @@ class Audience:
     _enabled_audiences: Optional[List["Audience"]] = None
     _disabled_audiences: Optional[List["Audience"]] = None
 
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) \
+            -> "Audience":
+
+        enabled_audience_refs = [OdxLinkRef.from_et(ref, doc_frags)
+            for ref in et_element.iterfind("ENABLED-AUDIENCE-REFS/"
+                                           "ENABLED-AUDIENCE-REF")]
+        disabled_audience_refs = [OdxLinkRef.from_et(ref, doc_frags)
+            for ref in et_element.iterfind("DISABLED-AUDIENCE-REFS/"
+                                           "DISABLED-AUDIENCE-REF")]
+        is_supplier = et_element.get("IS-SUPPLIER", "true") == 'true'
+        is_development = et_element.get("IS-DEVELOPMENT", "true") == 'true'
+        is_manufacturing = et_element.get("IS-MANUFACTURING", "true") == 'true'
+        is_aftersales = et_element.get("IS-AFTERSALES", "true") == 'true'
+        is_aftermarket = et_element.get("IS-AFTERMARKET", "true") == 'true'
+
+        return Audience(enabled_audience_refs=enabled_audience_refs,
+                        disabled_audience_refs=disabled_audience_refs,
+                        is_supplier=is_supplier,
+                        is_development=is_development,
+                        is_manufacturing=is_manufacturing,
+                        is_aftersales=is_aftersales,
+                        is_aftermarket=is_aftermarket)
+
+
     @property
     def enabled_audiences(self):
         return self._enabled_audiences
@@ -44,44 +69,24 @@ class AdditionalAudience:
     long_name: Optional[str] = None
     description: Optional[str] = None
 
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) \
+            -> "AdditionalAudience":
+
+        short_name = et_element.findtext("SHORT-NAME")
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+
+        long_name = et_element.findtext("LONG-NAME")
+        description = read_description_from_odx(et_element.find("DESC"))
+
+        return AdditionalAudience(odx_id=odx_id,
+                                  short_name=short_name,
+                                  long_name=long_name,
+                                  description=description)
+
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return { self.odx_id: self }
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
         pass
-
-
-def read_audience_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    enabled_audience_refs = [OdxLinkRef.from_et(ref, doc_frags)
-        for ref in et_element.iterfind("ENABLED-AUDIENCE-REFS/"
-                                       "ENABLED-AUDIENCE-REF")]
-    disabled_audience_refs = [OdxLinkRef.from_et(ref, doc_frags)
-        for ref in et_element.iterfind("DISABLED-AUDIENCE-REFS/"
-                                       "DISABLED-AUDIENCE-REF")]
-    is_supplier = et_element.get("IS-SUPPLIER", "true") == 'true'
-    is_development = et_element.get("IS-DEVELOPMENT", "true") == 'true'
-    is_manufacturing = et_element.get("IS-MANUFACTURING", "true") == 'true'
-    is_aftersales = et_element.get("IS-AFTERSALES", "true") == 'true'
-    is_aftermarket = et_element.get("IS-AFTERMARKET", "true") == 'true'
-
-    return Audience(enabled_audience_refs=enabled_audience_refs,
-                    disabled_audience_refs=disabled_audience_refs,
-                    is_supplier=is_supplier,
-                    is_development=is_development,
-                    is_manufacturing=is_manufacturing,
-                    is_aftersales=is_aftersales,
-                    is_aftermarket=is_aftermarket)
-
-
-def read_additional_audience_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    short_name = et_element.findtext("SHORT-NAME")
-    odx_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_id is not None
-
-    long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
-
-    return AdditionalAudience(odx_id=odx_id,
-                              short_name=short_name,
-                              long_name=long_name,
-                              description=description)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -8,15 +8,13 @@ from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 from zipfile import ZipFile
 
-from .comparam_subset import ComparamSubset, read_comparam_subset_from_odx
-from .diaglayer import (DiagLayer, DiagLayerContainer,
-                        read_diag_layer_container_from_odx)
+from .comparam_subset import ComparamSubset
+from .diaglayer import DiagLayer, DiagLayerContainer
 from .diaglayertype import DIAG_LAYER_TYPE
 from .globals import logger
 from .nameditemlist import NamedItemList
 from .odxlink import OdxLinkDatabase
 from .utils import short_name_as_id
-
 
 def version(v: str):
     return tuple(map(int, (v.split("."))))
@@ -63,9 +61,7 @@ class Database:
             model_version = version(root.attrib.get('MODEL-VERSION', '2.0'))
             dlc = root.find("DIAG-LAYER-CONTAINER")
             if dlc is not None:
-                dlcs.append(read_diag_layer_container_from_odx(
-                    dlc
-                ))
+                dlcs.append(DiagLayerContainer.from_et(dlc))
             # In ODX 2.0 there was only COMPARAM-SPEC
             # In ODX 2.2 content of COMPARAM-SPEC was renamed to COMPARAM-SUBSET
             # and COMPARAM-SPEC becomes a container for PROT-STACKS
@@ -73,11 +69,11 @@ class Database:
             if model_version >= version('2.2'):
                 subset = root.find("COMPARAM-SUBSET")
                 if subset is not None:
-                    comparam_subsets.append(read_comparam_subset_from_odx(subset))
+                    comparam_subsets.append(ComparamSubset.from_et(subset))
             else:
                 subset = root.find("COMPARAM-SPEC")
                 if subset is not None:
-                    comparam_subsets.append(read_comparam_subset_from_odx(subset))
+                    comparam_subsets.append(ComparamSubset.from_et(subset))
 
         self._diag_layer_containers = NamedItemList(short_name_as_id, dlcs)
         self._diag_layer_containers.sort(key=short_name_as_id)

--- a/odxtools/envdata.py
+++ b/odxtools/envdata.py
@@ -32,6 +32,34 @@ class EnvironmentData(BasicStructure):
                          description=description)
         self.dtc_values = dtc_values
 
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) \
+            -> "EnvironmentData":
+
+        """Reads Environment Data from Diag Layer."""
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+        short_name = et_element.findtext("SHORT-NAME")
+        long_name = et_element.findtext("LONG-NAME")
+        description = read_description_from_odx(et_element.find("DESC"))
+        parameters = [
+            read_parameter_from_odx(et_parameter, doc_frags)
+            for et_parameter in et_element.iterfind("PARAMS/PARAM")
+        ]
+        dtc_values = None
+        if (dtcv_elems := et_element.find("DTC-VALUES")) is not None:
+            dtc_values = [
+                int(dtcv_elem.text)
+                for dtcv_elem in dtcv_elems.iterfind("DTC-VALUE")
+            ]
+
+        return EnvironmentData(odx_id,
+                               short_name,
+                               parameters=parameters,
+                               dtc_values=dtc_values,
+                               long_name=long_name,
+                               description=description)
+
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
 
@@ -53,28 +81,3 @@ class EnvironmentData(BasicStructure):
         )
 
 
-def read_env_data_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
-    -> EnvironmentData:
-    """Reads Environment Data from Diag Layer."""
-    odx_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_id is not None
-    short_name = et_element.findtext("SHORT-NAME")
-    long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
-    parameters = [
-        read_parameter_from_odx(et_parameter, doc_frags)
-        for et_parameter in et_element.iterfind("PARAMS/PARAM")
-    ]
-    dtc_values = None
-    if (dtcv_elems := et_element.find("DTC-VALUES")) is not None:
-        dtc_values = [
-            int(dtcv_elem.text)
-            for dtcv_elem in dtcv_elems.iterfind("DTC-VALUE")
-        ]
-
-    return EnvironmentData(odx_id,
-                           short_name,
-                           parameters=parameters,
-                           dtc_values=dtc_values,
-                           long_name=long_name,
-                           description=description)

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -18,21 +18,22 @@ class FunctionalClass:
     long_name: Optional[str] = None
     description: Optional[str] = None
 
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]):
+        short_name = et_element.findtext("SHORT-NAME")
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+
+        long_name = et_element.findtext("LONG-NAME")
+        description = read_description_from_odx(et_element.find("DESC"))
+
+        return FunctionalClass(odx_id=odx_id,
+                               short_name=short_name,
+                               long_name=long_name,
+                               description=description)
+
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return { self.odx_id: self }
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
         pass
-
-def read_functional_class_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    short_name = et_element.findtext("SHORT-NAME")
-    odx_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_id is not None
-
-    long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
-
-    return FunctionalClass(odx_id=odx_id,
-                           short_name=short_name,
-                           long_name=long_name,
-                           description=description)

--- a/odxtools/parameters/parameterbase.py
+++ b/odxtools/parameters/parameterbase.py
@@ -11,7 +11,7 @@ from ..encodestate import EncodeState
 from ..exceptions import OdxWarning
 from ..odxlink import OdxLinkDatabase
 from ..globals import logger
-from ..specialdata import SpecialDataGroup, read_sdgs_from_odx
+from ..specialdata import SpecialDataGroup
 
 class Parameter(abc.ABC):
     def __init__(self,

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -56,15 +56,17 @@ class PhysicalType:
             self.display_radix = Radix(self.display_radix)
 
 
-def read_physical_type_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    base_data_type = et_element.get("BASE-DATA-TYPE")
-    assert base_data_type in ["A_INT32", "A_UINT32", "A_FLOAT32", "A_FLOAT64",
-                              "A_ASCIISTRING", "A_UTF8STRING", "A_UNICODE2STRING", "A_BYTEFIELD"]
-    display_radix = et_element.get("DISPLAY-RADIX")
-    precision = et_element.findtext("PRECISION")
-    if precision is not None:
-        precision = int(precision)
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]):
+        base_data_type = et_element.get("BASE-DATA-TYPE")
+        assert base_data_type in ["A_INT32", "A_UINT32", "A_FLOAT32", "A_FLOAT64",
+                                  "A_ASCIISTRING", "A_UTF8STRING",
+                                  "A_UNICODE2STRING", "A_BYTEFIELD"]
+        display_radix = et_element.get("DISPLAY-RADIX")
+        precision = et_element.findtext("PRECISION")
+        if precision is not None:
+            precision = int(precision)
 
-    return PhysicalType(base_data_type,
-                        display_radix=display_radix,
-                        precision=precision)
+        return PhysicalType(base_data_type,
+                            display_radix=display_radix,
+                            precision=precision)

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -5,7 +5,7 @@ from typing import List, Iterable, Optional, Union
 from xml.etree import ElementTree
 
 from .utils import short_name_as_id
-from .audience import Audience, read_audience_from_odx
+from .audience import Audience
 from .functionalclass import FunctionalClass
 from .state import State
 from .utils import read_description_from_odx
@@ -17,7 +17,7 @@ from .structures import Request, Response
 from .nameditemlist import NamedItemList
 from .message import Message
 from .specialdata import SpecialDataGroup, read_sdgs_from_odx
-from .admindata import read_admin_data_from_odx, AdminData
+from .admindata import AdminData
 
 class DiagService:
     def __init__(self,
@@ -108,6 +108,73 @@ class DiagService:
                 "negative_responses must be of type Union[List[str], List[Response], None]")
 
         self.sdgs = sdgs
+
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]):
+
+        # logger.info(f"Parsing service based on ET DiagService element: {et_element}")
+        short_name = et_element.findtext("SHORT-NAME")
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+
+        request_ref = OdxLinkRef.from_et(et_element.find("REQUEST-REF"), doc_frags)
+        assert request_ref is not None
+
+        pos_res_refs = [ ]
+        for el in et_element.iterfind("POS-RESPONSE-REFS/POS-RESPONSE-REF"):
+            ref = OdxLinkRef.from_et(el, doc_frags)
+            assert ref is not None
+            pos_res_refs.append(ref)
+
+        neg_res_refs = []
+        for el in et_element.iterfind("NEG-RESPONSE-REFS/NEG-RESPONSE-REF"):
+            ref = OdxLinkRef.from_et(el, doc_frags)
+            assert ref is not None
+            neg_res_refs.append(ref)
+
+        functional_class_refs = []
+        for el in et_element.iterfind("FUNCT-CLASS-REFS/FUNCT-CLASS-REF"):
+            ref = OdxLinkRef.from_et(el, doc_frags)
+            assert ref is not None
+            functional_class_refs.append(ref)
+
+        pre_condition_state_refs = []
+        for el in et_element.iterfind("PRE-CONDITION-STATE-REFS/PRE-CONDITION-STATE-REF"):
+            ref = OdxLinkRef.from_et(el, doc_frags)
+            assert ref is not None
+            pre_condition_state_refs.append(ref)
+
+        state_transition_refs = []
+        for el in et_element.iterfind("STATE-TRANSITION-REFS/STATE-TRANSITION-REF"):
+            ref = OdxLinkRef.from_et(el, doc_frags)
+            assert ref is not None
+            state_transition_refs.append(ref)
+
+        long_name = et_element.findtext("LONG-NAME")
+        description = read_description_from_odx(et_element.find("DESC"))
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        semantic = et_element.get("SEMANTIC")
+
+        audience = None
+        if et_element.find("AUDIENCE"):
+            audience = Audience.from_et(et_element.find("AUDIENCE"), doc_frags)
+
+        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+
+        return DiagService(odx_id,
+                           short_name,
+                           request_ref,
+                           pos_res_refs,
+                           neg_res_refs,
+                           long_name=long_name,
+                           description=description,
+                           admin_data=admin_data,
+                           semantic=semantic,
+                           audience=audience,
+                           functional_class_refs=functional_class_refs,
+                           pre_condition_state_refs=pre_condition_state_refs,
+                           state_transition_refs=state_transition_refs,
+                           sdgs=sdgs)
 
     @property
     def request(self) -> Optional[Request]:
@@ -257,69 +324,3 @@ class DiagService:
         return isinstance(o, DiagService) and self.odx_id == o.odx_id
 
 
-def read_diag_service_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-
-    # logger.info(f"Parsing service based on ET DiagService element: {et_element}")
-    short_name = et_element.findtext("SHORT-NAME")
-    odx_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_id is not None
-
-    request_ref = OdxLinkRef.from_et(et_element.find("REQUEST-REF"), doc_frags)
-    assert request_ref is not None
-
-    pos_res_refs = [ ]
-    for el in et_element.iterfind("POS-RESPONSE-REFS/POS-RESPONSE-REF"):
-        ref = OdxLinkRef.from_et(el, doc_frags)
-        assert ref is not None
-        pos_res_refs.append(ref)
-
-    neg_res_refs = []
-    for el in et_element.iterfind("NEG-RESPONSE-REFS/NEG-RESPONSE-REF"):
-        ref = OdxLinkRef.from_et(el, doc_frags)
-        assert ref is not None
-        neg_res_refs.append(ref)
-
-    functional_class_refs = []
-    for el in et_element.iterfind("FUNCT-CLASS-REFS/FUNCT-CLASS-REF"):
-         ref = OdxLinkRef.from_et(el, doc_frags)
-         assert ref is not None
-         functional_class_refs.append(ref)
-
-    pre_condition_state_refs = []
-    for el in et_element.iterfind("PRE-CONDITION-STATE-REFS/PRE-CONDITION-STATE-REF"):
-        ref = OdxLinkRef.from_et(el, doc_frags)
-        assert ref is not None
-        pre_condition_state_refs.append(ref)
-
-    state_transition_refs = []
-    for el in et_element.iterfind("STATE-TRANSITION-REFS/STATE-TRANSITION-REF"):
-        ref = OdxLinkRef.from_et(el, doc_frags)
-        assert ref is not None
-        state_transition_refs.append(ref)
-
-    long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
-    admin_data = read_admin_data_from_odx(et_element.find("ADMIN-DATA"), doc_frags)
-    semantic = et_element.get("SEMANTIC")
-
-    audience = None
-    if et_element.find("AUDIENCE"):
-        audience = read_audience_from_odx(et_element.find(
-            "AUDIENCE"), doc_frags)
-
-    sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
-
-    return DiagService(odx_id,
-                       short_name,
-                       request_ref,
-                       pos_res_refs,
-                       neg_res_refs,
-                       long_name=long_name,
-                       description=description,
-                       admin_data=admin_data,
-                       semantic=semantic,
-                       audience=audience,
-                       functional_class_refs=functional_class_refs,
-                       pre_condition_state_refs=pre_condition_state_refs,
-                       state_transition_refs=state_transition_refs,
-                       sdgs=sdgs)

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -76,6 +76,7 @@ class SpecialDataGroup:
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) \
             -> "SpecialDataGroup":
+
         sdg_caption = None
         if caption_elem := et_element.find("SDG-CAPTION"):
             sdg_caption = SpecialDataGroupCaption.from_et(caption_elem, doc_frags)

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -17,21 +17,23 @@ class State:
     long_name: Optional[str] = None
     description: Optional[str] = None
 
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) \
+            -> "State":
+        short_name = et_element.findtext("SHORT-NAME")
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+
+        long_name = et_element.findtext("LONG-NAME")
+        description = read_description_from_odx(et_element.find("DESC"))
+
+        return State(odx_id=odx_id,
+                     short_name=short_name,
+                     long_name=long_name,
+                     description=description)
+
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return { self.odx_id: self }
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
         pass
-
-def read_state_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    short_name = et_element.findtext("SHORT-NAME")
-    odx_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_id is not None
-
-    long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
-
-    return State(odx_id=odx_id,
-                 short_name=short_name,
-                 long_name=long_name,
-                 description=description)

--- a/odxtools/state_transition.py
+++ b/odxtools/state_transition.py
@@ -17,23 +17,27 @@ class StateTransition:
     source_short_name: Optional[str] = None
     target_short_name: Optional[str] = None
 
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) \
+            -> "StateTransition":
+
+        short_name = et_element.findtext("SHORT-NAME")
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+
+        long_name = et_element.findtext("LONG-NAME")
+        source_short_name = et_element.find("SOURCE-SNREF").attrib["SHORT-NAME"] if et_element.find("SOURCE-SNREF") is not None else None
+        target_short_name = et_element.find("TARGET-SNREF").attrib["SHORT-NAME"] if et_element.find("TARGET-SNREF") is not None else None
+
+        return StateTransition(odx_id=odx_id,
+                               short_name=short_name,
+                               long_name=long_name,
+                               source_short_name=source_short_name,
+                               target_short_name=target_short_name)
+
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return { self.odx_id: self }
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
         pass
 
-def read_state_transition_from_odx(et_element, doc_frags: List[OdxDocFragment]):
-    short_name = et_element.findtext("SHORT-NAME")
-    odx_id = OdxLinkId.from_et(et_element, doc_frags)
-    assert odx_id is not None
-
-    long_name = et_element.findtext("LONG-NAME")
-    source_short_name = et_element.find("SOURCE-SNREF").attrib["SHORT-NAME"] if et_element.find("SOURCE-SNREF") is not None else None
-    target_short_name = et_element.find("TARGET-SNREF").attrib["SHORT-NAME"] if et_element.find("TARGET-SNREF") is not None else None
-
-    return StateTransition(odx_id=odx_id,
-                           short_name=short_name,
-                           long_name=long_name,
-                           source_short_name=source_short_name,
-                           target_short_name=target_short_name)

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -14,8 +14,14 @@ from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, OdxWarning
 from .globals import logger
 from .nameditemlist import NamedItemList
-from .parameters import Parameter, ParameterWithDOP, read_parameter_from_odx
-from .parameters import CodedConstParameter, MatchingRequestParameter, ValueParameter
+from .parameters import (
+    read_parameter_from_odx,
+    Parameter,
+    ParameterWithDOP,
+    CodedConstParameter,
+    MatchingRequestParameter,
+    ValueParameter,
+)
 from .utils import read_description_from_odx
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 from .specialdata import SpecialDataGroup, read_sdgs_from_odx
@@ -576,7 +582,10 @@ class Response(BasicStructure):
         return f"Response('{self.short_name}')"
 
 
-def read_structure_from_odx(et_element, doc_frags: List[OdxDocFragment]) -> Union[Structure, Request, Response, None]:
+def read_structure_from_odx(et_element,
+                                doc_frags: List[OdxDocFragment]) \
+        -> Union[Structure, Request, Response, None]:
+
     odx_id = OdxLinkId.from_et(et_element, doc_frags)
     short_name = et_element.findtext("SHORT-NAME")
     long_name = et_element.findtext("LONG-NAME")

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -192,9 +192,9 @@ class TestTabIntpCompuMethod(unittest.TestCase):
 
         et_element = ElementTree.fromstring(self.compumethod_odx)
         actual = read_compu_method_from_odx(et_element,
-                                            doc_frags,
-                                            expected.internal_type,
-                                            expected.physical_type)
+                                                doc_frags,
+                                                expected.internal_type,
+                                                expected.physical_type)
         self.assertIsInstance(actual, TabIntpCompuMethod)
         self.assertEqual(expected.physical_type, actual.physical_type)
         self.assertEqual(expected.internal_type, actual.internal_type)

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -24,8 +24,7 @@ from odxtools.odxlink import (OdxDocFragment, OdxLinkDatabase, OdxLinkId,
 from odxtools.odxtypes import DataType
 from odxtools.physicaltype import PhysicalType
 from odxtools.singleecujob import (InputParam, NegOutputParam, OutputParam,
-                                   ProgCode, SingleEcuJob,
-                                   read_single_ecu_job_from_odx)
+                                   ProgCode, SingleEcuJob)
 from odxtools.utils import short_name_as_id
 from odxtools.write_pdx_file import jinja2_odxraise_helper
 
@@ -197,7 +196,7 @@ class TestSingleEcuJob(unittest.TestCase):
         expected = self.singleecujob_object
         sample_single_ecu_job_odx = self.singleecujob_odx
         et_element = ElementTree.fromstring(sample_single_ecu_job_odx)
-        sej = read_single_ecu_job_from_odx(et_element, doc_frags=doc_frags)
+        sej = SingleEcuJob.from_et(et_element, doc_frags)
         self.assertEqual(expected.prog_codes, sej.prog_codes)
         self.assertEqual(expected.output_params, sej.output_params)
         self.assertEqual(expected.neg_output_params,
@@ -235,7 +234,7 @@ class TestSingleEcuJob(unittest.TestCase):
 
         # Assert equality of objects
         # This tests the idempotency of read-write
-        sej = read_single_ecu_job_from_odx(ElementTree.fromstring(rawodx), doc_frags=doc_frags)
+        sej = SingleEcuJob.from_et(ElementTree.fromstring(rawodx), doc_frags)
         self.assertEqual(self.singleecujob_object, sej)
 
     def test_default_lists(self):

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -14,8 +14,7 @@ from odxtools.odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
 from odxtools.parameters import CodedConstParameter, ValueParameter
 from odxtools.physicaltype import PhysicalType
 from odxtools.structures import Request
-from odxtools.units import (PhysicalDimension, Unit, UnitSpec,
-                            read_unit_spec_from_odx)
+from odxtools.units import (PhysicalDimension, Unit, UnitSpec)
 
 doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
@@ -62,7 +61,7 @@ class TestUnitSpec(unittest.TestCase):
             </UNIT-SPEC>
         """
         et_element = ElementTree.fromstring(sample_unit_spec_odx)
-        spec = read_unit_spec_from_odx(et_element, doc_frags=doc_frags)
+        spec = UnitSpec.from_et(et_element, doc_frags)
         self.assertEqual(
             expected.units,
             spec.units


### PR DESCRIPTION
This PR is pretty large but quite boring (that's the best combination, isn't it?). These constructors mostly replace the `read_<foo>_from_odx()` functions and follow the convention `<Foo>.from_et(et_elem, doc_frags)`. The new approach has the advantages that much more of the code related to a given class is contained within the class' body and that only the class name (`Foo`) needs to be imported by the consumers.

Not all `read_<foo>_from_odx()` match well to be replaced by this pattern, though:

- Factory functions which create an object of a derived class but return it as an instance of the base class. These have been renamed to `create_any_<foo>_from_et()`, e.g., `create_any_data_object_property_from_et()`.
- Functions which do not return an object of a special-purpose class but e.g. a string.  Most prominently: `read_description_from_et()`
- Functions which return a list of a given object type, e.g., `create_sdgs_from_et()`

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)