### PR TITLE
use keyword=value to pass constuctor arguments when creating most types of objects

### DIFF
--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -11,7 +11,7 @@ from xml.etree import ElementTree
 from dataclasses import dataclass, field
 from typing import Optional, Any, Dict, List
 
-@dataclass()
+@dataclass
 class CompanyDocInfo:
     company_data_ref: OdxLinkRef
     team_member_ref: Optional[OdxLinkRef] = None
@@ -62,7 +62,7 @@ class CompanyDocInfo:
         for sdg in self.sdgs:
             sdg._resolve_references(odxlinks)
 
-@dataclass()
+@dataclass
 class Modification:
     change: Optional[str] = None
     reason: Optional[str] = None
@@ -77,7 +77,7 @@ class Modification:
         return Modification(change=change,
                             reason=reason)
 
-@dataclass()
+@dataclass
 class CompanyRevisionInfo:
     company_data_ref: OdxLinkRef
     revision_label: Optional[str] = None
@@ -109,7 +109,7 @@ class CompanyRevisionInfo:
         assert isinstance(cd, CompanyData)
         self._company_data = cd
 
-@dataclass()
+@dataclass
 class DocRevision:
     """
     Representation of a single revision of the relevant object.
@@ -165,7 +165,7 @@ class DocRevision:
         for cri in self.company_revision_infos:
             cri._resolve_references(odxlinks)
 
-@dataclass()
+@dataclass
 class AdminData:
     language: Optional[str] = None
     company_doc_infos: List[CompanyDocInfo] = field(default_factory=list)

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -7,7 +7,7 @@ from .utils import create_description_from_et
 from .odxtypes import odxstr_to_bool
 from .odxlink import OdxLinkRef, OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
-@dataclass()
+@dataclass
 class Audience:
     enabled_audience_refs: list = field(default_factory=list)
     disabled_audience_refs: list = field(default_factory=list)
@@ -80,7 +80,7 @@ class Audience:
                                     for ref in self.disabled_audience_refs]
 
 
-@dataclass()
+@dataclass
 class AdditionalAudience:
     """
     Corresponds to ADDITIONAL-AUDIENCE.

--- a/odxtools/communicationparameter.py
+++ b/odxtools/communicationparameter.py
@@ -19,6 +19,7 @@ from .utils import create_description_from_et
 class CommunicationParameterRef:
 
     def __init__(self,
+                 *,
                  value : Union[str, ComplexValue],
                  id_ref: OdxLinkRef,
                  is_functional = False,
@@ -62,8 +63,8 @@ class CommunicationParameterRef:
         if (psnref_elem := et_element.find("PROTOCOL-SNREF")) is not None:
             protocol_snref = psnref_elem.get("SHORT-NAME")
 
-        return CommunicationParameterRef(value,
-                                         id_ref,
+        return CommunicationParameterRef(value=value,
+                                         id_ref=id_ref,
                                          is_functional=is_functional,
                                          description=description,
                                          protocol_snref=protocol_snref,

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -11,7 +11,7 @@ from xml.etree import ElementTree
 from dataclasses import dataclass, field
 from typing import Optional, Any, Dict, List
 
-@dataclass()
+@dataclass
 class XDoc:
     short_name : str
     long_name : Optional[str] = None
@@ -46,7 +46,7 @@ class XDoc:
                     position=position,
                     )
 
-@dataclass()
+@dataclass
 class RelatedDoc:
     description: Optional[str] = None
     xdoc: Optional[XDoc] = None
@@ -63,7 +63,7 @@ class RelatedDoc:
                           )
 
 
-@dataclass()
+@dataclass
 class CompanySpecificInfo:
     related_docs: Optional[List[RelatedDoc]]
     sdgs: List[SpecialDataGroup] = field(default_factory=list)
@@ -95,7 +95,7 @@ class CompanySpecificInfo:
         for sdg in self.sdgs:
             sdg._resolve_references(odxlinks)
 
-@dataclass()
+@dataclass
 class TeamMember:
     odx_id: OdxLinkId
     short_name: str
@@ -149,7 +149,7 @@ class TeamMember:
                           email=email)
 
 
-@dataclass()
+@dataclass
 class CompanyData:
     odx_id: OdxLinkId
     short_name: str

--- a/odxtools/comparam_subset.py
+++ b/odxtools/comparam_subset.py
@@ -68,7 +68,7 @@ class BaseComparam:
         return {self.odx_id: self}
 
 
-@dataclass()
+@dataclass
 class ComplexComparam(BaseComparam):
     comparams: NamedItemList[BaseComparam]
     complex_physical_default_value: Optional[ComplexValue] = field(default=None, init=False)
@@ -117,7 +117,7 @@ class ComplexComparam(BaseComparam):
         return odxlinks
 
 
-@dataclass()
+@dataclass
 class Comparam(BaseComparam):
     dop_ref: OdxLinkRef
     physical_default_value: Optional[str] = field(default=None, init=False)
@@ -158,7 +158,7 @@ class Comparam(BaseComparam):
         assert isinstance(self._dop, DataObjectProperty)
 
 
-@dataclass()
+@dataclass
 class ComparamSubset:
     odx_id: Optional[OdxLinkId]
     short_name: str

--- a/odxtools/compumethods/compumethodbase.py
+++ b/odxtools/compumethods/compumethodbase.py
@@ -11,6 +11,7 @@ from ..odxtypes import DataType
 class CompuMethod:
 
     def __init__(self,
+                 *,
                  internal_type: Union[DataType, str],
                  physical_type: Union[DataType, str],
                  category: str):

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -143,7 +143,7 @@ def create_any_compu_method_from_et(et_element,
             "COMPU-INTERNAL-TO-PHYS/COMPU-SCALES/COMPU-SCALE")
         linear_methods = [_parse_compu_scale_to_linear_compu_method(
             scale, internal_type, physical_type, additional_kwargs=kwargs) for scale in scales]
-        return ScaleLinearCompuMethod(linear_methods)
+        return ScaleLinearCompuMethod(linear_methods=linear_methods)
 
     elif compu_category == "TAB-INTP":
 
