### PR TITLE
- resolved unused import in write_pdx_file.py

### DIFF
--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -5,14 +5,9 @@ import inspect
 import os
 import time
 import zipfile
-from typing import Any, Dict, List, Optional, Tuple
-
 import jinja2
-
 import odxtools
-
-from .comparam_subset import BaseComparam, Comparam, ComplexComparam
-from .exceptions import OdxError
+from typing import Any, Dict, List, Optional, Tuple
 from .odxtypes import bool_to_odxstr
 
 odxdatabase = None


### PR DESCRIPTION
removed two import lines from write_pdx_file.py as they are not used. making the overall codebase less memory consuming and the code more clean.

DO NOTE: Contributors License Agreement is in progress and I will send it in a bit. Will notify as part of this pull request when that is done. 