### PR TITLE
Structure: Pass byte_size argument to parent class

### DIFF
--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -502,6 +502,7 @@ class Structure(BasicStructure):
                          short_name,
                          parameters,
                          long_name=long_name,
+                         byte_size=byte_size,
                          description=description,
                          sdgs=sdgs)
 


### PR DESCRIPTION
The byte_size argument wasn't passed to the parent class.