### PR TITLE
fix handling of boolean attributes

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -895,7 +895,7 @@ somersault_services = {
                         OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id),
                         OdxLinkRef.from_id(somersault_additional_audiences["anyone"].odx_id),
                     ],
-                    _is_development=False)
+                    is_development_raw=False)
                 ),
 
     "set_operation_params":
@@ -934,7 +934,7 @@ somersault_services = {
                 ],
                 audience=Audience(
                     enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
-                    _is_development=False)
+                    is_development_raw=False)
                 ),
 
     "backward_flips":
@@ -953,7 +953,7 @@ somersault_services = {
                 ],
                 audience=Audience(
                     enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
-                    _is_development=False)
+                    is_development_raw=False)
                 ),
 
     "report_status":
@@ -969,8 +969,8 @@ somersault_services = {
                 ],
                 audience=Audience(
                     disabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
-                    _is_aftersales=False,
-                    _is_aftermarket=False)
+                    is_aftersales_raw=False,
+                    is_aftermarket_raw=False)
                 ),
 
 }

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -895,7 +895,7 @@ somersault_services = {
                         OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id),
                         OdxLinkRef.from_id(somersault_additional_audiences["anyone"].odx_id),
                     ],
-                    is_development=False)
+                    _is_development=False)
                 ),
 
     "set_operation_params":
@@ -934,7 +934,7 @@ somersault_services = {
                 ],
                 audience=Audience(
                     enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
-                    is_development=False)
+                    _is_development=False)
                 ),
 
     "backward_flips":
@@ -953,7 +953,7 @@ somersault_services = {
                 ],
                 audience=Audience(
                     enabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
-                    is_development=False)
+                    _is_development=False)
                 ),
 
     "report_status":
@@ -969,8 +969,8 @@ somersault_services = {
                 ],
                 audience=Audience(
                     disabled_audience_refs=[OdxLinkRef.from_id(somersault_additional_audiences["attentive_admirer"].odx_id)],
-                    is_aftersales=False,
-                    is_aftermarket=False)
+                    _is_aftersales=False,
+                    _is_aftermarket=False)
                 ),
 
 }

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -3,7 +3,8 @@
 
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
-from .utils import create_description_from_et, str_to_bool
+from .utils import create_description_from_et
+from .odxtypes import odxstr_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 @dataclass()
@@ -11,30 +12,30 @@ class Audience:
     enabled_audience_refs: list = field(default_factory=list)
     disabled_audience_refs: list = field(default_factory=list)
 
-    _is_supplier: Optional[bool] = None
+    is_supplier_raw: Optional[bool] = None
     @property
     def is_supplier(self) -> bool:
-        return self._is_supplier in [None, True]
+        return self.is_supplier_raw in [None, True]
 
-    _is_development: Optional[bool] = None
+    is_development_raw: Optional[bool] = None
     @property
     def is_development(self) -> bool:
-        return self._is_development in [None, True]
+        return self.is_development_raw in [None, True]
 
-    _is_manufacturing: Optional[bool] = None
+    is_manufacturing_raw: Optional[bool] = None
     @property
     def is_manufacturing(self) -> bool:
-        return self._is_manufacturing in [None, True]
+        return self.is_manufacturing_raw in [None, True]
 
-    _is_aftersales: Optional[bool] = None
+    is_aftersales_raw: Optional[bool] = None
     @property
     def is_aftersales(self) -> bool:
-        return self._is_aftersales in [None, True]
+        return self.is_aftersales_raw in [None, True]
 
-    _is_aftermarket: Optional[bool] = None
+    is_aftermarket_raw: Optional[bool] = None
     @property
     def is_aftermarket(self) -> bool:
-        return self._is_aftermarket in [None, True]
+        return self.is_aftermarket_raw in [None, True]
 
     _enabled_audiences: Optional[List["AdditionalAudience"]] = None
     @property
@@ -58,20 +59,19 @@ class Audience:
         disabled_audience_refs = [OdxLinkRef.from_et(ref, doc_frags)
             for ref in et_element.iterfind("DISABLED-AUDIENCE-REFS/"
                                            "DISABLED-AUDIENCE-REF")]
-        is_supplier = str_to_bool(et_element.get("IS-SUPPLIER"))
-        is_development = str_to_bool(et_element.get("IS-DEVELOPMENT"))
-        is_manufacturing = str_to_bool(et_element.get("IS-MANUFACTURING"))
-        is_aftersales = str_to_bool(et_element.get("IS-AFTERSALES"))
-        is_aftermarket = str_to_bool(et_element.get("IS-AFTERMARKET"))
+        is_supplier_raw = odxstr_to_bool(et_element.get("IS-SUPPLIER"))
+        is_development_raw = odxstr_to_bool(et_element.get("IS-DEVELOPMENT"))
+        is_manufacturing_raw = odxstr_to_bool(et_element.get("IS-MANUFACTURING"))
+        is_aftersales_raw = odxstr_to_bool(et_element.get("IS-AFTERSALES"))
+        is_aftermarket_raw = odxstr_to_bool(et_element.get("IS-AFTERMARKET"))
 
         return Audience(enabled_audience_refs=enabled_audience_refs,
                         disabled_audience_refs=disabled_audience_refs,
-                        _is_supplier=is_supplier,
-                        _is_development=is_development,
-                        _is_manufacturing=is_manufacturing,
-                        _is_aftersales=is_aftersales,
-                        _is_aftermarket=is_aftermarket)
-
+                        is_supplier_raw=is_supplier_raw,
+                        is_development_raw=is_development_raw,
+                        is_manufacturing_raw=is_manufacturing_raw,
+                        is_aftersales_raw=is_aftersales_raw,
+                        is_aftermarket_raw=is_aftermarket_raw)
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         self._enabled_audiences = [odxlinks.resolve(ref)

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -3,21 +3,50 @@
 
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
-from odxtools.utils import create_description_from_et
+from .utils import create_description_from_et, str_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 @dataclass()
 class Audience:
     enabled_audience_refs: list = field(default_factory=list)
     disabled_audience_refs: list = field(default_factory=list)
-    is_supplier: bool = True
-    is_development: bool = True
-    is_manufacturing: bool = True
-    is_aftersales: bool = True
-    is_aftermarket: bool = True
 
-    _enabled_audiences: Optional[List["Audience"]] = None
-    _disabled_audiences: Optional[List["Audience"]] = None
+    _is_supplier: Optional[bool] = None
+    @property
+    def is_supplier(self) -> bool:
+        return self._is_supplier in [None, True]
+
+    _is_development: Optional[bool] = None
+    @property
+    def is_development(self) -> bool:
+        return self._is_development in [None, True]
+
+    _is_manufacturing: Optional[bool] = None
+    @property
+    def is_manufacturing(self) -> bool:
+        return self._is_manufacturing in [None, True]
+
+    _is_aftersales: Optional[bool] = None
+    @property
+    def is_aftersales(self) -> bool:
+        return self._is_aftersales in [None, True]
+
+    _is_aftermarket: Optional[bool] = None
+    @property
+    def is_aftermarket(self) -> bool:
+        return self._is_aftermarket in [None, True]
+
+    _enabled_audiences: Optional[List["AdditionalAudience"]] = None
+    @property
+    def enabled_audiences(self) -> List["AdditionalAudience"]:
+        assert self._enabled_audiences is not None
+        return self._enabled_audiences
+
+    _disabled_audiences: Optional[List["AdditionalAudience"]] = None
+    @property
+    def disabled_audiences(self) -> List["AdditionalAudience"]:
+        assert self._disabled_audiences is not None
+        return self._disabled_audiences
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) \
@@ -29,28 +58,20 @@ class Audience:
         disabled_audience_refs = [OdxLinkRef.from_et(ref, doc_frags)
             for ref in et_element.iterfind("DISABLED-AUDIENCE-REFS/"
                                            "DISABLED-AUDIENCE-REF")]
