### PR TITLE
Fix/max length parsing

### DIFF
--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -640,7 +640,8 @@ def create_any_diag_coded_type_from_et(et_element, doc_frags: List[OdxDocFragmen
     elif dct_type == "MIN-MAX-LENGTH-TYPE":
         min_length = int(et_element.findtext("MIN-LENGTH"))
         max_length = None
-        if et_element.find("MAX-LENGTH"):
+        # comparison has to be 'is not None' as Element overwrites __bool__(), and always returns false for MAX-LENGTH elements
+        if et_element.find("MAX-LENGTH") is not None:
             max_length = int(et_element.findtext("MAX-LENGTH"))
         termination = et_element.get("TERMINATION")
 

--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -5,9 +5,12 @@ import inspect
 import os
 import time
 import zipfile
-import jinja2
-import odxtools
 from typing import Any, Dict, List, Optional, Tuple
+
+import jinja2
+
+import odxtools
+
 from .odxtypes import bool_to_odxstr
 
 odxdatabase = None

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -17,7 +17,6 @@ from odxtools.parameters import CodedConstParameter, LengthKeyParameter, ValuePa
 from odxtools.physicaltype import PhysicalType
 from odxtools.structures import Request
 from odxtools.utils import short_name_as_id
-from odxtools.globals import xsi
 
 doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
 
@@ -860,7 +859,6 @@ class TestMinMaxLengthType(unittest.TestCase):
         diag_coded_type_element = odx_element.find("DIAG-CODED-TYPE")
 
         actual = create_any_diag_coded_type_from_et(diag_coded_type_element, doc_frags)
-        print(actual)
 
         self.assertIsInstance(actual, MinMaxLengthType)
         self.assertEqual(actual.base_data_type, expected.base_data_type)
@@ -869,8 +867,6 @@ class TestMinMaxLengthType(unittest.TestCase):
         self.assertEqual(actual.max_length, expected.max_length)
         self.assertEqual(actual.termination, expected.termination)
         self.assertEqual(actual.is_highlow_byte_order, expected.is_highlow_byte_order)
-
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes a bug in create_any_diag_coded_type_from_et(). The check to see if a ``<MAX-LENGTH>`` element exists fails, because Element in xml.etree.ElementTree overwrites \_\_bool\_\_() and ``<MAX-LENGTH>`` never has any children ([see implementation](https://github.com/python/cpython/blob/9f89c471fb152fd031791f3c598ceba93d91dcf0/Lib/xml/etree/ElementTree.py#L207)).

Changed the check to the recommended explicit is not None comparison.