@@ -160,4 +160,6 @@ def create_any_compu_method_from_et(et_element,
     # TODO: Implement other categories (never instantiate CompuMethod)
     logger.warning(
         f"Warning: Computation category {compu_category} is not implemented!")
-    return CompuMethod(DataType.A_UINT32, DataType.A_UINT32, f"NOT-IMPLEMENTED:{compu_category}")
+    return CompuMethod(internal_type=DataType.A_UINT32,
+                       physical_type=DataType.A_UINT32,
+                       category=f"NOT-IMPLEMENTED:{compu_category}")

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -11,9 +11,12 @@ from .compumethodbase import CompuMethod
 
 class IdenticalCompuMethod(CompuMethod):
     def __init__(self,
+                 *,
                  internal_type: Union[DataType, str],
                  physical_type: Union[DataType, str]):
-        super().__init__(internal_type, physical_type, "IDENTICAL")
+        super().__init__(internal_type=internal_type,
+                         physical_type=physical_type,
+                         category="IDENTICAL")
 
     def convert_physical_to_internal(self, physical_value):
         return physical_value

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -59,6 +59,7 @@ class LinearCompuMethod(CompuMethod):
     """
 
     def __init__(self,
+                 *,
                  offset,
                  factor,
                  internal_type: Union[DataType, str],
@@ -66,7 +67,9 @@ class LinearCompuMethod(CompuMethod):
                  denominator=1,
                  internal_lower_limit: Optional[Limit] = None,
                  internal_upper_limit: Optional[Limit] = None):
-        super().__init__(internal_type, physical_type, "LINEAR")
+        super().__init__(internal_type=internal_type,
+                         physical_type=physical_type,
+                         category="LINEAR")
         self.offset = offset
         self.factor = factor
         self.denominator = denominator

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -11,10 +11,10 @@ from .linearcompumethod import LinearCompuMethod
 
 
 class ScaleLinearCompuMethod(CompuMethod):
-    def __init__(self, linear_methods: Iterable[LinearCompuMethod]):
-        super().__init__(list(linear_methods)[0].internal_type,
-                         list(linear_methods)[0].physical_type,
-                         "SCALE-LINEAR")
+    def __init__(self, *, linear_methods: Iterable[LinearCompuMethod]):
+        super().__init__(internal_type=list(linear_methods)[0].internal_type,
+                         physical_type=list(linear_methods)[0].physical_type,
+                         category="SCALE-LINEAR")
         self.linear_methods = list(linear_methods)
         logger.debug("Created scale linear compu method!")
 

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -69,11 +69,14 @@ class TabIntpCompuMethod(CompuMethod):
     """
 
     def __init__(self,
+                 *,
                  internal_type: Union[DataType, str],
                  physical_type: Union[DataType, str],
                  internal_points: List[Union[float, int]],
                  physical_points: List[Union[float, int]]):
-        super().__init__(internal_type, physical_type, "TAB-INTP")
+        super().__init__(internal_type=internal_type,
+                         physical_type=physical_type,
+                         category="TAB-INTP")
 
         self.internal_points = internal_points
         self.physical_points = physical_points

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -12,8 +12,10 @@ from .compuscale import CompuScale
 
 
 class TexttableCompuMethod(CompuMethod):
-    def __init__(self, internal_to_phys: List[CompuScale], internal_type):
-        super().__init__(internal_type, DataType.A_UNICODE2STRING, "TEXTTABLE")
+    def __init__(self, *, internal_to_phys: List[CompuScale], internal_type):
+        super().__init__(internal_type=internal_type,
+                         physical_type=DataType.A_UNICODE2STRING,
+                         category="TEXTTABLE")
         self.internal_to_phys = internal_to_phys
 
         assert all(scale.lower_limit is not None or scale.upper_limit is not None

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -26,8 +26,9 @@ class Database:
     """
 
     def __init__(self,
+                 *,
                  pdx_zip: Optional[ZipFile] = None,
-                 odx_d_file_name: Optional[str] = None):
+                 odx_d_file_name: Optional[str] = None) -> None:
 
         if pdx_zip is None and odx_d_file_name is None:
             # create an empty database object

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -29,6 +29,7 @@ class DopBase(abc.ABC):
     """
 
     def __init__(self,
+                 *,
                  odx_id,
                  short_name,
                  long_name=None,
@@ -73,6 +74,7 @@ class DataObjectProperty(DopBase):
     """This class represents a DATA-OBJECT-PROP."""
 
     def __init__(self,
+                 *,
                  odx_id: OdxLinkId,
                  short_name: str,
                  diag_coded_type: DiagCodedType,
@@ -117,11 +119,11 @@ class DataObjectProperty(DopBase):
 
         if et_element.tag == "DATA-OBJECT-PROP":
             unit_ref = OdxLinkRef.from_et(et_element.find("UNIT-REF"), doc_frags)
-            dop = DataObjectProperty(odx_id,
-                                     short_name,
-                                     diag_coded_type,
-                                     physical_type,
-                                     compu_method,
+            dop = DataObjectProperty(odx_id=odx_id,
+                                     short_name=short_name,
+                                     diag_coded_type=diag_coded_type,
+                                     physical_type=physical_type,
+                                     compu_method=compu_method,
                                      unit_ref=unit_ref,
                                      long_name=long_name,
                                      description=description,
@@ -288,7 +290,7 @@ class DtcRef:
     is resolved after loading the pdx database.
     """
 
-    def __init__(self, dtc_ref: OdxLinkRef):
+    def __init__(self, *, dtc_ref: OdxLinkRef):
         self.dtc_ref = dtc_ref
         self.dtc: Optional[DiagnosticTroubleCode] = None
 
@@ -297,7 +299,7 @@ class DtcRef:
         dtc_ref = OdxLinkRef.from_et(et_element, doc_frags)
         assert dtc_ref is not None
 
-        return DtcRef(dtc_ref)
+        return DtcRef(dtc_ref=dtc_ref)
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         dtc = odxlinks.resolve(self.dtc_ref)
@@ -338,6 +340,7 @@ class DtcDop(DataObjectProperty):
     """ A DOP describing a diagnostic trouble code """
 
     def __init__(self,
+                 *,
                  odx_id: OdxLinkId,
                  short_name: str,
                  diag_coded_type: DiagCodedType,

--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -28,6 +28,7 @@ ODX_TYPE_TO_FORMAT_LETTER = {
 
 class DiagCodedType(abc.ABC):
     def __init__(self,
+                 *,
                  base_data_type: Union[str, DataType],
                  dct_type: str,
                  base_type_encoding=None,
@@ -200,11 +201,12 @@ class DiagCodedType(abc.ABC):
 
 class LeadingLengthInfoType(DiagCodedType):
     def __init__(self,
+                 *,
                  base_data_type,
                  bit_length,
                  base_type_encoding=None,
                  is_highlow_byte_order_raw=True):
-        super().__init__(base_data_type,
+        super().__init__(base_data_type=base_data_type,
                          dct_type="LEADING-LENGTH-INFO-TYPE",
                          base_type_encoding=base_type_encoding,
                          is_highlow_byte_order_raw=is_highlow_byte_order_raw)
@@ -273,13 +275,14 @@ class LeadingLengthInfoType(DiagCodedType):
 
 class MinMaxLengthType(DiagCodedType):
     def __init__(self,
+                 *,
                  base_data_type,
                  min_length,
                  termination,
                  max_length=None,
                  base_type_encoding=None,
                  is_highlow_byte_order_raw=None):
-        super().__init__(base_data_type,
+        super().__init__(base_data_type=base_data_type,
                          dct_type="MIN-MAX-LENGTH-TYPE",
                          base_type_encoding=base_type_encoding,
                          is_highlow_byte_order_raw=is_highlow_byte_order_raw)
@@ -414,11 +417,12 @@ class MinMaxLengthType(DiagCodedType):
 
 class ParamLengthInfoType(DiagCodedType):
     def __init__(self,
+                 *,
                  base_data_type: Union[str, DataType],
                  length_key_id: OdxLinkId,
                  base_type_encoding=None,
                  is_highlow_byte_order_raw=True):
-        super().__init__(base_data_type,
+        super().__init__(base_data_type=base_data_type,
                          dct_type="PARAM-LENGTH-INFO-TYPE",
                          base_type_encoding=base_type_encoding,
                          is_highlow_byte_order_raw=is_highlow_byte_order_raw)
@@ -487,13 +491,14 @@ class ParamLengthInfoType(DiagCodedType):
 class StandardLengthType(DiagCodedType):
 
     def __init__(self,
+                 *,
                  base_data_type: Union[str, DataType],
                  bit_length: int,
                  bit_mask = None,
                  condensed: Optional[bool] = None,
                  base_type_encoding = None,
                  is_highlow_byte_order_raw = True):
-        super().__init__(base_data_type,
+        super().__init__(base_data_type=base_data_type,
                          dct_type="STANDARD-LENGTH-TYPE",
                          base_type_encoding=base_type_encoding,
                          is_highlow_byte_order_raw=is_highlow_byte_order_raw)
@@ -547,7 +552,7 @@ def create_any_diag_coded_type_from_et(et_element, doc_frags: List[OdxDocFragmen
     bit_length = None
     if dct_type == "LEADING-LENGTH-INFO-TYPE":
         bit_length = int(et_element.findtext("BIT-LENGTH"))
-        return LeadingLengthInfoType(base_data_type,
+        return LeadingLengthInfoType(base_data_type=base_data_type,
                                      bit_length=bit_length,
                                      base_type_encoding=base_type_encoding,
                                      is_highlow_byte_order_raw=is_highlow_byte_order_raw)
@@ -558,7 +563,7 @@ def create_any_diag_coded_type_from_et(et_element, doc_frags: List[OdxDocFragmen
             max_length = int(et_element.findtext("MAX-LENGTH"))
         termination = et_element.get("TERMINATION")
 
-        return MinMaxLengthType(base_data_type,
+        return MinMaxLengthType(base_data_type=base_data_type,
                                 min_length=min_length,
                                 max_length=max_length,
                                 termination=termination,
@@ -575,8 +580,8 @@ def create_any_diag_coded_type_from_et(et_element, doc_frags: List[OdxDocFragmen
         length_key_elem = et_element.find("LENGTH-KEY-REF")
         length_key_id = OdxLinkId(length_key_elem.attrib["ID-REF"], doc_frags)
 
-        return ParamLengthInfoType(base_data_type,
-                                   length_key_id,
+        return ParamLengthInfoType(base_data_type=base_data_type,
+                                   length_key_id=length_key_id,
                                    base_type_encoding=base_type_encoding,
                                    is_highlow_byte_order_raw=is_highlow_byte_order_raw)
     elif dct_type == "STANDARD-LENGTH-TYPE":
@@ -585,8 +590,8 @@ def create_any_diag_coded_type_from_et(et_element, doc_frags: List[OdxDocFragmen
         if et_element.find("BIT-MASK"):
             bit_mask = et_element.findtext("BIT-MASK")
         condensed = odxstr_to_bool(et_element.get("CONDENSED"))
-        return StandardLengthType(base_data_type,
-                                  bit_length,
+        return StandardLengthType(base_data_type=base_data_type,
+                                  bit_length=bit_length,
                                   bit_mask=bit_mask,
                                   condensed=condensed,
                                   base_type_encoding=base_type_encoding,

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -29,7 +29,7 @@ def _construct_named_item_list(iterable):
     return NamedItemList(short_name_as_id, iterable)
 
 
-@dataclass()
+@dataclass
 class DiagDataDictionarySpec:
     dtc_dops: NamedItemList[DtcDop] = field(
         default_factory=lambda: _construct_named_item_list([])

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -45,6 +45,7 @@ PRIORITY_OF_DIAG_LAYER_TYPE : Dict[DIAG_LAYER_TYPE,int]= {
 class DiagLayer:
     class ParentRef:
         def __init__(self,
+                     *,
                      parent: Union[OdxLinkRef, "DiagLayer"],
                      ref_type: str,
                      not_inherited_diag_comms=[],
@@ -90,7 +91,7 @@ class DiagLayer:
             ref_type = et_element.get(f"{xsi}type")
 
             return DiagLayer.ParentRef(
-                parent_ref,
+                parent=parent_ref,
                 ref_type=ref_type,
                 not_inherited_diag_comms=not_inherited_diag_comms,
                 not_inherited_dops=not_inherited_dops
@@ -133,6 +134,7 @@ class DiagLayer:
             return self.parent_diag_layer._communication_parameters
 
     def __init__(self,
+                 *,
                  variant_type : DIAG_LAYER_TYPE,
                  odx_id,
                  short_name,
@@ -312,9 +314,9 @@ class DiagLayer:
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         # Create DiagLayer
-        return DiagLayer(variant_type,
-                         odx_id,
-                         short_name,
+        return DiagLayer(variant_type=variant_type,
+                         odx_id=odx_id,
+                         short_name=short_name,
                          long_name=long_name,
                          description=description,
                          requests=requests,
@@ -882,6 +884,7 @@ class DiagLayer:
 
 class DiagLayerContainer:
     def __init__(self,
+                 *,
                  odx_id: OdxLinkId,
                  short_name: str,
                  long_name: Optional[str] = None,
@@ -939,8 +942,8 @@ class DiagLayerContainer:
         ecu_variants = [DiagLayer.from_et(dl_element, doc_frags)
                         for dl_element in et_element.iterfind("ECU-VARIANTS/ECU-VARIANT")]
 
-        return DiagLayerContainer(odx_id,
-                                  short_name,
+        return DiagLayerContainer(odx_id=odx_id,
+                                  short_name=short_name,
                                   long_name=long_name,
                                   description=description,
                                   admin_data=admin_data,

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -19,6 +19,7 @@ class EndOfPduField(DopBase):
     """ End of PDU fields are structures that are repeated until the end of the PDU """
 
     def __init__(self,
+                 *,
                  odx_id,
                  short_name,
                  structure=None,
@@ -29,8 +30,11 @@ class EndOfPduField(DopBase):
                  is_visible_raw: Optional[bool] = None,
                  long_name=None,
                  description=None):
-        super().__init__(odx_id, short_name, long_name=long_name,
-                         description=description, is_visible_raw=is_visible_raw)
+        super().__init__(odx_id=odx_id,
+                         short_name=short_name,
+                         long_name=long_name,
+                         description=description,
+                         is_visible_raw=is_visible_raw)
 
         self.structure_snref = structure_snref
         self.structure_ref = structure_ref
@@ -80,8 +84,8 @@ class EndOfPduField(DopBase):
             max_number_of_items = None
 
         is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
-        eopf = EndOfPduField(odx_id,
-                             short_name,
+        eopf = EndOfPduField(odx_id=odx_id,
+                             short_name=short_name,
                              long_name=long_name,
                              description=description,
                              structure_ref=structure_ref,

--- a/odxtools/envdata.py
+++ b/odxtools/envdata.py
@@ -19,15 +19,16 @@ class EnvironmentData(BasicStructure):
     """This class represents Environment Data that describes the circumstances in which the error occurred."""
 
     def __init__(self,
+                 *,
                  odx_id: OdxLinkId,
                  short_name: str,
                  parameters: List[Parameter],
                  dtc_values: Optional[List[int]] = None,
                  long_name: Optional[str] = None,
                  description: Optional[str] = None) -> None:
-        super().__init__(odx_id,
-                         short_name,
-                         parameters,
+        super().__init__(odx_id=odx_id,
+                         short_name=short_name,
+                         parameters=parameters,
                          long_name=long_name,
                          description=description)
         self.dtc_values = dtc_values
@@ -53,8 +54,8 @@ class EnvironmentData(BasicStructure):
                 for dtcv_elem in dtcv_elems.iterfind("DTC-VALUE")
             ]
 
-        return EnvironmentData(odx_id,
-                               short_name,
+        return EnvironmentData(odx_id=odx_id,
+                               short_name=short_name,
                                parameters=parameters,
                                dtc_values=dtc_values,
                                long_name=long_name,

--- a/odxtools/envdatadesc.py
+++ b/odxtools/envdatadesc.py
@@ -18,6 +18,7 @@ class EnvironmentDataDescription(DopBase):
     that is used to define the interpretation of environment data."""
 
     def __init__(self,
+                 *,
                  env_datas: List[EnvironmentData],
                  env_data_refs: List[OdxLinkRef],
                  param_snref: Optional[str] = None,

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -8,7 +8,7 @@ from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
 
-@dataclass()
+@dataclass
 class FunctionalClass:
     """
     Corresponds to FUNCT-CLASS.

--- a/odxtools/message.py
+++ b/odxtools/message.py
@@ -8,6 +8,7 @@ class Message:
     """A CAN message with its interpretation."""
 
     def __init__(self,
+                 *,
                  coded_message: Union[bytes, bytearray],
                  service,
                  structure,

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -12,9 +12,15 @@ from .parameterbase import Parameter
 
 
 class CodedConstParameter(Parameter):
-    def __init__(self, short_name, diag_coded_type: DiagCodedType, coded_value, **kwargs):
-        super().__init__(short_name,
-                         parameter_type="CODED-CONST", **kwargs)
+    def __init__(self,
+                 *,
+                 short_name,
+                 diag_coded_type: DiagCodedType,
+                 coded_value,
+                 **kwargs):
+        super().__init__(short_name=short_name,
+                         parameter_type="CODED-CONST",
+                         **kwargs)
 
         self._diag_coded_type = diag_coded_type
         assert isinstance(coded_value, (int, bytes, bytearray))

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -67,7 +67,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
         physical_constant_value = et_element.findtext(
             "PHYS-CONSTANT-VALUE")
 
-        return PhysicalConstantParameter(short_name,
+        return PhysicalConstantParameter(short_name=short_name,
                                          long_name=long_name,
                                          semantic=semantic,
                                          byte_position=byte_position,
@@ -84,7 +84,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
         coded_value = diag_coded_type.base_data_type.from_string(
             et_element.findtext("CODED-VALUE"))
 
-        return CodedConstParameter(short_name,
+        return CodedConstParameter(short_name=short_name,
                                    long_name=long_name,
                                    semantic=semantic,
                                    diag_coded_type=diag_coded_type,
@@ -100,7 +100,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
         coded_values = [diag_coded_type.base_data_type.from_string(val.text)
                         for val in et_element.iterfind("CODED-VALUES/CODED-VALUE")]
 
-        return NrcConstParameter(short_name,
+        return NrcConstParameter(short_name=short_name,
                                  long_name=long_name,
                                  semantic=semantic,
                                  diag_coded_type=diag_coded_type,
@@ -113,12 +113,12 @@ def create_any_parameter_from_et(et_element, doc_frags):
     elif parameter_type == "RESERVED":
         bit_length = int(et_element.findtext("BIT-LENGTH"))
 
-        return ReservedParameter(short_name,
+        return ReservedParameter(bit_length=bit_length,
+                                 short_name=short_name,
                                  long_name=long_name,
                                  semantic=semantic,
                                  byte_position=byte_position,
                                  bit_position=bit_position,
-                                 bit_length=bit_length,
                                  description=description,
                                  sdgs=sdgs)
 
@@ -127,7 +127,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
         request_byte_pos = int(
             et_element.findtext("REQUEST-BYTE-POS"))
 
-        return MatchingRequestParameter(short_name,
+        return MatchingRequestParameter(short_name=short_name,
                                         long_name=long_name,
                                         semantic=semantic,
                                         byte_position=byte_position, bit_position=bit_position,

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -7,6 +7,7 @@ from .parameterbase import Parameter
 
 class DynamicParameter(Parameter):
     def __init__(self,
+                 *,
                  short_name,
                  long_name=None,
                  byte_position=None,

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -18,6 +18,7 @@ class LengthKeyParameter(ParameterWithDOP):
     """
 
     def __init__(self,
+                 *,
                  short_name,
                  odx_id,
                  dop_ref=None,
@@ -28,7 +29,7 @@ class LengthKeyParameter(ParameterWithDOP):
                  semantic=None,
                  description=None,
                  **kwargs):
-        super().__init__(short_name,
+        super().__init__(short_name=short_name,
                          parameter_type="LENGTH-KEY",
                          dop_ref=dop_ref,
                          dop_snref=dop_snref,

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -10,12 +10,11 @@ from .parameterbase import Parameter
 
 class MatchingRequestParameter(Parameter):
     def __init__(self,
-                 short_name,
+                 *,
                  request_byte_position,
                  byte_length,
                  **kwargs):
-        super().__init__(short_name,
-                         parameter_type="MATCHING-REQUEST-PARAM",
+        super().__init__(parameter_type="MATCHING-REQUEST-PARAM",
                          **kwargs)
         assert byte_length is not None
         assert request_byte_position is not None

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -22,9 +22,15 @@ class NrcConstParameter(Parameter):
     See ASAM MCD-2 D (ODX), p. 77-79.
     """
 
-    def __init__(self, short_name, diag_coded_type: DiagCodedType, coded_values: List[int], **kwargs):
-        super().__init__(short_name,
-                         parameter_type="NRC-CONST", **kwargs)
+    def __init__(self,
+                 *,
+                 short_name,
+                 diag_coded_type: DiagCodedType,
+                 coded_values: List[int],
+                 **kwargs):
+        super().__init__(short_name=short_name,
+                         parameter_type="NRC-CONST",
+                         **kwargs)
 
         self._diag_coded_type = diag_coded_type
         # TODO: Does it have to be an integer or is that just common practice?

--- a/odxtools/parameters/parameterbase.py
+++ b/odxtools/parameters/parameterbase.py
@@ -15,6 +15,7 @@ from ..specialdata import SpecialDataGroup
 
 class Parameter(abc.ABC):
     def __init__(self,
+                 *,
                  short_name: str,
                  parameter_type: str,
                  long_name: Optional[str] = None,

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -16,13 +16,16 @@ from .parameterbase import Parameter
 
 class ParameterWithDOP(Parameter):
     def __init__(self,
+                 *,
                  short_name: str,
                  parameter_type: str,
                  dop=None,
                  dop_ref: Optional[OdxLinkRef] = None,
                  dop_snref: Optional[str] = None,
                  **kwargs):
-        super().__init__(short_name, parameter_type, **kwargs)
+        super().__init__(short_name=short_name,
+                         parameter_type=parameter_type,
+                         **kwargs)
         self.dop_ref = dop_ref
         self.dop_snref = dop_snref
 

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -12,10 +12,10 @@ from .parameterwithdop import ParameterWithDOP
 
 class PhysicalConstantParameter(ParameterWithDOP):
     def __init__(self,
-                 short_name,
+                 *,
                  physical_constant_value,
                  **kwargs):
-        super().__init__(short_name, parameter_type="PHYS-CONST",
+        super().__init__(parameter_type="PHYS-CONST",
                          **kwargs)
         assert physical_constant_value is not None
         self._physical_constant_value = physical_constant_value

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -11,11 +11,10 @@ from .parameterbase import Parameter
 
 class ReservedParameter(Parameter):
     def __init__(self,
-                 short_name,
+                 *,
                  bit_length,
                  **kwargs):
-        super().__init__(short_name,
-                         parameter_type="RESERVED",
+        super().__init__(parameter_type="RESERVED",
                          **kwargs)
         self._bit_length = bit_length
 

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -7,6 +7,7 @@ from .parameterwithdop import ParameterWithDOP
 
 class SystemParameter(ParameterWithDOP):
     def __init__(self,
+                 *,
                  short_name,
                  sysparam,
                  dop_ref=None,

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -6,6 +6,7 @@ from .parameterbase import Parameter
 
 class TableEntryParameter(Parameter):
     def __init__(self,
+                 *,
                  short_name,
                  target,
                  table_row_ref,

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 class TableKeyParameter(Parameter):
     def __init__(self,
+                 *,
                  short_name,
                  table_ref=None,
                  table_snref=None,

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -7,6 +7,7 @@ from .parameterbase import Parameter
 
 class TableStructParameter(Parameter):
     def __init__(self,
+                 *,
                  short_name,
                  table_key_ref=None,
                  table_key_snref=None,

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -10,12 +10,13 @@ from .parameterwithdop import ParameterWithDOP
 
 class ValueParameter(ParameterWithDOP):
     def __init__(self,
+                 *,
                  short_name,
                  physical_default_value_raw=None,
                  dop_ref=None,
                  dop_snref=None,
                  **kwargs):
-        super().__init__(short_name,
+        super().__init__(short_name=short_name,
                          parameter_type="VALUE",
                          dop_ref=dop_ref,
                          dop_snref=dop_snref,

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -21,6 +21,7 @@ from .admindata import AdminData
 
 class DiagService:
     def __init__(self,
+                 *,
                  odx_id: OdxLinkId,
                  short_name: str,
                  request: Union[OdxLinkRef, Request],
@@ -161,11 +162,11 @@ class DiagService:
 
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
-        return DiagService(odx_id,
-                           short_name,
-                           request_ref,
-                           pos_res_refs,
-                           neg_res_refs,
+        return DiagService(odx_id=odx_id,
+                           short_name=short_name,
+                           request=request_ref,
+                           positive_responses=pos_res_refs,
+                           negative_responses=neg_res_refs,
                            long_name=long_name,
                            description=description,
                            admin_data=admin_data,

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -7,7 +7,7 @@ from typing import Optional, List, Dict, Any
 from .utils import create_description_from_et
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
-@dataclass()
+@dataclass
 class State:
     """
     Corresponds to STATE.

--- a/odxtools/state_transition.py
+++ b/odxtools/state_transition.py
@@ -6,7 +6,7 @@ from typing import Optional, List, Dict, Any
 
 from .odxlink import OdxLinkId, OdxDocFragment, OdxLinkDatabase
 
-@dataclass()
+@dataclass
 class StateTransition:
     """
     Corresponds to STATE.

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -34,6 +34,7 @@ ParameterDict = Dict[str, Union[Parameter, "ParameterDict"]]
 
 class BasicStructure(DopBase):
     def __init__(self,
+                 *,
                  odx_id,
                  short_name,
                  parameters: Iterable[Union[Parameter, "EndOfPduField"]],
@@ -41,12 +42,12 @@ class BasicStructure(DopBase):
                  byte_size=None,
                  description=None,
                  sdgs=[]):
-        super().__init__(odx_id,
-                         short_name,
+        super().__init__(odx_id=odx_id,
+                         short_name=short_name,
                          long_name=long_name,
                          description=description,
                          sdgs=sdgs)
-        self.parameters : NamedItemList[Union[Parameter, "EndOfPduField"]] = NamedItemList(short_name_as_id, parameters)
+        self.parameters: NamedItemList[Union[Parameter, "EndOfPduField"]] = NamedItemList(short_name_as_id, parameters)
         self._byte_size = byte_size
 
     @property
@@ -491,6 +492,7 @@ class BasicStructure(DopBase):
 
 class Structure(BasicStructure):
     def __init__(self,
+                 *,
                  odx_id,
                  short_name,
                  parameters,
@@ -498,9 +500,9 @@ class Structure(BasicStructure):
                  byte_size=None,
                  description=None,
                  sdgs=[]):
-        super().__init__(odx_id,
-                         short_name,
-                         parameters,
+        super().__init__(odx_id=odx_id,
+                         short_name=short_name,
+                         parameters=parameters,
                          long_name=long_name,
                          description=description,
                          sdgs=sdgs)
@@ -522,15 +524,16 @@ class Structure(BasicStructure):
 
 class Request(BasicStructure):
     def __init__(self,
+                 *,
                  odx_id,
                  short_name,
                  parameters,
                  long_name=None,
                  description=None,
                  sdgs=[]):
-        super().__init__(odx_id,
-                         short_name,
-                         parameters,
+        super().__init__(odx_id=odx_id,
+                         short_name=short_name,
+                         parameters=parameters,
                          long_name=long_name,
                          description=description,
                          sdgs=sdgs)
@@ -544,6 +547,7 @@ class Request(BasicStructure):
 
 class Response(BasicStructure):
     def __init__(self,
+                 *,
                  odx_id,
                  short_name,
                  parameters,
@@ -551,9 +555,9 @@ class Response(BasicStructure):
                  response_type=None,
                  description=None,
                  sdgs=[]):
-        super().__init__(odx_id,
-                         short_name,
-                         parameters,
+        super().__init__(odx_id=odx_id,
+                         short_name=short_name,
+                         parameters=parameters,
                          long_name=long_name,
                          description=description,
                          sdgs=sdgs)
@@ -597,8 +601,8 @@ def create_any_structure_from_et(et_element,
     res: Union[Structure, Request, Response, None]
     if et_element.tag == "REQUEST":
         res = Request(
-            odx_id,
-            short_name,
+            odx_id=odx_id,
+            short_name=short_name,
             parameters=parameters,
             long_name=long_name,
             description=description,
@@ -606,8 +610,8 @@ def create_any_structure_from_et(et_element,
         )
     elif et_element.tag in ["POS-RESPONSE", "NEG-RESPONSE"]:
         res = Response(
-            odx_id,
-            short_name,
+            odx_id=odx_id,
+            short_name=short_name,
             response_type=et_element.tag,
             parameters=parameters,
             long_name=long_name,
@@ -618,8 +622,8 @@ def create_any_structure_from_et(et_element,
         byte_size_text = et_element.findtext("BYTE-SIZE")
         byte_size = int(byte_size_text) if byte_size_text is not None else None
         res = Structure(
-            odx_id,
-            short_name,
+            odx_id=odx_id,
+            short_name=short_name,
             parameters=parameters,
             byte_size=byte_size,
             long_name=long_name,

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -17,6 +17,7 @@ class TableBase(abc.ABC):
     """ Base class for all Tables."""
 
     def __init__(self,
+                 *,
                  odx_id: OdxLinkId,
                  short_name: str,
                  long_name=None,
@@ -131,18 +132,18 @@ class TableRow:
 class Table(TableBase):
     """This class represents a TABLE."""
 
-    def __init__(
-        self,
-        odx_id: OdxLinkId,
-        short_name: str,
-        table_rows: List[TableRow],
-        table_row_refs: Optional[List[OdxLinkRef]] = None,
-        long_name: Optional[str] = None,
-        key_dop_ref: Optional[OdxLinkRef] = None,
-        description: Optional[str] = None,
-        semantic: Optional[str] = None,
-        sdgs: List[SpecialDataGroup] = [],
-    ):
+    def __init__(self,
+                 *,
+                 odx_id: OdxLinkId,
+                 short_name: str,
+                 table_rows: List[TableRow],
+                 table_row_refs: Optional[List[OdxLinkRef]] = None,
+                 long_name: Optional[str] = None,
+                 key_dop_ref: Optional[OdxLinkRef] = None,
+                 description: Optional[str] = None,
+                 semantic: Optional[str] = None,
+                 sdgs: List[SpecialDataGroup] = [],
+                 ):
         super().__init__(odx_id=odx_id,
                          short_name=short_name,
                          long_name=long_name,

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -19,7 +19,10 @@ doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
 class TestLinearCompuMethod(unittest.TestCase):
     def test_linear_compu_method_type_int_int(self):
-        compu_method = LinearCompuMethod(1, 3, "A_INT32", "A_INT32")
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=3,
+                                         internal_type="A_INT32",
+                                         physical_type="A_INT32")
 
         self.assertEqual(compu_method.convert_internal_to_physical(4), 13)
         self.assertEqual(compu_method.convert_internal_to_physical(0), 1)
@@ -30,7 +33,10 @@ class TestLinearCompuMethod(unittest.TestCase):
         self.assertEqual(compu_method.convert_physical_to_internal(-5), -2)
 
     def test_linear_compu_method_type_int_float(self):
-        compu_method = LinearCompuMethod(1, 3, "A_INT32", "A_FLOAT32")
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=3,
+                                         internal_type="A_INT32",
+                                         physical_type="A_FLOAT32")
         self.assertTrue(compu_method.is_valid_internal_value(123))
         self.assertFalse(compu_method.is_valid_internal_value("123"))
         self.assertFalse(compu_method.is_valid_internal_value(1.2345))
@@ -40,7 +46,10 @@ class TestLinearCompuMethod(unittest.TestCase):
         self.assertFalse(compu_method.is_valid_physical_value("123"))
 
     def test_linear_compu_method_type_float_int(self):
-        compu_method = LinearCompuMethod(1, 3, "A_FLOAT32", "A_INT32")
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=3,
+                                         internal_type="A_FLOAT32",
+                                         physical_type="A_INT32")
         self.assertTrue(compu_method.is_valid_internal_value(1.2345))
         self.assertTrue(compu_method.is_valid_internal_value(123))
         self.assertFalse(compu_method.is_valid_internal_value("123"))
@@ -50,14 +59,19 @@ class TestLinearCompuMethod(unittest.TestCase):
         self.assertFalse(compu_method.is_valid_physical_value(1.2345))
 
     def test_linear_compu_method_type_string(self):
-        compu_method = LinearCompuMethod(
-            1, 3, "A_ASCIISTRING", "A_UNICODE2STRING")
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=3,
+                                         internal_type="A_ASCIISTRING",
+                                         physical_type="A_UNICODE2STRING")
         self.assertTrue(compu_method.is_valid_internal_value("123"))
         self.assertFalse(compu_method.is_valid_internal_value(123))
         self.assertFalse(compu_method.is_valid_internal_value(1.2345))
 
     def test_linear_compu_method_limits(self):
-        compu_method = LinearCompuMethod(1, 5, "A_INT32", "A_INT32",
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=5,
+                                         internal_type="A_INT32",
+                                         physical_type="A_INT32",
                                          internal_lower_limit=Limit(2),
                                          internal_upper_limit=Limit(15))
         self.assertFalse(compu_method.is_valid_internal_value(-3))
@@ -80,7 +94,10 @@ class TestLinearCompuMethod(unittest.TestCase):
 
     def test_linear_compu_method_physical_limits(self):
         # Define decoding function: f: (2, 15] -> [-74, -14], f(x) = -5*x + 1
-        compu_method = LinearCompuMethod(1, -5, "A_INT32", "A_INT32",
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=-5,
+                                         internal_type="A_INT32",
+                                         physical_type="A_INT32",
                                          internal_lower_limit=Limit(2,
                                                                     interval_type=IntervalType.OPEN),
                                          internal_upper_limit=Limit(15))
@@ -124,8 +141,8 @@ class TestTabIntpCompuMethod(unittest.TestCase):
 
         self.jinja_env = _get_jinja_environment()
 
-        self.compumethod = TabIntpCompuMethod(DataType.A_INT32,
-                                              DataType.A_FLOAT32,
+        self.compumethod = TabIntpCompuMethod(internal_type=DataType.A_INT32,
+                                              physical_type=DataType.A_FLOAT32,
                                               internal_points=[0, 10, 30],
                                               physical_points=[-1, 1, 2]
                                               )

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -27,13 +27,19 @@ doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
 class TestIdentifyingService(unittest.TestCase):
     def test_prefix_tree_construction(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        diag_coded_type_2 = StandardLengthType("A_UINT32", 16)
-        req_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x7d, byte_position=0)
-        req_param2 = CodedConstParameter(
-            "coded_const_parameter_2", diag_coded_type, coded_value=0xab, byte_position=1)
-        req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        diag_coded_type_2 = StandardLengthType(base_data_type="A_UINT32", bit_length=16)
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x7d,
+                                         byte_position=0)
+        req_param2 = CodedConstParameter(short_name="coded_const_parameter_2",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0xab,
+                                         byte_position=1)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2])
         odxlinks = OdxLinkDatabase()
         odxlinks.update({req.odx_id: req})
         service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
@@ -42,15 +48,21 @@ class TestIdentifyingService(unittest.TestCase):
                               positive_responses=[],
                               negative_responses=[])
 
-        req2_param2 = CodedConstParameter(
-            "coded_const_parameter_3", diag_coded_type_2, coded_value=0xcde)
-        req2 = Request(OdxLinkId("request_id2", doc_frags), "request_sn2", [req_param1, req2_param2])
+        req2_param2 = CodedConstParameter(short_name="coded_const_parameter_3",
+                                          diag_coded_type=diag_coded_type_2,
+                                          coded_value=0xcde)
+        req2 = Request(odx_id=OdxLinkId("request_id2", doc_frags),
+                       short_name="request_sn2",
+                       parameters=[req_param1, req2_param2])
         odxlinks.update({req2.odx_id: req2})
 
-        resp2_param2 = CodedConstParameter(
-            "coded_const_parameter_4", diag_coded_type_2, coded_value=0xc86)
-        resp2 = Response(OdxLinkId("response_id2", doc_frags), "response_sn2",
-                         [req_param1, resp2_param2])
+        resp2_param2 = CodedConstParameter(short_name="coded_const_parameter_4",
+                                           diag_coded_type=diag_coded_type_2,
+                                           coded_value=0xc86)
+        resp2 = Response(odx_id=OdxLinkId("response_id2", doc_frags),
+                         short_name="response_sn2",
+                         response_type="NEG-RESPONSE",
+                         parameters=[req_param1, resp2_param2])
         odxlinks.update({resp2.odx_id: resp2})
 
         service2 = DiagService(odx_id=OdxLinkId("service_id2", doc_frags),
@@ -59,7 +71,7 @@ class TestIdentifyingService(unittest.TestCase):
                                positive_responses=[resp2],
                                negative_responses=[])
 
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service, service2],
@@ -78,14 +90,18 @@ class TestIdentifyingService(unittest.TestCase):
 
 class TestDecoding(unittest.TestCase):
     def test_decode_request_coded_const(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        req_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x7d, byte_position=0)
-        req_param2 = CodedConstParameter(
-            "coded_const_parameter_2", diag_coded_type, coded_value=0xab, byte_position=1)
-        req = Request(OdxLinkId("request_id", doc_frags),
-                      "request_sn",
-                      [req_param1, req_param2])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x7d,
+                                         byte_position=0)
+        req_param2 = CodedConstParameter(short_name="coded_const_parameter_2",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0xab,
+                                         byte_position=1)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2])
 
         odxlinks = OdxLinkDatabase()
         odxlinks.update({req.odx_id: req})
@@ -94,7 +110,7 @@ class TestDecoding(unittest.TestCase):
                               request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
@@ -103,8 +119,12 @@ class TestDecoding(unittest.TestCase):
                                odxlinks=odxlinks)
 
         coded_message = bytes([0x7d, 0xab])
-        expected_message = Message(coded_message, service, req, param_dict={"SID": 0x7d,
-                                                                            "coded_const_parameter_2": 0xab})
+        expected_message = Message(coded_message=coded_message,
+                                   service=service,
+                                   structure=req,
+                                   param_dict={
+                                       "SID": 0x7d,
+                                       "coded_const_parameter_2": 0xab})
         decoded_message = diag_layer.decode(coded_message)[0]
 
         self.assertEqual(expected_message.coded_message,
@@ -118,17 +138,25 @@ class TestDecoding(unittest.TestCase):
         """Test decoding of parameter
         Test if the decoding works if the byte position of the second parameter
         must be inferred from the order in the surrounding structure."""
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        req_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x12, byte_position=0)
-        req_param2 = CodedConstParameter(
-            "coded_const_parameter_2", diag_coded_type, coded_value=0x56, byte_position=2)
-        req_param3 = CodedConstParameter(
-            "coded_const_parameter_3", diag_coded_type, coded_value=0x34, byte_position=1)
-        req_param4 = CodedConstParameter(
-            "coded_const_parameter_4", diag_coded_type, coded_value=0x78)
-        req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
-                      req_param1, req_param2, req_param3, req_param4])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x12,
+                                         byte_position=0)
+        req_param2 = CodedConstParameter(short_name="coded_const_parameter_2",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x56,
+                                         byte_position=2)
+        req_param3 = CodedConstParameter(short_name="coded_const_parameter_3",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x34,
+                                         byte_position=1)
+        req_param4 = CodedConstParameter(short_name="coded_const_parameter_4",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x78)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2, req_param3, req_param4])
 
         odxlinks = OdxLinkDatabase()
         odxlinks.update({req.odx_id: req})
@@ -137,7 +165,7 @@ class TestDecoding(unittest.TestCase):
                               request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
@@ -147,10 +175,14 @@ class TestDecoding(unittest.TestCase):
                              0x12: {0x34: {0x56: {0x78: {-1: [service]}}}}})
 
         coded_message = bytes([0x12, 0x34, 0x56, 0x78])
-        expected_message = Message(coded_message, service, req, param_dict={"SID": 0x12,
-                                                                            "coded_const_parameter_2": 0x56,
-                                                                            "coded_const_parameter_3": 0x34,
-                                                                            "coded_const_parameter_4": 0x78})
+        expected_message = Message(coded_message=coded_message,
+                                   service=service,
+                                   structure=req,
+                                   param_dict={
+                                       "SID": 0x12,
+                                       "coded_const_parameter_2": 0x56,
+                                       "coded_const_parameter_3": 0x34,
+                                       "coded_const_parameter_4": 0x78})
         decoded_message = diag_layer.decode(coded_message)[0]
         self.assertEqual(expected_message.coded_message,
                          decoded_message.coded_message)
@@ -162,40 +194,49 @@ class TestDecoding(unittest.TestCase):
     def test_decode_request_structure(self):
         """Test the decoding for a structure."""
         odxlinks = OdxLinkDatabase()
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        diag_coded_type_4 = StandardLengthType("A_UINT32", 4)
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        diag_coded_type_4 = StandardLengthType(base_data_type="A_UINT32", bit_length=4)
 
-        compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
-        dop = DataObjectProperty(OdxLinkId("dop.odx_id", doc_frags),
-                                 "dop_sn",
-                                 diag_coded_type_4,
+        compu_method = IdenticalCompuMethod(internal_type="A_INT32",
+                                            physical_type="A_INT32")
+        dop = DataObjectProperty(odx_id=OdxLinkId("dop.odx_id", doc_frags),
+                                 short_name="dop_sn",
+                                 diag_coded_type=diag_coded_type_4,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
         odxlinks.update({dop.odx_id: dop})
 
-        req_param1 = CodedConstParameter("SID",
-                                         diag_coded_type,
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
                                          coded_value=0x12,
                                          byte_position=0)
 
-        struct_param1 = CodedConstParameter(
-            "struct_param_1", diag_coded_type_4, coded_value=0x4, byte_position=0, bit_position=0)
-        struct_param2 = ValueParameter(
-            "struct_param_2", dop=dop, byte_position=0, bit_position=4)
-        struct = Structure(OdxLinkId("struct_id", doc_frags), "struct", [
-                           struct_param1, struct_param2])
+        struct_param1 = CodedConstParameter(short_name="struct_param_1",
+                                            diag_coded_type=diag_coded_type_4,
+                                            coded_value=0x4,
+                                            byte_position=0,
+                                            bit_position=0)
+        struct_param2 = ValueParameter(short_name="struct_param_2",
+                                       dop=dop,
+                                       byte_position=0,
+                                       bit_position=4)
+        struct = Structure(odx_id=OdxLinkId("struct_id", doc_frags),
+                           short_name="struct",
+                           parameters=[struct_param1, struct_param2])
         odxlinks.update({struct.odx_id: struct})
-        req_param2 = ValueParameter("structured_param", dop=struct)
+        req_param2 = ValueParameter(short_name="structured_param",
+                                    dop=struct)
 
-        req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
-                      req_param1, req_param2])
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2])
         odxlinks.update({req.odx_id: req})
         service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
                               request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
@@ -203,9 +244,14 @@ class TestDecoding(unittest.TestCase):
                                odxlinks=odxlinks)
 
         coded_message = bytes([0x12, 0x34])
-        expected_message = Message(coded_message, service, req,
-                                   param_dict={"SID": 0x12,
-                                               "structured_param": {"struct_param_1": 4, "struct_param_2": 3}})
+        expected_message = Message(coded_message=coded_message,
+                                   service=service,
+                                   structure=req,
+                                   param_dict={
+                                       "SID": 0x12,
+                                       "structured_param": {
+                                           "struct_param_1": 4,
+                                           "struct_param_2": 3}})
         decoded_message = diag_layer.decode(coded_message)[0]
         self.assertEqual(expected_message.coded_message,
                          decoded_message.coded_message)
@@ -217,45 +263,54 @@ class TestDecoding(unittest.TestCase):
     def test_decode_request_end_of_pdu_field(self):
         """Test the decoding for a structure."""
         odxlinks = OdxLinkDatabase()
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        diag_coded_type_4 = StandardLengthType("A_UINT32", 4)
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        diag_coded_type_4 = StandardLengthType(base_data_type="A_UINT32", bit_length=4)
 
-        compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
-        dop = DataObjectProperty(OdxLinkId("dop.odx_id", doc_frags),
-                                 "dop_sn",
-                                 diag_coded_type_4,
+        compu_method = IdenticalCompuMethod(internal_type="A_INT32",
+                                            physical_type="A_INT32")
+        dop = DataObjectProperty(odx_id=OdxLinkId("dop.odx_id", doc_frags),
+                                 short_name="dop_sn",
+                                 diag_coded_type=diag_coded_type_4,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
         odxlinks.update({dop.odx_id: dop})
 
-        req_param1 = CodedConstParameter("SID",
-                                         diag_coded_type,
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
                                          coded_value=0x12,
                                          byte_position=0)
 
-        struct_param1 = CodedConstParameter(
-            "struct_param_1", diag_coded_type_4, coded_value=0x4, byte_position=0, bit_position=0)
-        struct_param2 = ValueParameter(
-            "struct_param_2", dop=dop, byte_position=0, bit_position=4)
-        struct = Structure(OdxLinkId("struct_id", doc_frags), "struct", [
-                           struct_param1, struct_param2])
+        struct_param1 = CodedConstParameter(short_name="struct_param_1",
+                                            diag_coded_type=diag_coded_type_4,
+                                            coded_value=0x4,
+                                            byte_position=0,
+                                            bit_position=0)
+        struct_param2 = ValueParameter(short_name="struct_param_2",
+                                       dop=dop,
+                                       byte_position=0,
+                                       bit_position=4)
+        struct = Structure(odx_id=OdxLinkId("struct_id", doc_frags),
+                           short_name="struct",
+                           parameters=[struct_param1, struct_param2])
         odxlinks.update({struct.odx_id: struct})
-        eopf = EndOfPduField(OdxLinkId("eopf_id", doc_frags), "eopf_sn",
+        eopf = EndOfPduField(odx_id=OdxLinkId("eopf_id", doc_frags),
+                             short_name="eopf_sn",
                              structure=struct,
                              is_visible_raw=True)
         odxlinks.update({eopf.odx_id: eopf})
 
-        req_param2 = ValueParameter("eopf_param", dop=eopf)
+        req_param2 = ValueParameter(short_name="eopf_param", dop=eopf)
 
-        req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [
-                      req_param1, req_param2])
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2])
         odxlinks.update({req.odx_id: req})
         service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
                               short_name="service_sn",
                               request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
@@ -263,10 +318,14 @@ class TestDecoding(unittest.TestCase):
                                odxlinks=odxlinks)
 
         coded_message = bytes([0x12, 0x34, 0x34])
-        expected_message = Message(coded_message, service, req,
-                                   param_dict={"SID": 0x12,
-                                               "eopf_param": [{"struct_param_1": 4, "struct_param_2": 3},
-                                                              {"struct_param_1": 4, "struct_param_2": 3}]})
+        expected_message = Message(coded_message=coded_message,
+                                   service=service,
+                                   structure=req,
+                                   param_dict={
+                                       "SID": 0x12,
+                                       "eopf_param": [
+                                           {"struct_param_1": 4, "struct_param_2": 3},
+                                           {"struct_param_1": 4, "struct_param_2": 3}]})
         decoded_message = diag_layer.decode(coded_message)[0]
         self.assertEqual(expected_message.coded_message,
                          decoded_message.coded_message)
@@ -278,22 +337,27 @@ class TestDecoding(unittest.TestCase):
     def test_decode_request_linear_compu_method(self):
         odxlinks = OdxLinkDatabase()
 
-        compu_method = LinearCompuMethod(1, 5, "A_INT32", "A_INT32")
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        dop = DataObjectProperty(OdxLinkId("linear.dop.odx_id", doc_frags),
-                                 "linear.dop.sn",
-                                 diag_coded_type,
+        compu_method = LinearCompuMethod(offset=1,
+                                         factor=5,
+                                         internal_type="A_INT32",
+                                         physical_type="A_INT32")
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        dop = DataObjectProperty(odx_id=OdxLinkId("linear.dop.odx_id", doc_frags),
+                                 short_name="linear.dop.sn",
+                                 diag_coded_type=diag_coded_type,
                                  physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
         odxlinks.update({dop.odx_id: dop})
-        req_param1 = CodedConstParameter("SID",
-                                         diag_coded_type,
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
                                          coded_value=0x7d,
                                          byte_position=0)
-        req_param2 = ValueParameter("value_parameter_2",
+        req_param2 = ValueParameter(short_name="value_parameter_2",
                                     dop=dop,
                                     byte_position=1)
-        req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2])
 
         odxlinks.update({req.odx_id: req})
         service = DiagService(odx_id=OdxLinkId("service_id", doc_frags),
@@ -301,7 +365,7 @@ class TestDecoding(unittest.TestCase):
                               request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[],
                               negative_responses=[])
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
@@ -311,11 +375,12 @@ class TestDecoding(unittest.TestCase):
 
         coded_message = bytes([0x7d, 0x12])
         # The physical value of the second parameter is decode(0x12) = decode(18) = 5 * 18 + 1 = 91
-        expected_message = Message(coded_message,
-                                   service,
-                                   req,
-                                   param_dict={"SID": 0x7d,
-                                               "value_parameter_2": 91})
+        expected_message = Message(coded_message=coded_message,
+                                   service=service,
+                                   structure=req,
+                                   param_dict={
+                                       "SID": 0x7d,
+                                       "value_parameter_2": 91})
         decoded_message = diag_layer.decode(coded_message)[0]
         self.assertEqual(expected_message.coded_message,
                          decoded_message.coded_message)
@@ -327,26 +392,40 @@ class TestDecoding(unittest.TestCase):
                          decoded_message.param_dict)
 
     def test_decode_response(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        req_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x12, byte_position=0)
-        req_param2 = CodedConstParameter(
-            "req_param", diag_coded_type, coded_value=0xab, byte_position=1)
-        req = Request(OdxLinkId("request_id", doc_frags), "request_sn", [req_param1, req_param2])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x12,
+                                         byte_position=0)
+        req_param2 = CodedConstParameter(short_name="req_param",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0xab,
+                                         byte_position=1)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[req_param1, req_param2])
 
-        resp_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x34, byte_position=0)
-        resp_param2 = MatchingRequestParameter(
-            "matching_req_param", request_byte_position=1, byte_length=1)
-        pos_response = Response(OdxLinkId("pos_response_id", doc_frags), "pos_response_sn", [
-                                resp_param1, resp_param2])
+        resp_param1 = CodedConstParameter(short_name="SID",
+                                          diag_coded_type=diag_coded_type,
+                                          coded_value=0x34,
+                                          byte_position=0)
+        resp_param2 = MatchingRequestParameter(short_name="matching_req_param",
+                                               request_byte_position=1,
+                                               byte_length=1)
+        pos_response = Response(odx_id=OdxLinkId("pos_response_id", doc_frags),
+                                short_name="pos_response_sn",
+                                parameters=[resp_param1, resp_param2])
 
-        resp_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x56, byte_position=0)
-        resp_param2 = MatchingRequestParameter(
-            "matching_req_param", request_byte_position=1, byte_length=1)
-        neg_response = Response(OdxLinkId("neg_response_id", doc_frags), "neg_response_sn", [
-                                resp_param1, resp_param2])
+        resp_param1 = CodedConstParameter(short_name="SID",
+                                          diag_coded_type=diag_coded_type,
+                                          coded_value=0x56,
+                                          byte_position=0)
+        resp_param2 = MatchingRequestParameter(short_name="matching_req_param",
+                                               request_byte_position=1,
+                                               byte_length=1)
+        neg_response = Response(odx_id=OdxLinkId("neg_response_id", doc_frags),
+                                short_name="neg_response_sn",
+                                parameters=[resp_param1, resp_param2])
 
         odxlinks = OdxLinkDatabase()
         odxlinks.update({req.odx_id: req,
@@ -357,7 +436,7 @@ class TestDecoding(unittest.TestCase):
                               request=OdxLinkRef.from_id(req.odx_id),
                               positive_responses=[OdxLinkRef.from_id(pos_response.odx_id)],
                               negative_responses=[OdxLinkRef.from_id(neg_response.odx_id)])
-        diag_layer = DiagLayer(DIAG_LAYER_TYPE.BASE_VARIANT,
+        diag_layer = DiagLayer(variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
                                odx_id=OdxLinkId("dl_id", doc_frags),
                                short_name="dl_sn",
                                services=[service],
@@ -368,8 +447,12 @@ class TestDecoding(unittest.TestCase):
 
         for sid, message in [(0x34, pos_response), (0x56, neg_response)]:
             coded_message = bytes([sid, 0xab])
-            expected_message = Message(coded_message, service, message,
-                                       param_dict={"SID": sid, "matching_req_param": bytes([0xab])})
+            expected_message = Message(coded_message=coded_message,
+                                       service=service,
+                                       structure=message,
+                                       param_dict={
+                                           "SID": sid,
+                                           "matching_req_param": bytes([0xab])})
             decoded_message = diag_layer.decode(coded_message)[0]
             self.assertEqual(expected_message.coded_message,
                              decoded_message.coded_message)
@@ -381,8 +464,9 @@ class TestDecoding(unittest.TestCase):
 
     def test_decode_dtc(self):
         odxlinks = {}
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        compu_method = IdenticalCompuMethod("A_INT32", "A_INT32")
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        compu_method = IdenticalCompuMethod(internal_type="A_INT32",
+                                            physical_type="A_INT32")
 
         dtc1 = DiagnosticTroubleCode(odx_id=OdxLinkId("dtcID1", doc_frags),
                                      short_name="P34_sn",
@@ -396,20 +480,25 @@ class TestDecoding(unittest.TestCase):
                                      text="Crashed into wall",
                                      display_trouble_code="P56")
         dtcs = [dtc1, dtc2]
-        dop = DtcDop(OdxLinkId("dtc.dop.odx_id", doc_frags),
-                     "dtc_dop_sn",
-                     diag_coded_type,
+        dop = DtcDop(odx_id=OdxLinkId("dtc.dop.odx_id", doc_frags),
+                     short_name="dtc_dop_sn",
+                     diag_coded_type=diag_coded_type,
                      physical_type=PhysicalType(DataType.A_UINT32),
                      compu_method=compu_method,
                      dtcs=dtcs,
                      is_visible_raw=True)
         odxlinks[dop.odx_id] = dop
-        resp_param1 = CodedConstParameter(
-            "SID", diag_coded_type, coded_value=0x12, byte_position=0)
-        resp_param2 = ValueParameter(
-            "DTC_Param", dop=dop, byte_position=1)
-        pos_response = Response("pos_response_id", "pos_response_sn",
-                                [resp_param1, resp_param2])
+        resp_param1 = CodedConstParameter(short_name="SID",
+                                          diag_coded_type=diag_coded_type,
+                                          coded_value=0x12,
+                                          byte_position=0)
+        resp_param2 = ValueParameter(short_name="DTC_Param",
+                                     dop=dop,
+                                     byte_position=1)
+        pos_response = Response(odx_id=OdxLinkId("pos_response_id", doc_frags),
+                                short_name="pos_response_sn",
+                                parameters=[resp_param1, resp_param2],
+                                response_type="POS-RESPONSE")
 
         coded_message = bytes([0x12, 0x34])
         decoded_param_dict = pos_response.decode(coded_message)
@@ -424,7 +513,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
             DataObjectProperty(
                 odx_id=OdxLinkId("DOP_ID", doc_frags),
                 short_name="DOP",
-                diag_coded_type=MinMaxLengthType(DataType.A_BYTEFIELD,
+                diag_coded_type=MinMaxLengthType(base_data_type=DataType.A_BYTEFIELD,
                                                  min_length=0,
                                                  termination='END-OF-PDU'),
                 physical_type=PhysicalType(DataType.A_BYTEFIELD),
@@ -436,11 +525,11 @@ class TestDecodingAndEncoding(unittest.TestCase):
             dop=self.dop_bytes_termination_end_of_pdu
         )
 
-        self.parameter_sid = CodedConstParameter(
-            short_name="SID",
-            diag_coded_type=StandardLengthType("A_UINT32", 8),
-            coded_value=0x12,
-            byte_position=0
+        self.parameter_sid = CodedConstParameter(short_name="SID",
+                                                 diag_coded_type=StandardLengthType(base_data_type="A_UINT32",
+                                                                                    bit_length=8),
+                                                 coded_value=0x12,
+                                                 byte_position=0
         )
 
     def test_min_max_length_type_end_of_pdu(self):
@@ -505,7 +594,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         self.assertEqual(actual_coded_message, expected_coded_message)
 
     def test_physical_constant_parameter(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
         offset = 0x34
         dop = DataObjectProperty(
             odx_id=OdxLinkId("DOP_ID", doc_frags),
@@ -519,25 +608,22 @@ class TestDecodingAndEncoding(unittest.TestCase):
                 physical_type=DataType.A_INT32
             )
         )
-        req_param1 = CodedConstParameter(
-            short_name="SID",
-            diag_coded_type=diag_coded_type,
-            coded_value=0x12,
-            byte_position=0
-        )
-        req_param2 = PhysicalConstantParameter(
-            short_name="physical_constant_parameter",
-            physical_constant_value=offset,
-            dop=dop
-        )
-        request = Request(
-            odx_id=OdxLinkId("request", doc_frags),
-            short_name="Request",
-            parameters=[
-                req_param1,
-                req_param2
-            ]
-        )
+        req_param1 = CodedConstParameter(short_name="SID",
+                                         diag_coded_type=diag_coded_type,
+                                         coded_value=0x12,
+                                         byte_position=0
+                                         )
+        req_param2 = PhysicalConstantParameter(short_name="physical_constant_parameter",
+                                               physical_constant_value=offset,
+                                               dop=dop
+                                               )
+        request = Request(odx_id=OdxLinkId("request", doc_frags),
+                          short_name="Request",
+                          parameters=[
+                              req_param1,
+                              req_param2
+                          ]
+                          )
 
         expected_coded_message = bytes([0x12, 0x0])
         expected_param_dict = {

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -21,12 +21,12 @@ doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
 class TestLeadingLengthInfoType(unittest.TestCase):
     def test_decode_leading_length_info_type_bytefield(self):
-        dct = LeadingLengthInfoType("A_BYTEFIELD", 6)
+        dct = LeadingLengthInfoType(base_data_type="A_BYTEFIELD", bit_length=6)
         state = DecodeState(bytes([0x2, 0x34, 0x56]), [], 0)
         internal, next_byte = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
 
-        dct = LeadingLengthInfoType("A_BYTEFIELD", 5)
+        dct = LeadingLengthInfoType(base_data_type="A_BYTEFIELD", bit_length=5)
         state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), [], 1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
@@ -35,19 +35,19 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         self.assertEqual(internal, bytes([0x3]))
 
     def test_decode_leading_length_info_type_zero_length(self):
-        dct = LeadingLengthInfoType("A_BYTEFIELD", 8)
+        dct = LeadingLengthInfoType(base_data_type="A_BYTEFIELD", bit_length=8)
         state = DecodeState(bytes([0x0, 0x1]), [], 0)
         internal, next_byte = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, bytes())
         self.assertEqual(next_byte, 1)
 
     def test_encode_leading_length_info_type_bytefield(self):
-        dct = LeadingLengthInfoType("A_UTF8STRING", 6)
+        dct = LeadingLengthInfoType(base_data_type="A_UTF8STRING", bit_length=6)
         state = EncodeState(bytes([]), {})
         byte_val = dct.convert_internal_to_bytes("4V", state, bit_position=1)
         self.assertEqual(byte_val, bytes([0x4, 0x34, 0x56]))
 
-        dct = LeadingLengthInfoType("A_BYTEFIELD", 5)
+        dct = LeadingLengthInfoType(base_data_type="A_BYTEFIELD", bit_length=5)
         state = EncodeState(bytes([]), {})
         internal = dct.convert_internal_to_bytes(bytes([0x3]),
                                                  state,
@@ -55,7 +55,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         self.assertEqual(internal, bytes([0x2, 0x3]))
 
     def test_decode_leading_length_info_type_bytefield2(self):
-        dct = LeadingLengthInfoType("A_BYTEFIELD", 8)
+        dct = LeadingLengthInfoType(base_data_type="A_BYTEFIELD", bit_length=8)
         state = EncodeState(bytes([0x12, 0x34]), {})
         byte_val = dct.convert_internal_to_bytes(
             bytes([0x0]), state, bit_position=0)
@@ -65,7 +65,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         self.assertIn(byte_val, [bytes(), bytes([0x1, 0x0])])
 
     def test_decode_leading_length_info_type_unicode2string(self):
-        dct = LeadingLengthInfoType("A_UNICODE2STRING",
+        dct = LeadingLengthInfoType(base_data_type="A_UNICODE2STRING",
                                     bit_length=8)
         state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
@@ -73,7 +73,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         self.assertEqual(internal, "a9")
         self.assertEqual(next_byte, 6)
 
-        dct = LeadingLengthInfoType("A_UNICODE2STRING",
+        dct = LeadingLengthInfoType(base_data_type="A_UNICODE2STRING",
                                     bit_length=8,
                                     is_highlow_byte_order_raw=False)
         state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), [], 1)
@@ -83,7 +83,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         self.assertEqual(next_byte, 6)
 
     def test_encode_leading_length_info_type_unicode2string(self):
-        dct = LeadingLengthInfoType("A_UNICODE2STRING",
+        dct = LeadingLengthInfoType(base_data_type="A_UNICODE2STRING",
                                     bit_length=8)
         state = EncodeState(coded_message=bytes([0x12]), parameter_values={})
         byte_val = dct.convert_internal_to_bytes("a9",
@@ -91,7 +91,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                                                  bit_position=0)
         self.assertEqual(byte_val, bytes([0x4, 0x00, 0x61, 0x00, 0x39]))
 
-        dct = LeadingLengthInfoType("A_UNICODE2STRING",
+        dct = LeadingLengthInfoType(base_data_type="A_UNICODE2STRING",
                                     bit_length=8,
                                     is_highlow_byte_order_raw=False)
         byte_val = dct.convert_internal_to_bytes("a9",
@@ -159,9 +159,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         # Dummy diag layer to resolve references from request parameters to DOPs
         diag_layer = DiagLayer(
-            DIAG_LAYER_TYPE.BASE_VARIANT,
-            OdxLinkId("BV.dummy_DL", doc_frags),
-            "dummy_DL",
+            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
+            short_name="dummy_DL",
             requests=[request],
             diag_data_dictionary_spec=DiagDataDictionarySpec(
                 data_object_props=dops.values())
@@ -185,7 +185,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
 class TestStandardLengthType(unittest.TestCase):
     def test_decode_standard_length_type_uint(self):
-        dct = StandardLengthType("A_UINT32", 5)
+        dct = StandardLengthType(base_data_type="A_UINT32", bit_length=5)
         state = DecodeState(bytes([0x1, 0x72, 0x3]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=1)
@@ -193,7 +193,7 @@ class TestStandardLengthType(unittest.TestCase):
         self.assertEqual(next_byte, 2)
 
     def test_decode_standard_length_type_uint_byteorder(self):
-        dct = StandardLengthType("A_UINT32", 16, is_highlow_byte_order_raw=False)
+        dct = StandardLengthType(base_data_type="A_UINT32", bit_length=16, is_highlow_byte_order_raw=False)
         state = DecodeState(bytes([0x1, 0x2, 0x3]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=0)
@@ -201,7 +201,7 @@ class TestStandardLengthType(unittest.TestCase):
         self.assertEqual(next_byte, 3)
 
     def test_decode_standard_length_type_bytes(self):
-        dct = StandardLengthType("A_BYTEFIELD", 16)
+        dct = StandardLengthType(base_data_type="A_BYTEFIELD", bit_length=16)
         state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
                                                             bit_position=0)
@@ -212,7 +212,7 @@ class TestStandardLengthType(unittest.TestCase):
 class TestParamLengthInfoType(unittest.TestCase):
     def test_decode_param_info_length_type_uint(self):
         length_key_id = OdxLinkId("param.length_key", doc_frags)
-        dct = ParamLengthInfoType("A_UINT32",
+        dct = ParamLengthInfoType(base_data_type="A_UINT32",
                                   length_key_id=length_key_id)
         state = DecodeState(bytes([0x10, 0x12, 0x34, 0x56]),
                             [ParameterValuePair(
@@ -229,7 +229,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
     def test_encode_param_info_length_type_uint(self):
         length_key_id = OdxLinkId("param.length_key", doc_frags)
-        dct = ParamLengthInfoType("A_UINT32",
+        dct = ParamLengthInfoType(base_data_type="A_UINT32",
                                   length_key_id=length_key_id)
         state = EncodeState(bytes([0x10]), {}, length_keys={length_key_id: 40})
         byte_val = dct.convert_internal_to_bytes(0x12345,
@@ -318,9 +318,9 @@ class TestParamLengthInfoType(unittest.TestCase):
 
         # Dummy diag layer to resolve references from request parameters to DOPs
         diag_layer = DiagLayer(
-            DIAG_LAYER_TYPE.BASE_VARIANT,
-            OdxLinkId("BV.dummy_DL", doc_frags),
-            "dummy_DL",
+            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
+            short_name="dummy_DL",
             requests=[request],
             diag_data_dictionary_spec=DiagDataDictionarySpec(
                 data_object_props=dops.values())
@@ -351,7 +351,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
 class TestMinMaxLengthType(unittest.TestCase):
     def test_decode_min_max_length_type_bytes(self):
-        dct = MinMaxLengthType("A_BYTEFIELD", min_length=1,
+        dct = MinMaxLengthType(base_data_type="A_BYTEFIELD", min_length=1,
                                max_length=4, termination="HEX-FF")
         state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), [], 1)
         internal, next_byte = dct.convert_bytes_to_internal(state,
@@ -361,7 +361,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
     def test_decode_min_max_length_type_too_short_pdu(self):
         """If the PDU ends before min length is reached, an error must be raised."""
-        dct = MinMaxLengthType("A_BYTEFIELD", min_length=2,
+        dct = MinMaxLengthType(base_data_type="A_BYTEFIELD", min_length=2,
                                max_length=4, termination="HEX-FF")
         state = DecodeState(bytes([0x12, 0xFF]), [], 1)
         self.assertRaises(DecodeError, dct.convert_bytes_to_internal, state)
@@ -369,8 +369,7 @@ class TestMinMaxLengthType(unittest.TestCase):
     def test_decode_min_max_length_type_end_of_pdu(self):
         """If the PDU ends before max length is reached, the extracted value ends at the end of the PDU."""
         for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
-            dct = MinMaxLengthType(
-                "A_BYTEFIELD", min_length=2, max_length=5, termination=termination)
+            dct = MinMaxLengthType(base_data_type="A_BYTEFIELD", min_length=2, max_length=5, termination=termination)
             state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), [], 1)
             internal, next_byte = dct.convert_bytes_to_internal(state,
                                                                 bit_position=0)
@@ -380,7 +379,7 @@ class TestMinMaxLengthType(unittest.TestCase):
     def test_decode_min_max_length_type_max_length(self):
         """If the max length is smaller than the end of PDU, the extracted value ends after max length."""
         for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
-            dct = MinMaxLengthType("A_BYTEFIELD",
+            dct = MinMaxLengthType(base_data_type="A_BYTEFIELD",
                                    min_length=2,
                                    max_length=3,
                                    termination=termination)
@@ -391,7 +390,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             self.assertEqual(next_byte, 4)
 
     def test_encode_min_max_length_type_hex_ff(self):
-        dct = MinMaxLengthType("A_BYTEFIELD", min_length=1,
+        dct = MinMaxLengthType(base_data_type="A_BYTEFIELD", min_length=1,
                                max_length=4, termination="HEX-FF")
         state = EncodeState(bytes([0x12]),
                             parameter_values={},
@@ -402,7 +401,7 @@ class TestMinMaxLengthType(unittest.TestCase):
         self.assertEqual(byte_val, bytes([0x34, 0x56, 0xFF]))
 
     def test_encode_min_max_length_type_zero(self):
-        dct = MinMaxLengthType("A_UTF8STRING", min_length=2,
+        dct = MinMaxLengthType(base_data_type="A_UTF8STRING", min_length=2,
                                max_length=4, termination="ZERO")
         state = EncodeState(bytes([0x12]),
                             parameter_values={},
@@ -415,7 +414,7 @@ class TestMinMaxLengthType(unittest.TestCase):
     def test_encode_min_max_length_type_end_of_pdu(self):
         """If the parameter is at the end of the PDU, no termination char is added."""
         for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
-            dct = MinMaxLengthType("A_BYTEFIELD",
+            dct = MinMaxLengthType(base_data_type="A_BYTEFIELD",
                                    min_length=2,
                                    max_length=5,
                                    termination=termination)
@@ -427,7 +426,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                                                      bit_position=0)
             self.assertEqual(byte_val, bytes([0x34, 0x56, 0x78, 0x9A]))
 
-        dct = MinMaxLengthType("A_BYTEFIELD",
+        dct = MinMaxLengthType(base_data_type="A_BYTEFIELD",
                                min_length=2,
                                max_length=5,
                                termination="END-OF-PDU")
@@ -438,7 +437,7 @@ class TestMinMaxLengthType(unittest.TestCase):
     def test_encode_min_max_length_type_max_length(self):
         """If the internal value is larger than max length, an EncodeError must be raised."""
         for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
-            dct = MinMaxLengthType("A_BYTEFIELD",
+            dct = MinMaxLengthType(base_data_type="A_BYTEFIELD",
                                    min_length=2,
                                    max_length=3,
                                    termination=termination)
@@ -521,9 +520,9 @@ class TestMinMaxLengthType(unittest.TestCase):
 
         # Dummy diag layer to resolve references from request parameters to DOPs
         diag_layer = DiagLayer(
-            DIAG_LAYER_TYPE.BASE_VARIANT,
-            OdxLinkId("BV.dummy_DL", doc_frags),
-            "dummy_DL",
+            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
+            short_name="dummy_DL",
             requests=[request],
             diag_data_dictionary_spec=DiagDataDictionarySpec(
                 data_object_props=dops.values())

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -25,64 +25,60 @@ doc_frags = [ OdxDocFragment("UnitTest", "unit_test_doc") ]
 class TestDiagDataDictionarySpec(unittest.TestCase):
     def test_initialization(self):
         uint_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
-        ident_compu_method = IdenticalCompuMethod("A_UINT32", "A_UINT32")
+        ident_compu_method = IdenticalCompuMethod(internal_type="A_UINT32",
+                                                  physical_type="A_UINT32")
 
-        dtc_dop = DtcDop("DOP.dtc_dop", "dtc_dop",
+        dtc_dop = DtcDop(odx_id=OdxLinkId("DOP.dtc_dop", doc_frags),
+                         short_name="dtc_dop",
                          diag_coded_type=uint_type,
                          physical_type=PhysicalType("A_UINT32"),
                          compu_method=ident_compu_method,
                          dtcs=[DiagnosticTroubleCode(
-                             "DOP.dtc_dop.DTC.X10",
-                             "X10",
-                             0x10,
-                             "Something exploded.",
+                             odx_id=OdxLinkId("DOP.dtc_dop.DTC.X10", doc_frags),
+                             short_name="X10",
+                             trouble_code=0x10,
+                             text="Something exploded.",
                              display_trouble_code="X10"
                          )])
 
-        dop_1 = DataObjectProperty("DOP.the_dop",
-                                   "the_dop",
+        dop_1 = DataObjectProperty(odx_id=OdxLinkId("DOP.the_dop", doc_frags),
+                                   short_name="the_dop",
                                    diag_coded_type=uint_type,
                                    physical_type=PhysicalType("A_UINT32"),
                                    compu_method=ident_compu_method)
 
-        dop_2 = DataObjectProperty("DOP.another_dop",
-                                   "another_dop",
+        dop_2 = DataObjectProperty(odx_id=OdxLinkId("DOP.another_dop", doc_frags),
+                                   short_name="another_dop",
                                    diag_coded_type=uint_type,
                                    physical_type=PhysicalType("A_UINT32"),
                                    compu_method=ident_compu_method)
 
-        table = Table(
-                odx_id="somersault.table.flip_quality",
-                short_name="flip_quality",
-                long_name="Flip Quality",
-                key_dop_ref="",
-                table_rows=[
-                    TableRow(
-                        odx_id="somersault.table.flip_quality.average",
-                        short_name="average",
-                        long_name="Average",
-                        key=3,
-                        structure_ref="",
-                    ),
-                    TableRow(
-                        odx_id="somersault.table.flip_quality.good",
-                        short_name="good",
-                        long_name="Good",
-                        key=5,
-                        structure_ref="",
-                    ),
-                    TableRow(
-                        odx_id="somersault.table.flip_quality.best",
-                        short_name="best",
-                        long_name="Best",
-                        key=10,
-                        structure_ref="",
-                    ),
-                ]
-            )
+        table = Table(odx_id=OdxLinkId("somersault.table.flip_quality", doc_frags),
+                      short_name="flip_quality",
+                      long_name="Flip Quality",
+                      key_dop_ref="",
+                      table_rows=[
+                        TableRow(odx_id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
+                                 short_name="average",
+                                 long_name="Average",
+                                 key=3,
+                                 structure_ref="",
+                                 ),
+                          TableRow(odx_id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
+                                   short_name="good",
+                                   long_name="Good",
+                                   key=5,
+                                   ),
+                          TableRow(odx_id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
+                                   short_name="best",
+                                   long_name="Best",
+                                   key=10,
+                                   ),
+                      ]
+                      )
 
         env_data = EnvironmentData(
-            odx_id="somersault.env_data.flip_env_data",
+            odx_id=OdxLinkId("somersault.env_data.flip_env_data", doc_frags),
             short_name="flip_env_data",
             long_name="Flip Env Data",
             parameters=[
@@ -105,7 +101,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         )
 
         env_data_desc = EnvironmentDataDescription(
-            odx_id="somersault.env_data_desc.flip_env_data_desc",
+            odx_id=OdxLinkId("somersault.env_data_desc.flip_env_data_desc", doc_frags),
             short_name="flip_env_data_desc",
             long_name="Flip Env Data Desc",
             param_snref="flip_speed",
@@ -114,7 +110,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         )
 
         mux = Multiplexer(
-            odx_id="somersault.multiplexer.flip_preference",
+            odx_id=OdxLinkId("somersault.multiplexer.flip_preference", doc_frags),
             short_name="flip_preference",
             long_name="Flip Preference",
             byte_position=0,

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -17,32 +17,51 @@ doc_frags = [ OdxDocFragment("UnitTest", "WinneThePoh") ]
 
 class TestEncodeRequest(unittest.TestCase):
     def test_encode_coded_const_infer_order(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        param1 = CodedConstParameter(
-            "coded_const_parameter", diag_coded_type, coded_value=0x7d, byte_position=0)
-        param2 = CodedConstParameter(
-            "coded_const_parameter", diag_coded_type, coded_value=0xab)
-        req = Request("request_id", "request_sn", [param1, param2])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        param1 = CodedConstParameter(short_name="coded_const_parameter",
+                                     diag_coded_type=diag_coded_type,
+                                     coded_value=0x7d,
+                                     byte_position=0)
+        param2 = CodedConstParameter(short_name="coded_const_parameter",
+                                     diag_coded_type=diag_coded_type,
+                                     coded_value=0xab)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[param1, param2])
         self.assertEqual(req.encode(), bytearray([0x7d, 0xab]))
 
     def test_encode_coded_const_reorder(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        param1 = CodedConstParameter(
-            "param1", diag_coded_type, coded_value=0x34, byte_position=1)
-        param2 = CodedConstParameter(
-            "param2", diag_coded_type, coded_value=0x12, byte_position=0)
-        req = Request("request_id", "request_sn", [param1, param2])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        param1 = CodedConstParameter(short_name="param1",
+                                     diag_coded_type=diag_coded_type,
+                                     coded_value=0x34,
+                                     byte_position=1)
+        param2 = CodedConstParameter(short_name="param2",
+                                     diag_coded_type=diag_coded_type,
+                                     coded_value=0x12,
+                                     byte_position=0)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[param1, param2])
         self.assertEqual(req.encode(), bytearray([0x12, 0x34]))
 
     def test_encode_linear(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
         # This CompuMethod represents the linear function: decode(x) = 2*x + 8 and encode(x) = (x-8)/2
-        compu_method = LinearCompuMethod(8, 2, "A_UINT32", "A_UINT32")
-        dop = DataObjectProperty(OdxLinkId("dop-odx_id", doc_frags), "example dop", diag_coded_type,
-                                 physical_type=PhysicalType("A_UINT32"), compu_method=compu_method)
-        param1 = ValueParameter("linear_value_parameter",
+        compu_method = LinearCompuMethod(offset=8,
+                                         factor=2,
+                                         internal_type="A_UINT32",
+                                         physical_type="A_UINT32")
+        dop = DataObjectProperty(odx_id=OdxLinkId("dop-odx_id", doc_frags),
+                                 short_name="example dop",
+                                 diag_coded_type=diag_coded_type,
+                                 physical_type=PhysicalType("A_UINT32"),
+                                 compu_method=compu_method)
+        param1 = ValueParameter(short_name="linear_value_parameter",
                                 dop=dop)
-        req = Request("request_id", "request_sn", [param1])
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[param1])
 
         # Missing mandatory parameter.
         with self.assertRaises(TypeError) as cm:
@@ -54,26 +73,41 @@ class TestEncodeRequest(unittest.TestCase):
         )
 
     def test_encode_nrc_const(self):
-        diag_coded_type = StandardLengthType("A_UINT32", 8)
-        param1 = CodedConstParameter(
-            "param1", diag_coded_type, coded_value=0x12, byte_position=0)
-        param2 = NrcConstParameter(
-            "param2", diag_coded_type, coded_values=[0x34, 0xab], byte_position=1)
-        resp = Response("response_id", "response_sn", [param1, param2])
+        diag_coded_type = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        param1 = CodedConstParameter(short_name="param1",
+                                     diag_coded_type=diag_coded_type,
+                                     coded_value=0x12,
+                                     byte_position=0)
+        param2 = NrcConstParameter(short_name="param2",
+                                   diag_coded_type=diag_coded_type,
+                                   coded_values=[0x34, 0xab],
+                                   byte_position=1)
+        resp = Response(odx_id=OdxLinkId("response_id", doc_frags),
+                        short_name= "response_sn",
+                        parameters=[param1, param2])
         self.assertEqual(resp.encode(), bytearray([0x12, 0x34]))
         self.assertEqual(resp.encode(param2=0xab), bytearray([0x12, 0xab]))
         self.assertRaises(EncodeError, resp.encode, param2=0xef)
 
     def test_encode_overlapping(self):
-        uint24 = StandardLengthType("A_UINT32", 24)
-        uint8 = StandardLengthType("A_UINT32", 8)
-        param1 = CodedConstParameter(
-            "code", uint24, coded_value=0x123456)
-        param2 = CodedConstParameter(
-            "part1", uint8, coded_value=0x23, byte_position=0, bit_position=4)
-        param3 = CodedConstParameter(
-            "part2", uint8, coded_value=0x45, byte_position=1, bit_position=4)
-        req = Request("request_id", "request_sn", [param1, param2, param3])
+        uint24 = StandardLengthType(base_data_type="A_UINT32", bit_length=24)
+        uint8 = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
+        param1 = CodedConstParameter(short_name="code",
+                                     diag_coded_type=uint24,
+                                     coded_value=0x123456)
+        param2 = CodedConstParameter(short_name="part1",
+                                     diag_coded_type=uint8,
+                                     coded_value=0x23,
+                                     byte_position=0,
+                                     bit_position=4)
+        param3 = CodedConstParameter(short_name="part2",
+                                     diag_coded_type=uint8,
+                                     coded_value=0x45,
+                                     byte_position=1,
+                                     bit_position=4)
+        req = Request(odx_id=OdxLinkId("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=[param1, param2, param3])
         self.assertEqual(req.encode(), bytearray([0x12, 0x34, 0x56]))
         self.assertEqual(req.bit_length, 24)
 
@@ -81,17 +115,37 @@ class TestEncodeRequest(unittest.TestCase):
         self.skipTest("Not fixed yet")
         # see https://github.com/mercedes-benz/odxtools/issues/70
         # make sure overlapping params don't cause this function to go crazy
-        uint2 = StandardLengthType("A_UINT32", 2)
-        uint1 = StandardLengthType("A_UINT32", 1)
+        uint2 = StandardLengthType(base_data_type="A_UINT32", bit_length=2)
+        uint1 = StandardLengthType(base_data_type="A_UINT32", bit_length=1)
         params = [
-            CodedConstParameter("p1", uint2, bit_position=0, coded_value=0),
-            CodedConstParameter("p2", uint2, bit_position=2, coded_value=0),
-            CodedConstParameter("p3", uint2, bit_position=3, coded_value=0),
-            CodedConstParameter("p4", uint1, bit_position=5, coded_value=0),
-            CodedConstParameter("p5", uint1, bit_position=6, coded_value=0),
-            CodedConstParameter("p6", uint1, bit_position=7, coded_value=0),
+            CodedConstParameter(short_name="p1",
+                                diag_coded_type=uint2,
+                                bit_position=0,
+                                coded_value=0),
+            CodedConstParameter(short_name="p2",
+                                diag_coded_type=uint2,
+                                bit_position=2,
+                                coded_value=0),
+            CodedConstParameter(short_name="p3",
+                                diag_coded_type=uint2,
+                                bit_position=3,
+                                coded_value=0),
+            CodedConstParameter(short_name="p4",
+                                diag_coded_type=uint1,
+                                bit_position=5,
+                                coded_value=0),
+            CodedConstParameter(short_name="p5",
+                                diag_coded_type=uint1,
+                                bit_position=6,
+                                coded_value=0),
+            CodedConstParameter(short_name="p6",
+                                diag_coded_type=uint1,
+                                bit_position=7,
+                                coded_value=0),
         ]
-        req = Request("request_id", "request_sn", params)
+        req = Request(odx_id=OdxLinkRef("request_id", doc_frags),
+                      short_name="request_sn",
+                      parameters=params)
         self.assertTrue(req._BasicStructure__message_format_lines())
 
 if __name__ == '__main__':

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -60,8 +60,8 @@ class TestSingleEcuJob(unittest.TestCase):
             inputDOP=DataObjectProperty(
                 odx_id=OdxLinkId("ID.inputDOP", doc_frags),
                 short_name="inputDOP",
-                diag_coded_type=StandardLengthType(
-                    DataType.A_INT32, bit_length=1),
+                diag_coded_type=StandardLengthType(base_data_type=DataType.A_INT32,
+                                                   bit_length=1),
                 physical_type=PhysicalType(DataType.A_UNICODE2STRING),
                 compu_method=TexttableCompuMethod(
                     internal_to_phys=[
@@ -77,21 +77,25 @@ class TestSingleEcuJob(unittest.TestCase):
             outputDOP=DataObjectProperty(
                 odx_id=OdxLinkId("ID.outputDOP", doc_frags),
                 short_name="outputDOP",
-                diag_coded_type=StandardLengthType(
-                    DataType.A_INT32, bit_length=1),
+                diag_coded_type=StandardLengthType(base_data_type=DataType.A_INT32,
+                                                   bit_length=1),
                 physical_type=PhysicalType(DataType.A_UNICODE2STRING),
-                compu_method=LinearCompuMethod(1, -1,
-                                               internal_type=DataType.A_UINT32, physical_type=DataType.A_UINT32)
+                compu_method=LinearCompuMethod(offset=1,
+                                               factor=-1,
+                                               internal_type=DataType.A_UINT32,
+                                               physical_type=DataType.A_UINT32)
             ),
 
             negOutputDOP=DataObjectProperty(
                 odx_id=OdxLinkId("ID.negOutputDOP", doc_frags),
                 short_name="negOutputDOP",
-                diag_coded_type=StandardLengthType(
-                    DataType.A_INT32, bit_length=1),
+                diag_coded_type=StandardLengthType(base_data_type=DataType.A_INT32,
+                                                   bit_length=1),
                 physical_type=PhysicalType(DataType.A_UNICODE2STRING),
-                compu_method=LinearCompuMethod(1, -1,
-                                               internal_type=DataType.A_UINT32, physical_type=DataType.A_UINT32)
+                compu_method=LinearCompuMethod(offset=1,
+                                               factor=-1,
+                                               internal_type=DataType.A_UINT32,
+                                               physical_type=DataType.A_UINT32)
             )
         )
 

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -83,29 +83,32 @@ class TestUnitSpec(unittest.TestCase):
         unit = Unit(odx_id=OdxLinkId("unit_time_id", doc_frags),
                     short_name="second",
                     display_name="s")
-        dct = StandardLengthType("A_UINT32", 8)
+        dct = StandardLengthType(base_data_type="A_UINT32", bit_length=8)
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop_id", doc_frags),
             short_name="dop_sn",
             diag_coded_type=dct,
             physical_type=PhysicalType("A_UINT32"),
-            compu_method=IdenticalCompuMethod("A_UINT32", "A_UINT32"),
+            compu_method=IdenticalCompuMethod(internal_type="A_UINT32",
+                                              physical_type="A_UINT32"),
             unit_ref=OdxLinkRef.from_id(unit.odx_id)
         )
         dl = DiagLayer(
-            DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
             odx_id=OdxLinkId("BV_id", doc_frags),
             short_name="BaseVariant",
-            requests=[Request(OdxLinkId("rq_id", doc_frags), "rq_sn", [
-                CodedConstParameter(short_name="sid",
-                                    diag_coded_type=dct,
-                                    coded_value=0x12),
-                ValueParameter("time", dop_ref=OdxLinkRef.from_id(dop.odx_id)),
-            ])],
-            diag_data_dictionary_spec=DiagDataDictionarySpec(
-                data_object_props=[dop],
-                unit_spec=UnitSpec(units=[unit])
-            )
+            requests=[Request(odx_id=OdxLinkId("rq_id", doc_frags),
+                              short_name="rq_sn",
+                              parameters=[
+                                  CodedConstParameter(short_name="sid",
+                                                      diag_coded_type=dct,
+                                                      coded_value=0x12),
+                                  ValueParameter(short_name="time",
+                                                 dop_ref=OdxLinkRef.from_id(dop.odx_id)),
+                              ])],
+            diag_data_dictionary_spec=DiagDataDictionarySpec(data_object_props=[dop],
+                                                             unit_spec=UnitSpec(units=[unit])
+                                                             )
         )
         dl.finalize_init()
 


### PR DESCRIPTION
in this context, "most types of objects" basically means everything which is essentially a dataclass. this makes constructing them more explicit and less fragile.

note that for `@dataclass`es themselves, we currently cannot enforce this policy strictly because this would require to mark these classes with `kw_only=True` which is only available for python >= 3.10...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)