-        is_supplier = et_element.get("IS-SUPPLIER", "true") == 'true'
-        is_development = et_element.get("IS-DEVELOPMENT", "true") == 'true'
-        is_manufacturing = et_element.get("IS-MANUFACTURING", "true") == 'true'
-        is_aftersales = et_element.get("IS-AFTERSALES", "true") == 'true'
-        is_aftermarket = et_element.get("IS-AFTERMARKET", "true") == 'true'
+        is_supplier = str_to_bool(et_element.get("IS-SUPPLIER"))
+        is_development = str_to_bool(et_element.get("IS-DEVELOPMENT"))
+        is_manufacturing = str_to_bool(et_element.get("IS-MANUFACTURING"))
+        is_aftersales = str_to_bool(et_element.get("IS-AFTERSALES"))
+        is_aftermarket = str_to_bool(et_element.get("IS-AFTERMARKET"))
 
         return Audience(enabled_audience_refs=enabled_audience_refs,
                         disabled_audience_refs=disabled_audience_refs,
-                        is_supplier=is_supplier,
-                        is_development=is_development,
-                        is_manufacturing=is_manufacturing,
-                        is_aftersales=is_aftersales,
-                        is_aftermarket=is_aftermarket)
+                        _is_supplier=is_supplier,
+                        _is_development=is_development,
+                        _is_manufacturing=is_manufacturing,
+                        _is_aftersales=is_aftersales,
+                        _is_aftermarket=is_aftermarket)
 
-
-    @property
-    def enabled_audiences(self):
-        return self._enabled_audiences
-
-    @property
-    def disabled_audiences(self):
-        return self._disabled_audiences
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         self._enabled_audiences = [odxlinks.resolve(ref)

--- a/odxtools/comparam_subset.py
+++ b/odxtools/comparam_subset.py
@@ -8,7 +8,8 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .units import UnitSpec
 from .admindata import AdminData
 from .companydata import CompanyData, create_company_datas_from_et
-from .utils import create_description_from_et, short_name_as_id, str_to_bool
+from .utils import create_description_from_et, short_name_as_id
+from .odxtypes import odxstr_to_bool
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 StandardizationLevel = Literal[
@@ -71,7 +72,11 @@ class BaseComparam:
 class ComplexComparam(BaseComparam):
     comparams: NamedItemList[BaseComparam]
     complex_physical_default_value: Optional[ComplexValue] = field(default=None, init=False)
-    allow_multiple_values: Optional[bool] = None
+    allow_multiple_values_raw: Optional[bool] = None
+
+    @property
+    def allow_multiple_values(self) -> bool:
+        return self.allow_multiple_values_raw == True
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "ComplexComparam":
@@ -92,7 +97,7 @@ class ComplexComparam(BaseComparam):
         if cpdv_elem := et_element.find("COMPLEX-PHYSICAL-DEFAULT-VALUE"):
             self.complex_physical_default_value = create_complex_value_from_et(cpdv_elem)
 
-        self.allow_multiple_values = str_to_bool(et_element.get("ALLOW-MULTIPLE-VALUES"))
+        self.allow_multiple_values_raw = odxstr_to_bool(et_element.get("ALLOW-MULTIPLE-VALUES"))
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         super()._resolve_references(odxlinks)

--- a/odxtools/comparam_subset.py
+++ b/odxtools/comparam_subset.py
@@ -1,5 +1,3 @@
-
-
 from dataclasses import dataclass, field
 from typing import Any, Union, Dict, List, Literal, Optional
 from xml.etree.ElementTree import Element
@@ -10,7 +8,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .units import UnitSpec
 from .admindata import AdminData
 from .companydata import CompanyData, create_company_datas_from_et
-from .utils import create_description_from_et, short_name_as_id
+from .utils import create_description_from_et, short_name_as_id, str_to_bool
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
 
 StandardizationLevel = Literal[
@@ -94,8 +92,7 @@ class ComplexComparam(BaseComparam):
         if cpdv_elem := et_element.find("COMPLEX-PHYSICAL-DEFAULT-VALUE"):
             self.complex_physical_default_value = create_complex_value_from_et(cpdv_elem)
 
-        tmp = et_element.get("ALLOW-MULTIPLE-VALUES")
-        self.allow_multiple_values = (tmp == "true") if tmp is not None else None
+        self.allow_multiple_values = str_to_bool(et_element.get("ALLOW-MULTIPLE-VALUES"))
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         super()._resolve_references(odxlinks)

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -5,7 +5,8 @@ import abc
 from typing import cast, List, Dict, Optional, Any, Union
 from dataclasses import dataclass, field
 
-from .utils import create_description_from_et, str_to_bool
+from .utils import create_description_from_et
+from .odxtypes import odxstr_to_bool
 from .physicaltype import PhysicalType
 from .globals import logger
 from .compumethods import CompuMethod, create_any_compu_method_from_et
@@ -32,13 +33,13 @@ class DopBase(abc.ABC):
                  short_name,
                  long_name=None,
                  description=None,
-                 _is_visible=None,
+                 is_visible_raw=None,
                  sdgs = []):
         self.odx_id = odx_id
         self.short_name = short_name
         self.long_name = long_name
         self.description = description
-        self._is_visible = _is_visible
+        self.is_visible_raw = is_visible_raw
         self.sdgs = sdgs
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
@@ -55,7 +56,7 @@ class DopBase(abc.ABC):
 
     @property
     def is_visible(self) -> bool:
-        return self._is_visible in (None, True)
+        return self.is_visible_raw in (None, True)
 
     @abc.abstractmethod
     def convert_physical_to_bytes(self, physical_value, encode_state: EncodeState, bit_position: int) -> bytes:
@@ -80,12 +81,14 @@ class DataObjectProperty(DopBase):
                  unit_ref: Optional[OdxLinkRef] = None,
                  long_name: Optional[str] = None,
                  description: Optional[str] = None,
+                 is_visible_raw: Optional[bool] = None,
                  sdgs: List[SpecialDataGroup] = [],
                  ):
         super().__init__(odx_id=odx_id,
                          short_name=short_name,
                          long_name=long_name,
                          description=description,
+                         is_visible_raw=is_visible_raw,
                          sdgs=sdgs)
         self.diag_coded_type = diag_coded_type
         self.physical_type = physical_type
@@ -133,7 +136,7 @@ class DataObjectProperty(DopBase):
                     elif dtc_elem.tag == "DTC-REF":
                         dtclist.append(DtcRef.from_et(dtc_elem, doc_frags))
 
-            _is_visible = str_to_bool(et_element.get("IS-VISIBLE"))
+            is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
             dop = DtcDop(odx_id=odx_id,
                          short_name=short_name,
                          long_name=long_name,
@@ -142,7 +145,7 @@ class DataObjectProperty(DopBase):
                          physical_type=physical_type,
                          compu_method=compu_method,
                          dtcs=dtclist,
-                         _is_visible=_is_visible,
+                         is_visible_raw=is_visible_raw,
                          sdgs=sdgs)
         return dop
 
@@ -234,8 +237,12 @@ class DiagnosticTroubleCode:
     text: Optional[str] = None
     display_trouble_code: Optional[str] = None
     level: Union[bytes, bytearray, None] = None
-    is_temporary: Optional[bool] = None
+    is_temporary_raw: Optional[bool] = None
     sdgs: List[SpecialDataGroup] = field(default_factory=list)
+
+    @property
+    def is_temporary(self) -> bool:
+        return self.is_temporary_raw == True
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) \
@@ -250,7 +257,7 @@ class DiagnosticTroubleCode:
         else:
             level = None
 
