### PR TITLE
Decompose action into CI pipeline jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,7 @@
-name: Run Tests
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023 MBition GmbH
+
+name: odxtools CI pipeline
 
 on:
   push:
@@ -8,20 +11,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  unittest-and-lint:
-    runs-on: ${{matrix.os}}
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up yapf linter
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+        run: |
+          pip install toml yapf
+
+      - name: Lint code formatting
+        # make yapf fail if any file needs to be formatted
+        run: |
+          yapf -r --diff examples/ odxtools/ tests/
+
+  static-type-checking:
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        # restrict matrix to the latest Python version and one older version
+        # restrict the matrix to the oldest and the latest Python
+        # version being supported by odxtools
         python-version: ["3.8", "3.11"]
-
-        # due to the slow windows runners, we refrain from testing every python
-        # version on windows-latest
-        exclude:
-          - os: windows-latest
-            python-version: "3.8"
 
     steps:
       - uses: actions/checkout@v3
@@ -30,16 +45,46 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
+          cache: "pip"
 
-      - name: Install odxtools dependencies
+      - name: Install odxtools development and testing dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r test-requirements.txt
 
-      # we need additional dependencies for testing and the type checker
-      # but we avoided to specify as hard dependencies within 'requirements.txt'
-      - name: Install test dependencies
+      - name: Static type checking with mypy
         run: |
+          python -m mypy --ignore-missing-imports odxtools examples tests
+
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        # restrict the matrix to the oldest and the latest Python
+        # version being supported by odxtools
+        python-version: ["3.8", "3.11"]
+
+        # due to the slow windows runners, we refrain from testing every python
+        # version on windows-latest
+        exclude:
+          - os: windows-latest
+            python-version: "3.8"
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{matrix.python-version}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.python-version}}
+          cache: "pip"
+
+      # dependency are likely cached on ubuntu-latest
+      - name: Install odxtools development and testing dependencies
+        run: |
+          pip install -r requirements.txt
           pip install -r test-requirements.txt
 
       - name: Create somersault.pdx
@@ -57,7 +102,3 @@ jobs:
         run: |
           coverage run --source=odxtools --omit=tests -m pytest
           coverage report
-
-      - name: Static type checking with mypy
-        run: |
-          python -m mypy --ignore-missing-imports odxtools examples tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up yapf linter
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
+      - name: Setup up Linter
         run: |
           pip install toml yapf
 


### PR DESCRIPTION
The goal of this refactoring is to make the CI pipeline more transparent and enhance the traceability of failures.

The new pipeline has
- a lint job (using yapf, see also #119 and #120), 
- a static-type-checking job and
- a test job.

Each job runs independently from each other. To improve efficiency, pip dependencies are cached.

David Holtz <[david.holtz@mbition.io](mailto:david.holtz@mbition.io)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)