### PR TITLE
Various small writing fixes

### DIFF
--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -547,7 +547,7 @@ def create_any_structure_from_et(et_element, doc_frags: List[OdxDocFragment]
             byte_size=None,
             sdgs=sdgs,
         )
-    elif et_element.tag in ["POS-RESPONSE", "NEG-RESPONSE"]:
+    elif et_element.tag in ["POS-RESPONSE", "NEG-RESPONSE", "GLOBAL-NEG-RESPONSE"]:
         res = Response(
             odx_id=odx_id,
             short_name=short_name,

--- a/odxtools/templates/comparam-subset.odx-cs.xml.jinja2
+++ b/odxtools/templates/comparam-subset.odx-cs.xml.jinja2
@@ -6,7 +6,6 @@
  # This template writes an .odx-cs file for a communication
  # parameter subset.
 -#}
-{%- import('macros/printVariant.xml.jinja2') as pv -%}
 {%- import('macros/printComparam.xml.jinja2') as pcp -%}
 {%- import('macros/printAdminData.xml.jinja2') as pad -%}
 {%- import('macros/printCompanyData.xml.jinja2') as pcd -%}

--- a/odxtools/templates/macros/printMux.xml.jinja2
+++ b/odxtools/templates/macros/printMux.xml.jinja2
@@ -25,7 +25,7 @@
     {%- endif %}
   </DEFAULT-CASE>
   {%- endif %}
-  {%- if mux.default_cases %}
+  {%- if mux.cases %}
   <CASES>
     {%- for case in mux.cases %}
     <CASE>

--- a/odxtools/templates/macros/printParentRef.xml.jinja2
+++ b/odxtools/templates/macros/printParentRef.xml.jinja2
@@ -5,24 +5,10 @@
 -#}
 
 {%- macro printParentRef(par) -%}
-{#-
-
-
-WARNING: duck typing: assume the parent to be a document reference if
-its not_inherited_diag_comms and not_inherited_dops are
-empty. TODO: provide the xsi:type in the parent ref
-
--#}
-{%- if not par.not_inherited_diag_comms and not  not par.not_inherited_dops %}
 <PARENT-REF ID-REF="{{par.parent_ref.ref_id}}"
             DOCREF="{{par.parent_diag_layer.short_name}}"
             DOCTYPE="CONTAINER"
-            xsi:type="FUNCTIONAL-GROUP-REF"/>
-{%- else %}
-<PARENT-REF ID-REF="{{par.parent_ref.ref_id}}"
-            DOCREF="{{par.parent_diag_layer.short_name}}"
-            DOCTYPE="CONTAINER"
-            xsi:type="BASE-VARIANT-REF">
+            xsi:type="{{par.ref_type}}">
 {%- if par.not_inherited_diag_comms %}
  <NOT-INHERITED-DIAG-COMMS>
 {%-  for nidc in par.not_inherited_diag_comms %}
@@ -42,6 +28,5 @@ empty. TODO: provide the xsi:type in the parent ref
  </NOT-INHERITED-DOPS>
 {%- endif %}
 </PARENT-REF>
-{%- endif %}
 {%- endmacro -%}
 

--- a/odxtools/templates/macros/printService.xml.jinja2
+++ b/odxtools/templates/macros/printService.xml.jinja2
@@ -4,6 +4,7 @@
  # Copyright (c) 2022 MBition GmbH
 -#}
 
+{%- import('macros/printAdminData.xml.jinja2') as pad %}
 {%- import('macros/printAudience.xml.jinja2') as paud %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
@@ -23,6 +24,9 @@
  {{service.description}}
  </DESC>
 {%- endif %}
+ {%- if service.admin_data %}
+ {{- pad.printAdminData(service.admin_data)|indent(2, first=True) }}
+ {%- endif %}
  {{- psd.printSpecialDataGroups(service.sdgs)|indent(1, first=True) }}
 {%- if service.functional_class_refs %}
  <FUNCT-CLASS-REFS>
@@ -34,6 +38,20 @@
 {%- if service.audience %}
  {{ paud.printAudience(service.audience)|indent(1) }}
 {%- endif%}
+ {%- if service.pre_condition_state_refs %}
+ <PRE-CONDITION-STATE-REFS>
+   {%- for ps_ref in service.pre_condition_state_refs %}
+   <PRE-CONDITION-STATE-REF ID-REF="{{ps_ref.ref_id}}" />
+   {%- endfor %}
+ </PRE-CONDITION-STATE-REFS>
+ {%- endif%}
+ {%- if service.state_transition_refs %}
+ <STATE-TRANSITION-REFS>
+   {%- for st_ref in service.state_transition_refs %}
+   <STATE-TRANSITION-REF ID-REF="{{st_ref.ref_id}}" />
+   {%- endfor %}
+ </STATE-TRANSITION-REFS>
+ {%- endif%}
  <REQUEST-REF ID-REF="{{service.request_ref.ref_id}}"/>
 {%- if service.pos_res_refs %}
  <POS-RESPONSE-REFS>

--- a/odxtools/templates/macros/printStructure.xml.jinja2
+++ b/odxtools/templates/macros/printStructure.xml.jinja2
@@ -12,8 +12,8 @@
 {%- if st.long_name %}
  <LONG-NAME>{{st.long_name|e}}</LONG-NAME>
 {%- endif %}
-{%- if st.bit_length is not none %}
- <BYTE-SIZE>{{((st.bit_length + 7)/8)|int}}</BYTE-SIZE>
+{%- if st.byte_size is not none %}
+ <BYTE-SIZE>{{st.byte_size}}</BYTE-SIZE>
 {%- endif %}
  <PARAMS>
 {%- for param in st.parameters -%}


### PR DESCRIPTION
this contains a few minor fixes for the writing code which prevented `odxtools list` from being "round-trip invariant" on one of our internal files. (i.e. `cantools list` now produces the same output for the original file and for one which was passed through the `pdxcopy` example)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)