-        is_temporary = str_to_bool(et_element.get("IS-TEMPORARY"))
+        is_temporary_raw = odxstr_to_bool(et_element.get("IS-TEMPORARY"))
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return DiagnosticTroubleCode(odx_id=OdxLinkId.from_et(et_element, doc_frags),
@@ -260,7 +267,7 @@ class DiagnosticTroubleCode:
                                      text=et_element.findtext("TEXT"),
                                      display_trouble_code=display_trouble_code,
                                      level=level,
-                                     is_temporary=is_temporary,
+                                     is_temporary_raw=is_temporary_raw,
                                      sdgs=sdgs)
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
@@ -337,7 +344,7 @@ class DtcDop(DataObjectProperty):
                  physical_type: PhysicalType,
                  compu_method: CompuMethod,
                  dtcs: List[Union[DiagnosticTroubleCode, DtcRef]],
-                 _is_visible: bool = False,
+                 is_visible_raw: bool = False,
                  linked_dtc_dops: bool = False,
                  long_name: Optional[str] = None,
                  description: Optional[str] = None,
@@ -350,9 +357,9 @@ class DtcDop(DataObjectProperty):
                          diag_coded_type=diag_coded_type,
                          physical_type=physical_type,
                          compu_method=compu_method,
+                         is_visible_raw=is_visible_raw,
                          sdgs=sdgs)
         self.dtcs = dtcs
-        self._is_visible = _is_visible
         self.linked_dtc_dops = linked_dtc_dops
 
     def convert_bytes_to_physical(self, decode_state, bit_position: int = 0):

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Union, Optional
 
-from .utils import create_description_from_et
+from .utils import create_description_from_et, str_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 from .structures import BasicStructure
 from .dataobjectproperty import DopBase
@@ -25,11 +25,11 @@ class EndOfPduField(DopBase):
                  structure_snref=None,
                  min_number_of_items=0,
                  max_number_of_items=None,
-                 is_visible=False,
+                 _is_visible: Optional[bool] = None,
                  long_name=None,
                  description=None):
         super().__init__(odx_id, short_name, long_name=long_name,
-                         description=description, is_visible=is_visible)
+                         description=description, _is_visible=_is_visible)
 
         self.structure_snref = structure_snref
         self.structure_ref = structure_ref
@@ -41,8 +41,6 @@ class EndOfPduField(DopBase):
 
         self.min_number_of_items = min_number_of_items
         self.max_number_of_items = max_number_of_items
-
-        self.is_visible = is_visible
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) \
@@ -80,12 +78,7 @@ class EndOfPduField(DopBase):
         else:
             max_number_of_items = None
 
-        is_visible = et_element.get("IS-VISIBLE")
-        if is_visible is not None:
-            assert is_visible in ["true", "false"]
-            is_visible = is_visible == "true"
-        else:
-            is_visible = False
+        _is_visible = str_to_bool(et_element.get("IS-VISIBLE"))
         eopf = EndOfPduField(odx_id,
                              short_name,
                              long_name=long_name,
@@ -94,7 +87,7 @@ class EndOfPduField(DopBase):
                              structure_snref=structure_snref,
                              min_number_of_items=min_number_of_items,
                              max_number_of_items=max_number_of_items,
-                             is_visible=is_visible)
+                             _is_visible=_is_visible)
 
         return eopf
 

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -3,7 +3,8 @@
 
 from typing import TYPE_CHECKING, List, Union, Optional
 
-from .utils import create_description_from_et, str_to_bool
+from .utils import create_description_from_et
+from .odxtypes import odxstr_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 from .structures import BasicStructure
 from .dataobjectproperty import DopBase
@@ -25,11 +26,11 @@ class EndOfPduField(DopBase):
                  structure_snref=None,
                  min_number_of_items=0,
                  max_number_of_items=None,
-                 _is_visible: Optional[bool] = None,
+                 is_visible_raw: Optional[bool] = None,
                  long_name=None,
                  description=None):
         super().__init__(odx_id, short_name, long_name=long_name,
-                         description=description, _is_visible=_is_visible)
+                         description=description, is_visible_raw=is_visible_raw)
 
         self.structure_snref = structure_snref
         self.structure_ref = structure_ref
@@ -78,7 +79,7 @@ class EndOfPduField(DopBase):
         else:
             max_number_of_items = None
 
-        _is_visible = str_to_bool(et_element.get("IS-VISIBLE"))
+        is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
         eopf = EndOfPduField(odx_id,
                              short_name,
                              long_name=long_name,
@@ -87,7 +88,7 @@ class EndOfPduField(DopBase):
                              structure_snref=structure_snref,
                              min_number_of_items=min_number_of_items,
                              max_number_of_items=max_number_of_items,
-                             _is_visible=_is_visible)
+                             is_visible_raw=is_visible_raw)
 
         return eopf
 

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 from enum import Enum
-from typing import Any, Callable, Dict, Literal, Type, Union
+from typing import Any, Optional, Callable, Dict, Literal, Type, Union, overload
 
 def bytefield_to_bytearray(bytefield: str) -> bytearray:
     bytes_string = [bytefield[i:i+2] for i in range(0, len(bytefield), 2)]
