### PR TITLE
rename the remaining `read_<foo>_from_odx()` functions

### DIFF
--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -4,8 +4,8 @@
 from .nameditemlist import NamedItemList
 from .companydata import CompanyData, TeamMember
 from .odxlink import OdxLinkId, OdxLinkRef, OdxLinkDatabase, OdxDocFragment
-from .utils import read_description_from_odx
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .utils import create_description_from_et
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 from xml.etree import ElementTree
 from dataclasses import dataclass, field
@@ -38,7 +38,7 @@ class CompanyDocInfo:
         assert company_data_ref is not None
         team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
         doc_label = et_element.findtext("DOC-LABEL")
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return CompanyDocInfo(company_data_ref=company_data_ref,
                               team_member_ref=team_member_ref,

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
-from odxtools.utils import read_description_from_odx
+from odxtools.utils import create_description_from_et
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 @dataclass()
@@ -78,7 +78,7 @@ class AdditionalAudience:
         assert odx_id is not None
 
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         return AdditionalAudience(odx_id=odx_id,
                                   short_name=short_name,

--- a/odxtools/communicationparameter.py
+++ b/odxtools/communicationparameter.py
@@ -9,12 +9,12 @@ from .comparam_subset import (
     Comparam,
     ComplexComparam,
     ComplexValue,
-    read_complex_value_from_odx,
+    create_complex_value_from_et,
 )
 from .diaglayertype import DIAG_LAYER_TYPE
 from .exceptions import OdxWarning
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 
 class CommunicationParameterRef:
 
@@ -49,10 +49,10 @@ class CommunicationParameterRef:
         elif et_element.find("SIMPLE-VALUE") is not None:
             value = et_element.findtext("SIMPLE-VALUE")
         else:
-            value = read_complex_value_from_odx(et_element.find("COMPLEX-VALUE"))
+            value = create_complex_value_from_et(et_element.find("COMPLEX-VALUE"))
 
         is_functional = (dl_type == DIAG_LAYER_TYPE.FUNCTIONAL_GROUP)
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         prot_stack_snref = None
         if (psnref_elem := et_element.find("PROT-STACK-SNREF")) is not None:

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2022 MBition GmbH
 
 from .nameditemlist import NamedItemList
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxLinkDatabase, OdxDocFragment
 from .utils import short_name_as_id
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 from xml.etree import ElementTree
 from dataclasses import dataclass, field
@@ -27,7 +27,7 @@ class XDoc:
     def from_et(xdoc) -> "XDoc":
         short_name = xdoc.findtext("SHORT-NAME")
         long_name = xdoc.findtext("LONG-NAME")
-        description = read_description_from_odx(xdoc.find("DESC"))
+        description = create_description_from_et(xdoc.find("DESC"))
         number = xdoc.findtext("NUMBER")
         state = xdoc.findtext("STATE")
         date = xdoc.findtext("DATE")
@@ -53,7 +53,7 @@ class RelatedDoc:
 
     @staticmethod
     def from_et(et_element) -> "RelatedDoc":
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         xdoc = et_element.find("XDOC")
         if xdoc is not None:
             xdoc = XDoc.from_et(xdoc)
@@ -78,7 +78,7 @@ class CompanySpecificInfo:
 
             related_docs = rdlist
 
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return CompanySpecificInfo(related_docs=related_docs,
                                    sdgs=sdgs)
@@ -118,7 +118,7 @@ class TeamMember:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         roles = list()
         if (roles_elem := et_element.find("ROLES")) is not None:
@@ -167,7 +167,7 @@ class CompanyData:
         assert odx_id is not None
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         roles = et_element.find("ROLES")
         if roles is not None:
             rlist = list()
@@ -215,7 +215,7 @@ class CompanyData:
         if self.company_specific_info:
             self.company_specific_info._resolve_references(odxlinks)
 
-def read_company_datas_from_odx(et_element, doc_frags: List[OdxDocFragment]) \
+def create_company_datas_from_et(et_element, doc_frags: List[OdxDocFragment]) \
         -> NamedItemList[CompanyData]:
     if et_element is None:
         return NamedItemList(short_name_as_id)

--- a/odxtools/compumethods/__init__.py
+++ b/odxtools/compumethods/__init__.py
@@ -20,4 +20,4 @@ from .texttablecompumethod import TexttableCompuMethod
 from .compurationalcoeffs import CompuRationalCoeffs
 from .compuscale import CompuScale
 from .limit import IntervalType, Limit
-from .readcompumethod import read_compu_method_from_odx
+from .createanycompumethod import create_any_compu_method_from_et

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -5,7 +5,7 @@
 from typing import Any, Dict, List, Optional, Union, Type
 
 from ..odxtypes import DataType
-from ..utils import read_description_from_odx
+from ..utils import create_description_from_et
 from ..globals import logger
 from ..odxlink import OdxDocFragment
 
@@ -77,7 +77,7 @@ def _parse_compu_scale_to_linear_compu_method(scale_element,
 
     return LinearCompuMethod(offset=offset, factor=factor, **kwargs)
 
-def read_compu_method_from_odx(et_element,
+def create_any_compu_method_from_et(et_element,
                                   doc_frags: List[OdxDocFragment],
                                   internal_type: DataType,
                                   physical_type: DataType) -> CompuMethod:
@@ -120,7 +120,7 @@ def read_compu_method_from_odx(et_element,
             internal_to_phys.append(CompuScale(
                 short_label=(scale.findtext("SHORT-LABEL")
                              if scale.find("SHORT-LABEL") is not None else None),
-                description=read_description_from_odx(scale.find("DESC")),
+                description=create_description_from_et(scale.find("DESC")),
                 lower_limit=lower_limit,
                 upper_limit=upper_limit,
                 compu_inverse_value=compu_inverse_value,

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -5,20 +5,20 @@ import abc
 from typing import cast, List, Dict, Optional, Any, Union
 from dataclasses import dataclass, field
 
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .physicaltype import PhysicalType
 from .globals import logger
-from .compumethods import CompuMethod, read_compu_method_from_odx
+from .compumethods import CompuMethod, create_any_compu_method_from_et
 from .units import Unit
 from .diagcodedtypes import (
     DiagCodedType,
     StandardLengthType,
-    read_diag_coded_type_from_odx,
+    create_any_diag_coded_type_from_et,
 )
 from .decodestate import DecodeState
 from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 class DopBase(abc.ABC):
@@ -97,15 +97,15 @@ class DataObjectProperty(DopBase):
         assert odx_id is not None
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        description = create_description_from_et(et_element.find("DESC"))
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
-        diag_coded_type = read_diag_coded_type_from_odx(
+        diag_coded_type = create_any_diag_coded_type_from_et(
             et_element.find("DIAG-CODED-TYPE"), doc_frags)
 
         physical_type = PhysicalType.from_et(
             et_element.find("PHYSICAL-TYPE"), doc_frags)
-        compu_method = read_compu_method_from_odx(et_element.find(
+        compu_method = create_any_compu_method_from_et(et_element.find(
             "COMPU-METHOD"), doc_frags, diag_coded_type.base_data_type, physical_type.base_data_type)
 
         if et_element.tag == "DATA-OBJECT-PROP":
@@ -246,7 +246,7 @@ class DiagnosticTroubleCode:
         else:
             level = None
 
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return DiagnosticTroubleCode(odx_id=OdxLinkId.from_et(et_element, doc_frags),
                                      short_name=et_element.findtext("SHORT-NAME"),

--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -525,7 +525,7 @@ class StandardLengthType(DiagCodedType):
         return self.__repr__()
 
 
-def read_diag_coded_type_from_odx(et_element, doc_frags: List[OdxDocFragment]):
+def create_any_diag_coded_type_from_et(et_element, doc_frags: List[OdxDocFragment]):
     base_type_encoding = et_element.get("BASE-TYPE-ENCODING")
 
     base_data_type = et_element.get("BASE-DATA-TYPE")

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -16,11 +16,11 @@ from .envdatadesc import EnvironmentDataDescription
 from .globals import logger
 from .multiplexer import Multiplexer
 from .nameditemlist import NamedItemList
-from .structures import BasicStructure, read_structure_from_odx
+from .structures import BasicStructure, create_any_structure_from_et
 from .table import Table
 from .units import UnitSpec
 from .odxlink import OdxLinkId, OdxLinkDatabase, OdxDocFragment
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
@@ -106,7 +106,7 @@ class DiagDataDictionarySpec:
 
         structures = []
         for structure_element in et_element.iterfind("STRUCTURES/STRUCTURE"):
-            structure = read_structure_from_odx(structure_element, doc_frags)
+            structure = create_any_structure_from_et(structure_element, doc_frags)
             assert structure is not None
             structures.append(structure)
 
@@ -164,7 +164,7 @@ class DiagDataDictionarySpec:
             if num > 0:
                 logger.info(f"Not implemented: Did not parse {num} {name}.")
 
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return DiagDataDictionarySpec(
             data_object_props=NamedItemList(short_name_as_id, data_object_props),

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -14,7 +14,7 @@ from odxtools.diaglayertype import DIAG_LAYER_TYPE
 from .admindata import AdminData
 from .audience import AdditionalAudience
 from .communicationparameter import CommunicationParameterRef
-from .companydata import CompanyData, read_company_datas_from_odx
+from .companydata import CompanyData, create_company_datas_from_et
 from .dataobjectproperty import DopBase
 from .diagdatadictionaryspec import DiagDataDictionarySpec
 from .exceptions import DecodeError, OdxWarning
@@ -25,11 +25,11 @@ from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .service import DiagService
 from .singleecujob import SingleEcuJob
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 from .state import State
 from .state_transition import StateTransition
-from .structures import Request, Response, read_structure_from_odx
-from .utils import read_description_from_odx, short_name_as_id
+from .structures import Request, Response, create_any_structure_from_et
+from .utils import create_description_from_et, short_name_as_id
 
 # Defines priority of overriding objects
 PRIORITY_OF_DIAG_LAYER_TYPE : Dict[DIAG_LAYER_TYPE,int]= {
@@ -216,7 +216,7 @@ class DiagLayer:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         logger.info(f"Parsing diagnostic layer '{short_name}' "
                     f"of type {variant_type.value} ...")
@@ -258,19 +258,19 @@ class DiagLayer:
         # Parse Requests and Responses
         requests = []
         for rq_elem in et_element.iterfind("REQUESTS/REQUEST"):
-            rq = read_structure_from_odx(rq_elem, doc_frags)
+            rq = create_any_structure_from_et(rq_elem, doc_frags)
             assert isinstance(rq, Request)
             requests.append(rq)
 
         positive_responses = []
         for pr_elem in et_element.iterfind("POS-RESPONSES/POS-RESPONSE"):
-            pr = read_structure_from_odx(pr_elem, doc_frags)
+            pr = create_any_structure_from_et(pr_elem, doc_frags)
             assert isinstance(pr, Response)
             positive_responses.append(pr)
 
         negative_responses = []
         for nr_elem in et_element.iterfind("NEG-RESPONSES/NEG-RESPONSE"):
-            nr = read_structure_from_odx(nr_elem, doc_frags)
+            nr = create_any_structure_from_et(nr_elem, doc_frags)
             assert isinstance(nr, Response)
             negative_responses.append(nr)
 
@@ -309,7 +309,7 @@ class DiagLayer:
             for ref in et_element.iterfind("IMPORT-REFS/IMPORT-REF")
         ]
 
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         # Create DiagLayer
         return DiagLayer(variant_type,
@@ -924,9 +924,9 @@ class DiagLayerContainer:
 
         odx_id = OdxLinkId.from_et(et_element, doc_frags)
         assert odx_id is not None
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
-        company_datas = read_company_datas_from_odx(et_element.find("COMPANY-DATAS"), doc_frags)
+        company_datas = create_company_datas_from_et(et_element.find("COMPANY-DATAS"), doc_frags)
         ecu_shared_datas = [DiagLayer.from_et(dl_element, doc_frags)
                             for dl_element in et_element.iterfind("ECU-SHARED-DATAS/ECU-SHARED-DATA")]
         protocols = [DiagLayer.from_et(dl_element, doc_frags)

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -3,7 +3,7 @@
 
 from typing import TYPE_CHECKING, List, Union
 
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 from .structures import BasicStructure
 from .dataobjectproperty import DopBase
@@ -51,7 +51,7 @@ class EndOfPduField(DopBase):
         assert odx_id is not None
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         structure_ref = OdxLinkRef.from_et(et_element.find("BASIC-STRUCTURE-REF"), doc_frags)
 

--- a/odxtools/envdata.py
+++ b/odxtools/envdata.py
@@ -4,8 +4,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Any, Dict, List
 
-from .parameters import read_parameter_from_odx
-from .utils import read_description_from_odx
+from .parameters import create_any_parameter_from_et
+from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 from .structures import BasicStructure
 from .parameters.parameterbase import Parameter
@@ -41,9 +41,9 @@ class EnvironmentData(BasicStructure):
         assert odx_id is not None
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         parameters = [
-            read_parameter_from_odx(et_parameter, doc_frags)
+            create_any_parameter_from_et(et_parameter, doc_frags)
             for et_parameter in et_element.iterfind("PARAMS/PARAM")
         ]
         dtc_values = None

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, Dict, List, Any
 
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 
@@ -25,7 +25,7 @@ class FunctionalClass:
         assert odx_id is not None
 
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         return FunctionalClass(odx_id=odx_id,
                                short_name=short_name,

--- a/odxtools/parameters/__init__.py
+++ b/odxtools/parameters/__init__.py
@@ -18,4 +18,4 @@ from .tablekeyparameter import TableKeyParameter
 from .tablestructparameter import TableStructParameter
 from .valueparameter import ValueParameter
 
-from .readparameter import read_parameter_from_odx
+from .createanyparameter import create_any_parameter_from_et

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -3,11 +3,11 @@
 
 from typing import List
 
-from ..diagcodedtypes import read_diag_coded_type_from_odx
+from ..diagcodedtypes import create_any_diag_coded_type_from_et
 from ..globals import xsi
-from ..utils import read_description_from_odx
+from ..utils import create_description_from_et
 from ..odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment
-from ..specialdata import SpecialDataGroup, read_sdgs_from_odx
+from ..specialdata import SpecialDataGroup, create_sdgs_from_et
 
 from .codedconstparameter import CodedConstParameter
 from .dynamicparameter import DynamicParameter
@@ -23,10 +23,10 @@ from .tablestructparameter import TableStructParameter
 from .valueparameter import ValueParameter
 
 
-def read_parameter_from_odx(et_element, doc_frags):
+def create_any_parameter_from_et(et_element, doc_frags):
     short_name = et_element.findtext("SHORT-NAME")
     long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
+    description = create_description_from_et(et_element.find("DESC"))
     semantic = et_element.get("SEMANTIC")
     byte_position_str = et_element.findtext("BYTE-POSITION")
     byte_position = int(byte_position_str) if byte_position_str is not None else None
@@ -36,7 +36,7 @@ def read_parameter_from_odx(et_element, doc_frags):
         bit_position = int(bit_position_str)
     parameter_type = et_element.get(f"{xsi}type")
 
-    sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+    sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
     # Which attributes are set depends on the type of the parameter.
     if parameter_type in ["VALUE", "PHYS-CONST", "SYSTEM", "LENGTH-KEY"]:
@@ -79,7 +79,7 @@ def read_parameter_from_odx(et_element, doc_frags):
                                          sdgs=sdgs)
 
     elif parameter_type == "CODED-CONST":
-        diag_coded_type = read_diag_coded_type_from_odx(
+        diag_coded_type = create_any_diag_coded_type_from_et(
             et_element.find("DIAG-CODED-TYPE"), doc_frags)
         coded_value = diag_coded_type.base_data_type.from_string(
             et_element.findtext("CODED-VALUE"))
@@ -95,7 +95,7 @@ def read_parameter_from_odx(et_element, doc_frags):
                                    sdgs=sdgs)
 
     elif parameter_type == "NRC-CONST":
-        diag_coded_type = read_diag_coded_type_from_odx(
+        diag_coded_type = create_any_diag_coded_type_from_et(
             et_element.find("DIAG-CODED-TYPE"), doc_frags)
         coded_values = [diag_coded_type.base_data_type.from_string(val.text)
                         for val in et_element.iterfind("CODED-VALUES/CODED-VALUE")]

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -8,7 +8,7 @@ from .utils import short_name_as_id
 from .audience import Audience
 from .functionalclass import FunctionalClass
 from .state import State
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .exceptions import DecodeError
 from .parameters import Parameter
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
@@ -16,7 +16,7 @@ from .state_transition import StateTransition
 from .structures import Request, Response
 from .nameditemlist import NamedItemList
 from .message import Message
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 from .admindata import AdminData
 
 class DiagService:
@@ -151,7 +151,7 @@ class DiagService:
             state_transition_refs.append(ref)
 
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
         semantic = et_element.get("SEMANTIC")
 
@@ -159,7 +159,7 @@ class DiagService:
         if et_element.find("AUDIENCE"):
             audience = Audience.from_et(et_element.find("AUDIENCE"), doc_frags)
 
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return DiagService(odx_id,
                            short_name,

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -9,13 +9,13 @@ from .dataobjectproperty import DopBase
 from .admindata import AdminData
 from .audience import Audience
 from .functionalclass import FunctionalClass
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
 from .nameditemlist import NamedItemList
 from .globals import logger
 from .exceptions import EncodeError, DecodeError
 from .message import Message
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 DiagClassType = Literal["STARTCOMM",
                         "STOPCOMM",
@@ -44,7 +44,7 @@ class InputParam:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         dop_base_ref = OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags)
         assert dop_base_ref is not None
         physical_default_value = et_element.findtext("PHYSICAL-DEFAULT-VALUE")
@@ -93,7 +93,7 @@ class OutputParam:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         dop_base_ref = OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags)
         assert dop_base_ref is not None
 
@@ -136,7 +136,7 @@ class NegOutputParam:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         dop_base_ref = OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags)
         assert dop_base_ref is not None
 
@@ -269,7 +269,7 @@ class SingleEcuJob:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
         semantic = et_element.get("SEMANTIC")
 
@@ -305,7 +305,7 @@ class SingleEcuJob:
                          else True)
         is_final = True if et_element.get("IS-FINAL") == "true" else False
 
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return SingleEcuJob(odx_id=odx_id,
                             short_name=short_name,

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 
 from .utils import short_name_as_id
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 
 @dataclass
 class SpecialDataGroupCaption:
@@ -27,7 +27,7 @@ class SpecialDataGroupCaption:
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         return SpecialDataGroupCaption(odx_id=odx_id,
                                        short_name=short_name,
@@ -123,7 +123,7 @@ class SpecialDataGroup:
         for val in self.values:
             val._resolve_references(odxlinks)
 
-def read_sdgs_from_odx(et_element: Optional[ElementTree.Element],
+def create_sdgs_from_et(et_element: Optional[ElementTree.Element],
                        doc_frags: List[OdxDocFragment]) \
         -> List[SpecialDataGroup]:
 

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 @dataclass()
@@ -25,7 +25,7 @@ class State:
         assert odx_id is not None
 
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         return State(odx_id=odx_id,
                      short_name=short_name,

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -15,16 +15,16 @@ from .exceptions import DecodeError, EncodeError, OdxWarning
 from .globals import logger
 from .nameditemlist import NamedItemList
 from .parameters import (
-    read_parameter_from_odx,
+    create_any_parameter_from_et,
     Parameter,
     ParameterWithDOP,
     CodedConstParameter,
     MatchingRequestParameter,
     ValueParameter,
 )
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
@@ -583,17 +583,17 @@ class Response(BasicStructure):
         return f"Response('{self.short_name}')"
 
 
-def read_structure_from_odx(et_element,
+def create_any_structure_from_et(et_element,
                                 doc_frags: List[OdxDocFragment]) \
         -> Union[Structure, Request, Response, None]:
 
     odx_id = OdxLinkId.from_et(et_element, doc_frags)
     short_name = et_element.findtext("SHORT-NAME")
     long_name = et_element.findtext("LONG-NAME")
-    description = read_description_from_odx(et_element.find("DESC"))
-    parameters = [read_parameter_from_odx(et_parameter, doc_frags)
+    description = create_description_from_et(et_element.find("DESC"))
+    parameters = [create_any_parameter_from_et(et_parameter, doc_frags)
                   for et_parameter in et_element.iterfind("PARAMS/PARAM")]
-    sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+    sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
     res: Union[Structure, Request, Response, None]
     if et_element.tag == "REQUEST":

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -5,12 +5,12 @@ import abc
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, Iterable
 
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
 
 from .dataobjectproperty import DopBase
 from .globals import logger
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 
 class TableBase(abc.ABC):
@@ -66,7 +66,7 @@ class TableRow:
         assert short_name is not None
         long_name=et_element.findtext("LONG-NAME")
         semantic=et_element.get("SEMANTIC")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         key = et_element.findtext("KEY")
         structure_ref = None
         if et_element.find("STRUCTURE-REF") is not None:
@@ -74,7 +74,7 @@ class TableRow:
         dop_ref = None
         if et_element.find("DATA-OBJECT-PROP-REF") is not None:
             dop_ref = OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags)
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return TableRow(
             odx_id=odx_id,
@@ -166,7 +166,7 @@ class Table(TableBase):
         assert short_name is not None
         long_name = et_element.findtext("LONG-NAME")
         semantic = et_element.get("SEMANTIC")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         key_dop_ref = None
         if et_element.find("KEY-DOP-REF") is not None:
             key_dop_ref = OdxLinkRef.from_et(et_element.find("KEY-DOP-REF"), doc_frags)
@@ -182,7 +182,7 @@ class Table(TableBase):
             ref = OdxLinkRef.from_et(el, doc_frags)
             assert ref is not None
             table_row_refs.append(ref)
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return Table(odx_id=odx_id,
                      short_name=short_name,

--- a/odxtools/units.py
+++ b/odxtools/units.py
@@ -6,9 +6,9 @@ from typing import Dict, List, Any, Literal, Optional, Union
 
 from .utils import short_name_as_id
 from .nameditemlist import NamedItemList
-from .utils import read_description_from_odx
+from .utils import create_description_from_et
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
-from .specialdata import SpecialDataGroup, read_sdgs_from_odx
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 UnitGroupCategory = Literal["COUNTRY", "EQUIV-UNITS"]
 
@@ -65,7 +65,7 @@ class PhysicalDimension:
         oid = et_element.get("OID")
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
 
         def read_optional_int(element, name):
             if element.findtext(name):
@@ -159,7 +159,7 @@ class Unit:
         oid = et_element.get("OID")
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         display_name = et_element.findtext("DISPLAY-NAME")
 
         def read_optional_float(element, name):
@@ -219,7 +219,7 @@ class UnitGroup:
         oid = et_element.get("OID")
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
-        description = read_description_from_odx(et_element.find("DESC"))
+        description = create_description_from_et(et_element.find("DESC"))
         category = et_element.findtext("CATEGORY")
         assert category in [
             "COUNTRY", "EQUIV-UNITS"], f'A UNIT-GROUP-CATEGORY must be "COUNTRY" or "EQUIV-UNITS". It was {category}.'
@@ -284,7 +284,7 @@ class UnitSpec:
                  for el in et_element.iterfind("UNITS/UNIT")]
         physical_dimensions = [PhysicalDimension.from_et(el, doc_frags)
                                for el in et_element.iterfind("PHYSICAL-DIMENSIONS/PHYSICAL-DIMENSION")]
-        sdgs = read_sdgs_from_odx(et_element.find("SDGS"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return UnitSpec(
             unit_groups=unit_groups,

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment
 
-def read_description_from_odx(et_element: Optional[ElementTree.Element]) \
+def create_description_from_et(et_element: Optional[ElementTree.Element]) \
  -> Optional[str]:
     """Read a description tag.
 

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -10,7 +10,7 @@ import jinja2
 import odxtools
 
 from odxtools.compumethods import Limit, LinearCompuMethod, IntervalType, TabIntpCompuMethod
-from odxtools.compumethods.readcompumethod import read_compu_method_from_odx
+from odxtools.compumethods.createanycompumethod import create_any_compu_method_from_et
 from odxtools.exceptions import DecodeError, EncodeError
 from odxtools.odxtypes import DataType
 from odxtools.odxlink import OdxDocFragment
@@ -191,7 +191,7 @@ class TestTabIntpCompuMethod(unittest.TestCase):
         expected = self.compumethod
 
         et_element = ElementTree.fromstring(self.compumethod_odx)
-        actual = read_compu_method_from_odx(et_element,
+        actual = create_any_compu_method_from_et(et_element,
                                                 doc_frags,
                                                 expected.internal_type,
                                                 expected.physical_type)

--- a/tests/test_readparameters.py
+++ b/tests/test_readparameters.py
@@ -5,13 +5,13 @@ import unittest
 from xml.etree import ElementTree
 
 from odxtools.odxtypes import DataType
-from odxtools.parameters import NrcConstParameter, read_parameter_from_odx
+from odxtools.parameters import NrcConstParameter, create_any_parameter_from_et
 from odxtools.odxlink import OdxDocFragment
 
 doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
 class TestReadNrcParam(unittest.TestCase):
-    def test_read_nrcconst_from_odx(self):
+    def test_create_nrcconst_from_et(self):
         ODX = """
         <PARAM SEMANTIC="SUBFUNCTION-ID" xsi:type="NRC-CONST" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SHORT-NAME>NR_identifier</SHORT-NAME>
@@ -27,7 +27,7 @@ class TestReadNrcParam(unittest.TestCase):
         </PARAM>
         """
         root = ElementTree.fromstring(ODX)
-        param = read_parameter_from_odx(root, doc_frags=doc_frags)
+        param = create_any_parameter_from_et(root, doc_frags=doc_frags)
 
         self.assertIsInstance(param, NrcConstParameter)
         self.assertEqual("SUBFUNCTION-ID", param.semantic)


### PR DESCRIPTION
most of these are factory functions that are now called `create_any_<foo>_from_et()`, while functions which produce a list of objects are called   `create_<foo>s_from_et()`. Finally, unspecific helper functions are called `create_<foo>_from_et()`  (e.g. `create_description_from_et()`)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)