@@ -10,6 +10,25 @@ def bytefield_to_bytearray(bytefield: str) -> bytearray:
 
 PythonType = Union[str, int, float, bytearray]
 LiteralPythonType = Type[Union[str, int, float, bytearray]]
+
+@overload
+def odxstr_to_bool(str_val: None) -> None: ...
+
+@overload
+def odxstr_to_bool(str_val: str) -> bool: ...
+
+def odxstr_to_bool(str_val: Optional[str]) -> Optional[bool]:
+    if str_val is None:
+        return None
+
+    str_val = str_val.strip()
+    assert str_val in ["0", "1", "false", "true"], \
+        f"String '{str_val}' cannot be converted to a boolean"
+
+    return str_val in ["1", "true"]
+
+def bool_to_odxstr(bool_val: bool) -> str:
+    return "true" if bool_val else "false"
 
 def parse_int(value: str) -> int:
     try:

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -49,7 +49,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
                 f"A parameter of type {parameter_type} must reference a DOP! {dop_ref}, {dop_snref}")
 
     if parameter_type == "VALUE":
-        physical_default_value = et_element.findtext("PHYSICAL-DEFAULT-VALUE") \
+        physical_default_value_raw = et_element.findtext("PHYSICAL-DEFAULT-VALUE") \
             if et_element.find("PHYSICAL-DEFAULT-VALUE") is not None else None
 
         return ValueParameter(short_name=short_name,
@@ -59,7 +59,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
                               bit_position=bit_position,
                               dop_ref=dop_ref,
                               dop_snref=dop_snref,
-                              physical_default_value=physical_default_value,
+                              physical_default_value_raw=physical_default_value_raw,
                               description=description,
                               sdgs=sdgs)
 

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -11,7 +11,7 @@ from .parameterwithdop import ParameterWithDOP
 class ValueParameter(ParameterWithDOP):
     def __init__(self,
                  short_name,
-                 physical_default_value=None,
+                 physical_default_value_raw=None,
                  dop_ref=None,
                  dop_snref=None,
                  **kwargs):
@@ -20,21 +20,21 @@ class ValueParameter(ParameterWithDOP):
                          dop_ref=dop_ref,
                          dop_snref=dop_snref,
                          **kwargs)
-        # _physical_default_value is a string. Conversion to actual type must happen after parsing
-        self._physical_default_value = physical_default_value
+        # physical_default_value is a string. Conversion to actual type must happen after parsing
+        self.physical_default_value_raw = physical_default_value_raw
 
     @property
     def physical_default_value(self):
-        if self._physical_default_value is None:
+        if self.physical_default_value_raw is None:
             return None
         else:
-            return self.dop.physical_type.base_data_type.from_string(self._physical_default_value)
+            return self.dop.physical_type.base_data_type.from_string(self.physical_default_value_raw)
 
     def is_required(self):
-        return True if self.physical_default_value is None else False
+        return self.physical_default_value is None
 
     def is_optional(self):
-        return True if self._physical_default_value is not None else False
+        return not self.is_required()
 
     def get_coded_value(self, physical_value=None):
         if physical_value is not None:

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -4,12 +4,11 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 
-from .utils import short_name_as_id
 from .dataobjectproperty import DopBase
 from .admindata import AdminData
 from .audience import Audience
 from .functionalclass import FunctionalClass
-from .utils import create_description_from_et
+from .utils import create_description_from_et, short_name_as_id, str_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
 from .nameditemlist import NamedItemList
 from .globals import logger
@@ -240,9 +239,12 @@ class SingleEcuJob:
     # xsd:attributes inherited from DIAG-COMM (and thus shared with DIAG-SERVICE)
     semantic: Optional[str] = None
     diagnostic_class: Optional[DiagClassType] = None
-    is_mandatory: bool = False
-    is_executable: bool = True
-    is_final: bool = False
+    is_mandatory: Optional[bool] = None
+    _is_executable: Optional[bool] = None
+    @property
+    def is_executable(self):
+        return self._is_executable in (None, True)
+    is_final: Optional[bool] = None
     sdgs: List[SpecialDataGroup] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -300,10 +302,9 @@ class SingleEcuJob:
         ]
 
         # Read boolean flags. Note that the "else" clause contains the default value.
-        is_mandatory = True if et_element.get("IS-MANDATORY") == "true" else False
-        is_executable = (False if et_element.get("IS-EXECUTABLE") == "false"
-                         else True)
-        is_final = True if et_element.get("IS-FINAL") == "true" else False
+        is_mandatory = str_to_bool(et_element.get("IS-MANDATORY"))
+        is_executable = str_to_bool(et_element.get("IS-MANDATORY"))
+        is_final = str_to_bool(et_element.get("IS-FINAL"))
 
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
@@ -320,7 +321,7 @@ class SingleEcuJob:
                             output_params=output_params,
                             neg_output_params=neg_output_params,
                             is_mandatory=is_mandatory,
-                            is_executable=is_executable,
+                            _is_executable=is_executable,
                             is_final=is_final,
                             sdgs=sdgs)
 

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -8,7 +8,8 @@ from .dataobjectproperty import DopBase
 from .admindata import AdminData
 from .audience import Audience
 from .functionalclass import FunctionalClass
-from .utils import create_description_from_et, short_name_as_id, str_to_bool
+from .utils import create_description_from_et, short_name_as_id
+from .odxtypes import odxstr_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxLinkDatabase, OdxDocFragment
 from .nameditemlist import NamedItemList
 from .globals import logger
@@ -239,13 +240,22 @@ class SingleEcuJob:
     # xsd:attributes inherited from DIAG-COMM (and thus shared with DIAG-SERVICE)
     semantic: Optional[str] = None
     diagnostic_class: Optional[DiagClassType] = None
-    is_mandatory: Optional[bool] = None
-    _is_executable: Optional[bool] = None
+    is_mandatory_raw: Optional[bool] = None
+    is_executable_raw: Optional[bool] = None
+    is_final_raw: Optional[bool] = None
+    sdgs: List[SpecialDataGroup] = field(default_factory=list)
+
+    @property
+    def is_mandatory(self):
+        return self.is_mandatory_raw == True
+
     @property
     def is_executable(self):
-        return self._is_executable in (None, True)
-    is_final: Optional[bool] = None
-    sdgs: List[SpecialDataGroup] = field(default_factory=list)
+        return self.is_executable_raw in (None, True)
+
+    @property
+    def is_final(self):
+        return self.is_final_raw == True
 
     def __post_init__(self) -> None:
         if not self.functional_class_refs:
@@ -302,9 +312,9 @@ class SingleEcuJob:
         ]
 
         # Read boolean flags. Note that the "else" clause contains the default value.
-        is_mandatory = str_to_bool(et_element.get("IS-MANDATORY"))
-        is_executable = str_to_bool(et_element.get("IS-MANDATORY"))
-        is_final = str_to_bool(et_element.get("IS-FINAL"))
+        is_mandatory_raw = odxstr_to_bool(et_element.get("IS-MANDATORY"))
+        is_executable_raw = odxstr_to_bool(et_element.get("IS-MANDATORY"))
+        is_final_raw = odxstr_to_bool(et_element.get("IS-FINAL"))
 
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
@@ -320,9 +330,9 @@ class SingleEcuJob:
                             input_params=input_params,
                             output_params=output_params,
                             neg_output_params=neg_output_params,
-                            is_mandatory=is_mandatory,
-                            _is_executable=is_executable,
-                            is_final=is_final,
+                            is_mandatory_raw=is_mandatory_raw,
+                            is_executable_raw=is_executable_raw,
+                            is_final_raw=is_final_raw,
                             sdgs=sdgs)
 
     @property

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -151,8 +151,7 @@ class BasicStructure(DopBase):
         for param in self.parameters:
             if param == self.parameters[-1]:
                 # The last parameter is at the end of the PDU if the structure itself is at the end of the PDU
-                encode_state = encode_state._replace(
-                    is_end_of_pdu=is_end_of_pdu)
+                encode_state = encode_state._replace(is_end_of_pdu=is_end_of_pdu)
 
             implicit_length_encoding = isinstance(param, LengthKeyParameter) and param.short_name not in param_values
             if implicit_length_encoding:

--- a/odxtools/templates/macros/printAudience.xml.jinja2
+++ b/odxtools/templates/macros/printAudience.xml.jinja2
@@ -19,32 +19,22 @@
 {%- endmacro -%}
 
 {%- macro printAudience(audience) -%}
-<AUDIENCE 
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if not audience.is_supplier %}
-                 IS-SUPPLIER="false"
+<AUDIENCE
+  {%- if audience._is_supplier is not none %}
+                 IS-SUPPLIER="{{bool_to_str(audience._is_supplier)}}"
   {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if not audience.is_development %}
-                 IS-DEVELOPMENT="false"
+  {%- if audience._is_development is not none %}
+                 IS-DEVELOPMENT="{{bool_to_str(audience._is_development)}}"
   {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if not audience.is_manufacturing %}
-                 IS-MANUFACTURING="false"
+  {%- if audience._is_manufactoring is not none %}
+                 IS-MANUFACTORING="{{bool_to_str(audience._is_manufactoring)}}"
   {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if not audience.is_aftersales %}
-                 IS-AFTERSALES="false"
+  {%- if audience._is_aftersales is not none %}
+                 IS-AFTERSALES="{{bool_to_str(audience._is_aftersales)}}"
   {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if not audience.is_aftermarket %}
-                 IS-AFTERMARKET="false"
-  {%- endif %}
- {%- endfilter %} >
+  {%- if audience._is_aftermarket is not none %}
+                 IS-AFTERMARKET="{{bool_to_str(audience._is_aftermarket)}}"
+  {%- endif %} >
 {%- if audience.enabled_audience_refs %}
  <ENABLED-AUDIENCE-REFS>
 {%- for ref in audience.enabled_audience_refs %}

--- a/odxtools/templates/macros/printAudience.xml.jinja2
+++ b/odxtools/templates/macros/printAudience.xml.jinja2
@@ -19,22 +19,11 @@
 {%- endmacro -%}
 
 {%- macro printAudience(audience) -%}
-<AUDIENCE
-  {%- if audience._is_supplier is not none %}
-                 IS-SUPPLIER="{{bool_to_str(audience._is_supplier)}}"
-  {%- endif %}
-  {%- if audience._is_development is not none %}
-                 IS-DEVELOPMENT="{{bool_to_str(audience._is_development)}}"
-  {%- endif %}
-  {%- if audience._is_manufactoring is not none %}
-                 IS-MANUFACTORING="{{bool_to_str(audience._is_manufactoring)}}"
-  {%- endif %}
-  {%- if audience._is_aftersales is not none %}
-                 IS-AFTERSALES="{{bool_to_str(audience._is_aftersales)}}"
-  {%- endif %}
-  {%- if audience._is_aftermarket is not none %}
-                 IS-AFTERMARKET="{{bool_to_str(audience._is_aftermarket)}}"
-  {%- endif %} >
+<AUDIENCE {{-make_bool_xml_attrib("IS-SUPPLIER", audience.is_supplier_raw)}}
+          {{-make_bool_xml_attrib("IS-DEVELOPMENT", audience.is_development_raw)}}
+          {{-make_bool_xml_attrib("IS-MANUFACTORING", audience.is_manufactoring_raw)}}
+          {{-make_bool_xml_attrib("IS-AFTERSALES", audience.is_aftersales_raw)}}
+          {{-make_bool_xml_attrib("IS-AFTERMARKET", audience.is_aftermarket_raw)}}>
 {%- if audience.enabled_audience_refs %}
  <ENABLED-AUDIENCE-REFS>
 {%- for ref in audience.enabled_audience_refs %}

--- a/odxtools/templates/macros/printComparam.xml.jinja2
+++ b/odxtools/templates/macros/printComparam.xml.jinja2
@@ -40,9 +40,7 @@
 <COMPARAM ID="{{cp.odx_id.local_id}}"
           PARAM-CLASS="{{cp.param_class}}"
           CPTYPE="{{cp.cptype}}"
-          {%- if cp.display_level is not none %}
-          DISPLAY-LEVEL="{{cp.display_level}}"
-          {%- endif %}
+         {{make_xml_attrib("DISPLAY-LEVEL", cp.display_level)}}
           CPUSAGE="{{cp.cpusage}}">
  <SHORT-NAME>{{cp.short_name}}</SHORT-NAME>
  {%- if cp.long_name and cp.long_name.strip() %}
@@ -62,16 +60,10 @@
 <COMPLEX-COMPARAM ID="{{cp.odx_id.local_id}}"
                   PARAM-CLASS="{{cp.param_class}}"
                   CPTYPE="{{cp.cptype}}"
-                  {%- if cp.display_level is not none %}
-                  DISPLAY-LEVEL="{{cp.display_level}}"
-                  {%- endif %}
+                 {{make_xml_attrib("DISPLAY-LEVEL", cp.display_level)}}
                   CPUSAGE="{{cp.cpusage}}"
-                  {%- if cp.allow_multiple_values == True %}
-                  ALLOW-MULTIPLE-VALUES="true"
-                  {%- elif cp.allow_multiple_values == False %}
-                  ALLOW-MULTIPLE-VALUES="false"
-                  {%- endif %}
-                  >
+                 {{make_bool_xml_attrib("ALLOW-MULTIPLE-VALUES", cp.allow_multiple_values_raw)}}
+                  {#- #}>
  <SHORT-NAME>{{cp.short_name}}</SHORT-NAME>
  {%- if cp.long_name and cp.long_name.strip() %}
  <LONG-NAME>{{cp.long_name|e}}</LONG-NAME>

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -7,27 +7,11 @@
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printDiagCodedType(dct) -%}
-<DIAG-CODED-TYPE BASE-DATA-TYPE="{{dct.base_data_type.value}}"
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if dct.base_type_encoding %}
-                 BASE-TYPE-ENCODING="{{dct.base_type_encoding}}"
-  {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if dct.termination %}
-                 TERMINATION="{{dct.termination}}"
-  {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if dct.is_highlow_byte_order %}
-                 IS-HIGHLOW-BYTE-ORDER="true"
-  {%- else %}
-                 IS-HIGHLOW-BYTE-ORDER="false"
-  {%- endif %}
- {%- endfilter %}
- {%- filter odxtools_collapse_xml_attribute %}
-                 xsi:type="{{dct.dct_type}}" >
- {%- endfilter %}
+<DIAG-CODED-TYPE {{-make_xml_attrib("BASE-DATA-TYPE", dct.base_data_type.value)}}
+                 {{-make_xml_attrib("BASE-TYPE-ENCODING", dct.base_type_encoding)}}
+                 {{-make_xml_attrib("TERMINATION", dct.termination)}}
+                 {{-make_bool_xml_attrib("IS-HIGHLOW-BYTE-ORDER", dct.is_highlow_byte_order_raw)}}
+                 {#- #} xsi:type="{{dct.dct_type}}">
  {%- if dct.dct_type in ("STANDARD-LENGTH-TYPE", "LEADING-LENGTH-INFO-TYPE") %}
  <BIT-LENGTH>{{dct.bit_length}}</BIT-LENGTH>
  {%- else %}

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -10,37 +10,12 @@
 
 {%- macro printSingleEcuJob(job) -%}
 <SINGLE-ECU-JOB ID="{{job.odx_id.local_id}}"
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if job.oid %}
-                OID="{{job.oid}}"
-  {%- endif %}
- {%- endfilter -%}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if job.semantic %}
-                SEMANTIC="{{job.semantic}}"
-  {%- endif %}
- {%- endfilter -%}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if job.diagnostic_class %}
-                DIAGNOSTIC-CLASS="{{job.diagnostic_class}}"
-  {%- endif %}
- {%- endfilter -%}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if job.is_mandatory %}
-                IS-MANDATORY="true"
-  {%- endif %}
- {%- endfilter -%}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if not job.is_executable %}
-                IS-EXECUTABLE="false"
-  {%- endif %}
- {%- endfilter -%}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if job.is_final %}
-                IS-FINAL="true"
-  {%- endif %}
- {%- endfilter -%}
- >
+                {{-make_xml_attrib("OID", job.oid)}}
+                {{-make_xml_attrib("SEMANTIC", job.semantic)}}
+                {{-make_xml_attrib("DIAGNOSTIC-CLASS", job.diagnostic_class)}}
+                {{-make_bool_xml_attrib("IS-MANDATORY", job.is_mandatory_raw)}}
+                {{-make_bool_xml_attrib("IS-EXECUTABLE", job.is_executable_raw)}}
+                {{-make_bool_xml_attrib("IS-FINAL", job.is_final_raw)}}>
  {{ peid.printElementID(job)|indent(1) }}
  {{- psd.printSpecialDataGroups(job.sdgs)|indent(1, first=True) }}
 {%- if job.functional_class_refs %}
@@ -106,18 +81,8 @@
 
 
 {%- macro printInputParam(param) -%}
-<INPUT-PARAM
-{%- filter odxtools_collapse_xml_attribute %}
-  {%- if param.semantic %}
-                SEMANTIC="{{param.semantic}}"
-  {%- endif %}
- {%- endfilter -%}
-{%- filter odxtools_collapse_xml_attribute %}
-  {%- if param.oid %}
-                OID="{{param.oid}}"
-  {%- endif %}
- {%- endfilter -%}
->
+<INPUT-PARAM {{-make_xml_attrib("OID", param.oid)}}
+             {{-make_xml_attrib("SEMANTIC", param.semantic)}}>
  {{ peid.printElementID(param)|indent(1) }}
 {%- if param.physical_default_value %}
  <PHYSICAL-DEFAULT-VALUE>{{param.physical_default_value}}</PHYSICAL-DEFAULT-VALUE>
@@ -128,17 +93,8 @@
 
 {%- macro printOutputParam(param) -%}
 <OUTPUT-PARAM ID="{{param.odx_id.local_id}}"
-{%- filter odxtools_collapse_xml_attribute %}
-  {%- if param.oid %}
-             OID="{{param.oid}}"
-  {%- endif %}
- {%- endfilter -%}
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if param.semantic %}
-             SEMANTIC="{{param.semantic}}"
-  {%- endif %}
- {%- endfilter -%}
->
+              {{-make_xml_attrib("OID", param.oid)}}
+              {{-make_xml_attrib("SEMANTIC", param.semantic)}}>
  {{ peid.printElementID(param)|indent(1) }}
  <DOP-BASE-REF ID-REF="{{param.dop_base_ref.ref_id}}" />
 </OUTPUT-PARAM>

--- a/odxtools/templates/macros/printSpecialData.xml.jinja2
+++ b/odxtools/templates/macros/printSpecialData.xml.jinja2
@@ -24,11 +24,7 @@
 {%- endmacro %}
 
 {%- macro printSpecialDataGroup(sdg) %}
-<SDG
- {%- if sdg.semantic_info is not none %}
- SI="{{sdg.semantic_info}}"
- {%- endif %}
- {#- -#}>
+<SDG {{-make_xml_attrib("SI", sdg.semantic_info)}}>
  {%- if sdg.sdg_caption_ref %}
  <SDG-CAPTION-REF ID-REF="{{sdg.sdg_caption_ref.ref_id}}" />
  {%- elif sdg.sdg_caption %}

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -8,12 +8,7 @@
 
 {%- macro printTable(table) %}
 <TABLE ID="{{table.odx_id.local_id}}"
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if table.semantic %}
-    SEMANTIC="{{table.semantic}}"
-  {%- endif %}
- {%- endfilter -%}
->
+       {{-make_xml_attrib("SEMANTIC", table.semantic)}}>
  <SHORT-NAME>{{table.short_name}}</SHORT-NAME>
 {%- if table.long_name %}
   <LONG-NAME>{{table.long_name|e}}</LONG-NAME>
@@ -26,12 +21,7 @@
 {%- endif %}
 {%- for table_row in table.table_rows %}
  <TABLE-ROW ID="{{table_row.odx_id.local_id}}"
-  {%- filter odxtools_collapse_xml_attribute %}
-  {%- if table_row.semantic %}
-    SEMANTIC="{{table_row.semantic}}"
-  {%- endif %}
-  {%- endfilter -%}
- >
+            {{-make_xml_attrib("SEMANTIC", table_row.semantic)}}>
   <SHORT-NAME>{{table_row.short_name}}</SHORT-NAME>
   {%- if table_row.long_name %}
   <LONG-NAME>{{table_row.long_name|e}}</LONG-NAME>

--- a/odxtools/templates/macros/printUnitSpec.xml.jinja2
+++ b/odxtools/templates/macros/printUnitSpec.xml.jinja2
@@ -37,11 +37,7 @@
 
 {%- macro printUnit(unit) -%}
 <UNIT ID="{{unit.odx_id.local_id}}"
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if unit.oid %}
-                OID="{{unit.oid}}"
-  {%- endif %}
- {%- endfilter -%}>
+      {{-make_xml_attrib("OID", unit.oid)}}>
  {{ peid.printElementID(unit) }}
  <DISPLAY-NAME>{{ unit.display_name }}</DISPLAY-NAME>
  {%- if unit.factor_si_to_unit is not none %}
@@ -72,11 +68,7 @@
 
 {%- macro printPhysicalDimesion(dim) -%}
 <PHYSICAL-DIMENSION ID="{{dim.odx_id.local_id}}"
- {%- filter odxtools_collapse_xml_attribute %}
-  {%- if dim.oid %}
-                OID="{{dim.oid}}"
-  {%- endif %}
- {%- endfilter -%}>
+                    {{-make_xml_attrib("OID",dim.oid)}}>
  {{ peid.printElementID(dim) }}
  {%- if dim.length_exp %}
  <LENGTH-EXP>{{ dim.length_exp }}</LENGTH-EXP>

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -1,10 +1,28 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
-from typing import Dict, Literal, Optional, Any
+from typing import Dict, Literal, Optional, Any, Union, overload
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment
+
+@overload
+def str_to_bool(str_val: None) -> None: ...
+
+@overload
+def str_to_bool(str_val: str) -> bool: ...
+
+def str_to_bool(str_val: Union[None, str]) -> Union[None, bool]:
+    if str_val is None:
+        return None
+
+    str_val = str_val.strip()
+    assert str_val in ["0", "1", "false", "true"]
+
+    return str_val in ["1", "true"]
+
+def bool_to_str(bool_val: bool) -> str:
+    return "true" if bool_val else "false"
 
 def create_description_from_et(et_element: Optional[ElementTree.Element]) \
  -> Optional[str]:

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -1,28 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
-from typing import Dict, Literal, Optional, Any, Union, overload
+from typing import Dict, Literal, Optional, Any, Union
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment
-
-@overload
-def str_to_bool(str_val: None) -> None: ...
-
-@overload
-def str_to_bool(str_val: str) -> bool: ...
-
-def str_to_bool(str_val: Union[None, str]) -> Union[None, bool]:
-    if str_val is None:
-        return None
-
-    str_val = str_val.strip()
-    assert str_val in ["0", "1", "false", "true"]
-
-    return str_val in ["1", "true"]
-
-def bool_to_str(bool_val: bool) -> str:
-    return "true" if bool_val else "false"
 
 def create_description_from_et(et_element: Optional[ElementTree.Element]) \
  -> Optional[str]:

--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Tuple
 
 from .exceptions import OdxError
 from .comparam_subset import BaseComparam, Comparam, ComplexComparam
+from .utils import bool_to_str
 
 odxdatabase = None
 
@@ -97,6 +98,7 @@ def write_pdx_file(output_file_name : str,
         jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
         jinja_env.globals['hasattr'] = hasattr
         jinja_env.globals['odxraise'] = jinja2_odxraise_helper
+        jinja_env.globals['bool_to_str'] = bool_to_str
 
         # allows to put XML attributes on a separate line while it is
         # collapsed with the previous line in the rendering

--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -9,16 +9,28 @@ import time
 import datetime
 import inspect
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Optional
 
 from .exceptions import OdxError
 from .comparam_subset import BaseComparam, Comparam, ComplexComparam
-from .utils import bool_to_str
+from .odxtypes import bool_to_odxstr
 
 odxdatabase = None
 
 def jinja2_odxraise_helper(msg: str) -> None:
     raise Exception(msg)
+
+def make_xml_attrib(attrib_name: str, attrib_val: Optional[Any]) -> str:
+    if attrib_val is None:
+        return ""
+
+    return f' {attrib_name}="{attrib_val}"'
+
+def make_bool_xml_attrib(attrib_name: str, attrib_val: Optional[bool]) -> str:
+    if attrib_val is None:
+        return ""
+
+    return make_xml_attrib(attrib_name, bool_to_odxstr(attrib_val))
 
 __module_filename = inspect.getsourcefile(odxtools)
 assert isinstance(__module_filename, str)
@@ -98,11 +110,8 @@ def write_pdx_file(output_file_name : str,
         jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
         jinja_env.globals['hasattr'] = hasattr
         jinja_env.globals['odxraise'] = jinja2_odxraise_helper
-        jinja_env.globals['bool_to_str'] = bool_to_str
-
-        # allows to put XML attributes on a separate line while it is
-        # collapsed with the previous line in the rendering
-        jinja_env.filters["odxtools_collapse_xml_attribute"] = lambda x: " "+x.strip() if x.strip() else ""
+        jinja_env.globals['make_xml_attrib'] = make_xml_attrib
+        jinja_env.globals['make_bool_xml_attrib'] = make_bool_xml_attrib
 
         vars: Dict[str, Any] = {}
         vars["odxtools_version"] = odxtools.__version__

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -242,7 +242,7 @@ class TestDecoding(unittest.TestCase):
         odxlinks.update({struct.odx_id: struct})
         eopf = EndOfPduField(OdxLinkId("eopf_id", doc_frags), "eopf_sn",
                              structure=struct,
-                             _is_visible=True)
+                             is_visible_raw=True)
         odxlinks.update({eopf.odx_id: eopf})
 
         req_param2 = ValueParameter("eopf_param", dop=eopf)
@@ -402,7 +402,7 @@ class TestDecoding(unittest.TestCase):
                      physical_type=PhysicalType(DataType.A_UINT32),
                      compu_method=compu_method,
                      dtcs=dtcs,
-                     _is_visible=True)
+                     is_visible_raw=True)
         odxlinks[dop.odx_id] = dop
         resp_param1 = CodedConstParameter(
             "SID", diag_coded_type, coded_value=0x12, byte_position=0)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -242,7 +242,7 @@ class TestDecoding(unittest.TestCase):
         odxlinks.update({struct.odx_id: struct})
         eopf = EndOfPduField(OdxLinkId("eopf_id", doc_frags), "eopf_sn",
                              structure=struct,
-                             is_visible=True)
+                             _is_visible=True)
         odxlinks.update({eopf.odx_id: eopf})
 
         req_param2 = ValueParameter("eopf_param", dop=eopf)
@@ -402,7 +402,7 @@ class TestDecoding(unittest.TestCase):
                      physical_type=PhysicalType(DataType.A_UINT32),
                      compu_method=compu_method,
                      dtcs=dtcs,
-                     is_visible=True)
+                     _is_visible=True)
         odxlinks[dop.odx_id] = dop
         resp_param1 = CodedConstParameter(
             "SID", diag_coded_type, coded_value=0x12, byte_position=0)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -75,7 +75,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         dct = LeadingLengthInfoType("A_UNICODE2STRING",
                                     bit_length=8,
-                                    _is_highlow_byte_order=False)
+                                    is_highlow_byte_order_raw=False)
         state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=0)
@@ -93,7 +93,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         dct = LeadingLengthInfoType("A_UNICODE2STRING",
                                     bit_length=8,
-                                    _is_highlow_byte_order=False)
+                                    is_highlow_byte_order_raw=False)
         byte_val = dct.convert_internal_to_bytes("a9",
                                                  state,
                                                  bit_position=0)
@@ -193,7 +193,7 @@ class TestStandardLengthType(unittest.TestCase):
         self.assertEqual(next_byte, 2)
 
     def test_decode_standard_length_type_uint_byteorder(self):
-        dct = StandardLengthType("A_UINT32", 16, _is_highlow_byte_order=False)
+        dct = StandardLengthType("A_UINT32", 16, is_highlow_byte_order_raw=False)
         state = DecodeState(bytes([0x1, 0x2, 0x3]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=0)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -75,7 +75,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         dct = LeadingLengthInfoType("A_UNICODE2STRING",
                                     bit_length=8,
-                                    is_highlow_byte_order=False)
+                                    _is_highlow_byte_order=False)
         state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=0)
@@ -93,7 +93,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         dct = LeadingLengthInfoType("A_UNICODE2STRING",
                                     bit_length=8,
-                                    is_highlow_byte_order=False)
+                                    _is_highlow_byte_order=False)
         byte_val = dct.convert_internal_to_bytes("a9",
                                                  state,
                                                  bit_position=0)
@@ -193,7 +193,7 @@ class TestStandardLengthType(unittest.TestCase):
         self.assertEqual(next_byte, 2)
 
     def test_decode_standard_length_type_uint_byteorder(self):
-        dct = StandardLengthType("A_UINT32", 16, is_highlow_byte_order=False)
+        dct = StandardLengthType("A_UINT32", 16, _is_highlow_byte_order=False)
         state = DecodeState(bytes([0x1, 0x2, 0x3]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=0)

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -25,7 +25,7 @@ from odxtools.odxtypes import DataType
 from odxtools.physicaltype import PhysicalType
 from odxtools.singleecujob import (InputParam, NegOutputParam, OutputParam,
                                    ProgCode, SingleEcuJob)
-from odxtools.utils import short_name_as_id
+from odxtools.utils import short_name_as_id, bool_to_str
 from odxtools.write_pdx_file import jinja2_odxraise_helper
 
 doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
@@ -150,7 +150,8 @@ class TestSingleEcuJob(unittest.TestCase):
                 <FUNCT-CLASS-REFS>
                     <FUNCT-CLASS-REF ID-REF="{self.singleecujob_object.functional_class_refs[0].ref_id}"/>
                 </FUNCT-CLASS-REFS>
-                <AUDIENCE>
+                <AUDIENCE
+                          IS-MANUFACTORING="false">
                     <ENABLED-AUDIENCE-REFS>
                         <ENABLED-AUDIENCE-REF ID-REF="{cast(Audience, self.singleecujob_object.audience).enabled_audience_refs[0].ref_id}"/>
                     </ENABLED-AUDIENCE-REFS>
@@ -213,6 +214,7 @@ class TestSingleEcuJob(unittest.TestCase):
         jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(templates_dir))
         jinja_env.globals['odxraise'] = jinja2_odxraise_helper
+        jinja_env.globals['bool_to_str'] = bool_to_str
         jinja_env.globals['hasattr'] = hasattr
         jinja_env.filters["odxtools_collapse_xml_attribute"] = (
             lambda x: " " + x.strip() if x.strip() else "")

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -25,8 +25,8 @@ from odxtools.odxtypes import DataType
 from odxtools.physicaltype import PhysicalType
 from odxtools.singleecujob import (InputParam, NegOutputParam, OutputParam,
                                    ProgCode, SingleEcuJob)
-from odxtools.utils import short_name_as_id, bool_to_str
-from odxtools.write_pdx_file import jinja2_odxraise_helper
+from odxtools.utils import short_name_as_id
+from odxtools.write_pdx_file import make_xml_attrib, make_bool_xml_attrib, jinja2_odxraise_helper
 
 doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
@@ -150,8 +150,7 @@ class TestSingleEcuJob(unittest.TestCase):
                 <FUNCT-CLASS-REFS>
                     <FUNCT-CLASS-REF ID-REF="{self.singleecujob_object.functional_class_refs[0].ref_id}"/>
                 </FUNCT-CLASS-REFS>
-                <AUDIENCE
-                          IS-MANUFACTORING="false">
+                <AUDIENCE IS-MANUFACTORING="false">
                     <ENABLED-AUDIENCE-REFS>
                         <ENABLED-AUDIENCE-REF ID-REF="{cast(Audience, self.singleecujob_object.audience).enabled_audience_refs[0].ref_id}"/>
                     </ENABLED-AUDIENCE-REFS>
@@ -214,10 +213,9 @@ class TestSingleEcuJob(unittest.TestCase):
         jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(templates_dir))
         jinja_env.globals['odxraise'] = jinja2_odxraise_helper
-        jinja_env.globals['bool_to_str'] = bool_to_str
+        jinja_env.globals['make_xml_attrib'] = make_xml_attrib
+        jinja_env.globals['make_bool_xml_attrib'] = make_bool_xml_attrib
         jinja_env.globals['hasattr'] = hasattr
-        jinja_env.filters["odxtools_collapse_xml_attribute"] = (
-            lambda x: " " + x.strip() if x.strip() else "")
 
         # Small template
         template = jinja_env.from_string("""
@@ -232,6 +230,7 @@ class TestSingleEcuJob(unittest.TestCase):
         expected = self.singleecujob_odx.replace(" ", "")
 
         # Assert equality of outputted string
+        self.maxDiff = None
         self.assertEqual(expected, actual)
 
         # Assert equality of objects


### PR DESCRIPTION
In ODX, a true value can be specified by either the strings "true" or "1", and a false one by the strings "false" or "0". Also, leading and trailing white space is to be ignored. All of these complications are now dealt with by the new and shiny `str_to_bool()` function. (Suggestions for a better name are appreciated!)

Further, if an attribute of the XML is optional but specified to default to true, `None` must be interpreted as true, which is done by assigning the raw value to a protected attribute `._<foo>` while also defining a property `foo` that returns a boolean...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)