### PR TITLE
Untangle Diaglayer (1 of X)

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -21,7 +21,7 @@ from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 from odxtools.diaglayer import DiagLayer, DiagLayerContainer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.envdata import EnvironmentData
 from odxtools.envdatadesc import EnvironmentDataDescription
 from odxtools.functionalclass import FunctionalClass
@@ -1719,7 +1719,7 @@ somersault_diag_data_dictionary_spec = DiagDataDictionarySpec(
 
 # diagnostics layer
 somersault_diaglayer = DiagLayer(
-    variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+    variant_type=DiagLayerType.BASE_VARIANT,
     odx_id=OdxLinkId("somersault", doc_frags),
     short_name="somersault",
     long_name="Somersault base variant",
@@ -1746,7 +1746,7 @@ somersault_diaglayer = DiagLayer(
 
 # TODO: inheritance (without too much code duplication)
 somersault_lazy_diaglayer = DiagLayer(
-    variant_type=DIAG_LAYER_TYPE.ECU_VARIANT,
+    variant_type=DiagLayerType.ECU_VARIANT,
     odx_id=OdxLinkId("somersault_lazy", doc_frags),
     short_name="somersault_lazy",
     long_name="Somersault lazy ECU",
@@ -1785,7 +1785,7 @@ somersault_lazy_diaglayer = DiagLayer(
 
 # TODO: inheritance (without too much code duplication)
 somersault_assiduous_diaglayer = DiagLayer(
-    variant_type=DIAG_LAYER_TYPE.ECU_VARIANT,
+    variant_type=DiagLayerType.ECU_VARIANT,
     odx_id=OdxLinkId("somersault_assiduous", doc_frags),
     short_name="somersault_assiduous",
     long_name="Somersault assiduous ECU",

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -32,6 +32,7 @@ from odxtools.odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters import (CodedConstParameter, MatchingRequestParameter, NrcConstParameter,
                                  ValueParameter)
+from odxtools.parentref import ParentRef
 from odxtools.physicaltype import PhysicalType
 from odxtools.service import DiagService
 from odxtools.singleecujob import ProgCode, SingleEcuJob
@@ -1751,7 +1752,7 @@ somersault_lazy_diaglayer = DiagLayer(
     long_name="Somersault lazy ECU",
     description="<p>Sloppy variant of the somersault ECU (lazy &lt; assiduous)</p>",
     parent_refs=[
-        DiagLayer.ParentRef(  # <- TODO: this is a bit sketchy IMO
+        ParentRef(  # <- TODO: this is a bit sketchy IMO
             parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does not do backflips
@@ -1802,7 +1803,7 @@ somersault_assiduous_diaglayer = DiagLayer(
         sdgs=[],
     ),
     parent_refs=[
-        DiagLayer.ParentRef(  # <- TODO: this is a bit sketchy IMO
+        ParentRef(  # <- TODO: this is a bit sketchy IMO
             parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does everything which the base variant does

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1753,7 +1753,7 @@ somersault_lazy_diaglayer = DiagLayer(
     long_name="Somersault lazy ECU",
     description="<p>Sloppy variant of the somersault ECU (lazy &lt; assiduous)</p>",
     parent_refs=[
-        ParentRef(  # <- TODO: this is a bit sketchy IMO
+        ParentRef(
             parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does not do backflips
@@ -1804,7 +1804,7 @@ somersault_assiduous_diaglayer = DiagLayer(
         sdgs=[],
     ),
     parent_refs=[
-        ParentRef(  # <- TODO: this is a bit sketchy IMO
+        ParentRef(
             parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
             ref_type="BASE-VARIANT-REF",
             # this variant does everything which the base variant does

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -20,7 +20,8 @@ from odxtools.database import Database
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
-from odxtools.diaglayer import DiagLayer, DiagLayerContainer
+from odxtools.diaglayer import DiagLayer
+from odxtools.diaglayercontainer import DiagLayerContainer
 from odxtools.diaglayertype import DiagLayerType
 from odxtools.envdata import EnvironmentData
 from odxtools.envdatadesc import EnvironmentDataDescription

--- a/odxtools/communicationparameter.py
+++ b/odxtools/communicationparameter.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Union
 
 from .comparam_subset import (BaseComparam, Comparam, ComplexComparam, ComplexValue,
                               create_complex_value_from_et)
-from .diaglayertype import DIAG_LAYER_TYPE
+from .diaglayertype import DiagLayerType
 from .exceptions import OdxWarning
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
 from .utils import create_description_from_et
@@ -33,7 +33,7 @@ class CommunicationParameterRef:
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment],
-                dl_type: DIAG_LAYER_TYPE) -> "CommunicationParameterRef":
+                dl_type: DiagLayerType) -> "CommunicationParameterRef":
         id_ref = OdxLinkRef.from_et(et_element, doc_frags)
         assert id_ref is not None
 
@@ -47,7 +47,7 @@ class CommunicationParameterRef:
         else:
             value = create_complex_value_from_et(et_element.find("COMPLEX-VALUE"))
 
-        is_functional = dl_type == DIAG_LAYER_TYPE.FUNCTIONAL_GROUP
+        is_functional = dl_type == DiagLayerType.FUNCTIONAL_GROUP
         description = create_description_from_et(et_element.find("DESC"))
 
         prot_stack_snref = None

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile
 
 from .comparam_subset import ComparamSubset
 from .diaglayer import DiagLayer, DiagLayerContainer
-from .diaglayertype import DIAG_LAYER_TYPE
+from .diaglayertype import DiagLayerType
 from .globals import logger
 from .nameditemlist import NamedItemList
 from .odxlink import OdxLinkDatabase
@@ -108,7 +108,7 @@ class Database:
         for dlc in self.diag_layer_containers:
             dlc._resolve_references(self._odxlinks)
 
-        for dl_type_name in DIAG_LAYER_TYPE:
+        for dl_type_name in DiagLayerType:
             for dl in self.diag_layers:
                 if dl.variant_type == dl_type_name:
                     dl._resolve_references(self._odxlinks)
@@ -147,7 +147,7 @@ class Database:
         """
         result_dict = dict()
         for dl in self.diag_layers:
-            if dl.variant_type == DIAG_LAYER_TYPE.PROTOCOL:
+            if dl.variant_type == DiagLayerType.PROTOCOL:
                 result_dict[dl.short_name] = dl
 
         return NamedItemList(short_name_as_id, list(result_dict.values()))

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -8,7 +8,8 @@ from xml.etree.ElementTree import Element
 from zipfile import ZipFile
 
 from .comparam_subset import ComparamSubset
-from .diaglayer import DiagLayer, DiagLayerContainer
+from .diaglayer import DiagLayer
+from .diaglayercontainer import DiagLayerContainer
 from .diaglayertype import DiagLayerType
 from .globals import logger
 from .nameditemlist import NamedItemList

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -16,7 +16,7 @@ from .communicationparameter import CommunicationParameterRef
 from .companydata import CompanyData, create_company_datas_from_et
 from .dataobjectproperty import DopBase
 from .diagdatadictionaryspec import DiagDataDictionarySpec
-from .diaglayertype import DIAG_LAYER_TYPE
+from .diaglayertype import DiagLayerType
 from .exceptions import DecodeError, OdxWarning
 from .functionalclass import FunctionalClass
 from .globals import logger
@@ -37,7 +37,7 @@ class DiagLayer:
     def __init__(
         self,
         *,
-        variant_type: DIAG_LAYER_TYPE,
+        variant_type: DiagLayerType,
         odx_id,
         short_name,
         long_name,
@@ -103,7 +103,7 @@ class DiagLayer:
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagLayer":
 
-        variant_type = DIAG_LAYER_TYPE.from_str(et_element.tag)
+        variant_type = DiagLayerType.from_str(et_element.tag)
 
         short_name = et_element.findtext("SHORT-NAME")
         assert short_name is not None
@@ -196,7 +196,7 @@ class DiagLayer:
 
         ecu_variant_patterns = create_ecu_variant_patterns_from_et(
             et_element.find("ECU-VARIANT-PATTERNS"), doc_frags)
-        if variant_type is not DIAG_LAYER_TYPE.ECU_VARIANT:
+        if variant_type is not DiagLayerType.ECU_VARIANT:
             assert (
                 len(ecu_variant_patterns) == 0
             ), "DiagLayer of type other than 'ECU-VARIANT' must not define a ECU-VARIANT-PATTERN"
@@ -253,7 +253,7 @@ class DiagLayer:
             for prot in parent_ref.parent_diag_layer.protocols:
                 result_dict[prot.short_name] = prot
 
-        if self.variant_type == DIAG_LAYER_TYPE.PROTOCOL:
+        if self.variant_type == DiagLayerType.PROTOCOL:
             result_dict[self.short_name] = self
 
         return NamedItemList(short_name_as_id, list(result_dict.values()))

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -8,8 +8,6 @@ from xml.etree import ElementTree
 
 from deprecation import deprecated
 
-from odxtools.ecu_variant_patterns import EcuVariantPattern, create_ecu_variant_patterns_from_et
-
 from .admindata import AdminData
 from .audience import AdditionalAudience, Audience
 from .communicationparameter import CommunicationParameterRef
@@ -17,6 +15,7 @@ from .companydata import CompanyData, create_company_datas_from_et
 from .dataobjectproperty import DopBase
 from .diagdatadictionaryspec import DiagDataDictionarySpec
 from .diaglayertype import DiagLayerType
+from .ecu_variant_patterns import EcuVariantPattern, create_ecu_variant_patterns_from_et
 from .exceptions import DecodeError, OdxWarning
 from .functionalclass import FunctionalClass
 from .globals import logger
@@ -758,158 +757,3 @@ class DiagLayer:
 
     def __str__(self) -> str:
         return f"DiagLayer('{self.short_name}', type='{self.variant_type.value}')"
-
-
-class DiagLayerContainer:
-
-    def __init__(
-        self,
-        *,
-        odx_id: OdxLinkId,
-        short_name: str,
-        long_name: Optional[str],
-        description: Optional[str],
-        admin_data: Optional[AdminData],
-        company_datas: Optional[NamedItemList[CompanyData]],
-        ecu_shared_datas: List[DiagLayer],
-        protocols: List[DiagLayer],
-        functional_groups: List[DiagLayer],
-        base_variants: List[DiagLayer],
-        ecu_variants: List[DiagLayer],
-        sdgs: List[SpecialDataGroup],
-    ) -> None:
-        self.odx_id = odx_id
-        self.short_name = short_name
-        self.long_name = long_name
-        self.description = description
-        self.admin_data = admin_data
-        self.company_datas = company_datas
-
-        self.ecu_shared_datas = ecu_shared_datas
-        self.protocols = protocols
-        self.functional_groups = functional_groups
-        self.base_variants = base_variants
-        self.ecu_variants = ecu_variants
-        self.sdgs = sdgs
-
-        self._diag_layers = NamedItemList[DiagLayer](
-            short_name_as_id,
-            list(
-                chain(
-                    self.ecu_shared_datas,
-                    self.protocols,
-                    self.functional_groups,
-                    self.base_variants,
-                    self.ecu_variants,
-                )),
-        )
-
-    @staticmethod
-    def from_et(et_element) -> "DiagLayerContainer":
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
-        long_name = et_element.findtext("LONG-NAME")
-
-        # create the current ODX "document fragment" (description of the
-        # current document for references and IDs)
-        doc_frags = [OdxDocFragment(short_name, "CONTAINER")]
-
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-        description = create_description_from_et(et_element.find("DESC"))
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
-        company_datas = create_company_datas_from_et(et_element.find("COMPANY-DATAS"), doc_frags)
-        ecu_shared_datas = [
-            DiagLayer.from_et(dl_element, doc_frags)
-            for dl_element in et_element.iterfind("ECU-SHARED-DATAS/ECU-SHARED-DATA")
-        ]
-        protocols = [
-            DiagLayer.from_et(dl_element, doc_frags)
-            for dl_element in et_element.iterfind("PROTOCOLS/PROTOCOL")
-        ]
-        functional_groups = [
-            DiagLayer.from_et(dl_element, doc_frags)
-            for dl_element in et_element.iterfind("FUNCTIONAL-GROUPS/FUNCTIONAL-GROUP")
-        ]
-        base_variants = [
-            DiagLayer.from_et(dl_element, doc_frags)
-            for dl_element in et_element.iterfind("BASE-VARIANTS/BASE-VARIANT")
-        ]
-        ecu_variants = [
-            DiagLayer.from_et(dl_element, doc_frags)
-            for dl_element in et_element.iterfind("ECU-VARIANTS/ECU-VARIANT")
-        ]
-        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
-
-        return DiagLayerContainer(
-            odx_id=odx_id,
-            short_name=short_name,
-            long_name=long_name,
-            description=description,
-            admin_data=admin_data,
-            company_datas=company_datas,
-            ecu_shared_datas=ecu_shared_datas,
-            protocols=protocols,
-            functional_groups=functional_groups,
-            base_variants=base_variants,
-            ecu_variants=ecu_variants,
-            sdgs=sdgs,
-        )
-
-    def _build_odxlinks(self):
-        result = {}
-        result[self.odx_id] = self
-
-        if self.admin_data is not None:
-            result.update(self.admin_data._build_odxlinks())
-
-        if self.company_datas is not None:
-            for cd in self.company_datas:
-                result.update(cd._build_odxlinks())
-
-        for dl in chain(
-                self.ecu_shared_datas,
-                self.protocols,
-                self.functional_groups,
-                self.base_variants,
-                self.ecu_variants,
-        ):
-            result.update(dl._build_odxlinks())
-
-        for sdg in self.sdgs:
-            result.update(sdg._build_odxlinks())
-
-        return result
-
-    def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
-        if self.admin_data is not None:
-            self.admin_data._resolve_references(odxlinks)
-
-        if self.company_datas is not None:
-            for cd in self.company_datas:
-                cd._resolve_references(odxlinks)
-
-        for dl in chain(
-                self.ecu_shared_datas,
-                self.protocols,
-                self.functional_groups,
-                self.base_variants,
-                self.ecu_variants,
-        ):
-            dl._resolve_references(odxlinks)
-
-        for sdg in self.sdgs:
-            sdg._resolve_references(odxlinks)
-
-    @property
-    def diag_layers(self):
-        return self._diag_layers
-
-    def __getitem__(self, key: Union[int, str]) -> DiagLayer:
-        return self.diag_layers[key]
-
-    def __repr__(self) -> str:
-        return f"DiagLayerContainer('{self.short_name}')"
-
-    def __str__(self) -> str:
-        return f"DiagLayerContainer('{self.short_name}')"

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: MIT
+
+from itertools import chain
+from typing import List, Optional, Union
+
+from .admindata import AdminData
+from .companydata import CompanyData, create_company_datas_from_et
+from .diaglayer import DiagLayer
+from .nameditemlist import NamedItemList
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
+from .utils import create_description_from_et, short_name_as_id
+
+
+class DiagLayerContainer:
+
+    def __init__(
+        self,
+        *,
+        odx_id: OdxLinkId,
+        short_name: str,
+        long_name: Optional[str],
+        description: Optional[str],
+        admin_data: Optional[AdminData],
+        company_datas: Optional[NamedItemList[CompanyData]],
+        ecu_shared_datas: List[DiagLayer],
+        protocols: List[DiagLayer],
+        functional_groups: List[DiagLayer],
+        base_variants: List[DiagLayer],
+        ecu_variants: List[DiagLayer],
+        sdgs: List[SpecialDataGroup],
+    ) -> None:
+        self.odx_id = odx_id
+        self.short_name = short_name
+        self.long_name = long_name
+        self.description = description
+        self.admin_data = admin_data
+        self.company_datas = company_datas
+
+        self.ecu_shared_datas = ecu_shared_datas
+        self.protocols = protocols
+        self.functional_groups = functional_groups
+        self.base_variants = base_variants
+        self.ecu_variants = ecu_variants
+        self.sdgs = sdgs
+
+        self._diag_layers = NamedItemList[DiagLayer](
+            short_name_as_id,
+            list(
+                chain(
+                    self.ecu_shared_datas,
+                    self.protocols,
+                    self.functional_groups,
+                    self.base_variants,
+                    self.ecu_variants,
+                )),
+        )
+
+    @staticmethod
+    def from_et(et_element) -> "DiagLayerContainer":
+        short_name = et_element.findtext("SHORT-NAME")
+        assert short_name is not None
+        long_name = et_element.findtext("LONG-NAME")
+
+        # create the current ODX "document fragment" (description of the
+        # current document for references and IDs)
+        doc_frags = [OdxDocFragment(short_name, "CONTAINER")]
+
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+        description = create_description_from_et(et_element.find("DESC"))
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        company_datas = create_company_datas_from_et(et_element.find("COMPANY-DATAS"), doc_frags)
+        ecu_shared_datas = [
+            DiagLayer.from_et(dl_element, doc_frags)
+            for dl_element in et_element.iterfind("ECU-SHARED-DATAS/ECU-SHARED-DATA")
+        ]
+        protocols = [
+            DiagLayer.from_et(dl_element, doc_frags)
+            for dl_element in et_element.iterfind("PROTOCOLS/PROTOCOL")
+        ]
+        functional_groups = [
+            DiagLayer.from_et(dl_element, doc_frags)
+            for dl_element in et_element.iterfind("FUNCTIONAL-GROUPS/FUNCTIONAL-GROUP")
+        ]
+        base_variants = [
+            DiagLayer.from_et(dl_element, doc_frags)
+            for dl_element in et_element.iterfind("BASE-VARIANTS/BASE-VARIANT")
+        ]
+        ecu_variants = [
+            DiagLayer.from_et(dl_element, doc_frags)
+            for dl_element in et_element.iterfind("ECU-VARIANTS/ECU-VARIANT")
+        ]
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
+
+        return DiagLayerContainer(
+            odx_id=odx_id,
+            short_name=short_name,
+            long_name=long_name,
+            description=description,
+            admin_data=admin_data,
+            company_datas=company_datas,
+            ecu_shared_datas=ecu_shared_datas,
+            protocols=protocols,
+            functional_groups=functional_groups,
+            base_variants=base_variants,
+            ecu_variants=ecu_variants,
+            sdgs=sdgs,
+        )
+
+    def _build_odxlinks(self):
+        result = {}
+        result[self.odx_id] = self
+
+        if self.admin_data is not None:
+            result.update(self.admin_data._build_odxlinks())
+
+        if self.company_datas is not None:
+            for cd in self.company_datas:
+                result.update(cd._build_odxlinks())
+
+        for dl in chain(
+                self.ecu_shared_datas,
+                self.protocols,
+                self.functional_groups,
+                self.base_variants,
+                self.ecu_variants,
+        ):
+            result.update(dl._build_odxlinks())
+
+        for sdg in self.sdgs:
+            result.update(sdg._build_odxlinks())
+
+        return result
+
+    def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
+        if self.admin_data is not None:
+            self.admin_data._resolve_references(odxlinks)
+
+        if self.company_datas is not None:
+            for cd in self.company_datas:
+                cd._resolve_references(odxlinks)
+
+        for dl in chain(
+                self.ecu_shared_datas,
+                self.protocols,
+                self.functional_groups,
+                self.base_variants,
+                self.ecu_variants,
+        ):
+            dl._resolve_references(odxlinks)
+
+        for sdg in self.sdgs:
+            sdg._resolve_references(odxlinks)
+
+    @property
+    def diag_layers(self):
+        return self._diag_layers
+
+    def __getitem__(self, key: Union[int, str]) -> DiagLayer:
+        return self.diag_layers[key]
+
+    def __repr__(self) -> str:
+        return f"DiagLayerContainer('{self.short_name}')"
+
+    def __str__(self) -> str:
+        return f"DiagLayerContainer('{self.short_name}')"

--- a/odxtools/diaglayertype.py
+++ b/odxtools/diaglayertype.py
@@ -3,7 +3,7 @@
 from enum import Enum
 
 
-class DIAG_LAYER_TYPE(Enum):
+class DiagLayerType(Enum):
     PROTOCOL = "PROTOCOL"
     FUNCTIONAL_GROUP = "FUNCTIONAL-GROUP"
     BASE_VARIANT = "BASE-VARIANT"
@@ -14,5 +14,5 @@ class DIAG_LAYER_TYPE(Enum):
     def from_str(cls, value: str):
         if value not in cls._value2member_map_.keys():
             raise ValueError(
-                f"{value} is not a string representation of a DIAG_LAYER_TYPE enum instance.")
+                f"{value} is not a string representation of a DiagLayerType enum instance.")
         return cls._value2member_map_[value]

--- a/odxtools/ecu_variant_matcher.py
+++ b/odxtools/ecu_variant_matcher.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import ByteString, Dict, Generator, List, Optional, Union
 
 from odxtools.diaglayer import DiagLayer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.ecu_variant_patterns import MatchingParameter
 from odxtools.exceptions import OdxError
 from odxtools.service import DiagService
@@ -21,7 +21,7 @@ class EcuVariantMatcher:
     ```python
 
     # initialize the matcher with a list of ecu variants,
-    # i.e., DiagLayer instances of variant_type == DIAG_LAYER_TYPE.ECU-VARIANT
+    # i.e., DiagLayer instances of variant_type == DiagLayerType.ECU-VARIANT
     matcher = EcuVariantMatcher(ecu_variant_candidates=[...], use_cache=use_cache)
 
     # run the request loop to obtain responses for every request
@@ -95,7 +95,7 @@ class EcuVariantMatcher:
 
         self.ecus = ecu_variant_candidates
         for ecu in self.ecus:
-            assert ecu.variant_type == DIAG_LAYER_TYPE.ECU_VARIANT
+            assert ecu.variant_type == DiagLayerType.ECU_VARIANT
 
         self.use_cache = use_cache
         self.req_resp_cache: Dict[ByteString, bytes] = {}

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -3,7 +3,7 @@ import warnings
 from typing import TYPE_CHECKING, Dict, List, Union
 
 from .dataobjectproperty import DopBase
-from .diaglayertype import DIAG_LAYER_TYPE
+from .diaglayertype import DiagLayerType
 from .exceptions import OdxWarning
 from .globals import xsi
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -14,17 +14,17 @@ if TYPE_CHECKING:
     from .diaglayer import DiagLayer
 
 # Defines priority of overriding objects
-PRIORITY_OF_DIAG_LAYER_TYPE: Dict[DIAG_LAYER_TYPE, int] = {
-    DIAG_LAYER_TYPE.PROTOCOL:
+PRIORITY_OF_DIAG_LAYER_TYPE: Dict[DiagLayerType, int] = {
+    DiagLayerType.PROTOCOL:
         1,
-    DIAG_LAYER_TYPE.FUNCTIONAL_GROUP:
+    DiagLayerType.FUNCTIONAL_GROUP:
         2,
-    DIAG_LAYER_TYPE.BASE_VARIANT:
+    DiagLayerType.BASE_VARIANT:
         3,
-    DIAG_LAYER_TYPE.ECU_VARIANT:
+    DiagLayerType.ECU_VARIANT:
         4,
     # Inherited services from ECU Shared Data always override inherited services from other diag layers
-    DIAG_LAYER_TYPE.ECU_SHARED_DATA:
+    DiagLayerType.ECU_SHARED_DATA:
         5,
 }
 

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+import warnings
+from typing import TYPE_CHECKING, Dict, List, Union
+
+from .dataobjectproperty import DopBase
+from .diaglayertype import DIAG_LAYER_TYPE
+from .exceptions import OdxWarning
+from .globals import xsi
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .service import DiagService
+from .singleecujob import SingleEcuJob
+
+if TYPE_CHECKING:
+    from .diaglayer import DiagLayer
+
+# Defines priority of overriding objects
+PRIORITY_OF_DIAG_LAYER_TYPE: Dict[DIAG_LAYER_TYPE, int] = {
+    DIAG_LAYER_TYPE.PROTOCOL:
+        1,
+    DIAG_LAYER_TYPE.FUNCTIONAL_GROUP:
+        2,
+    DIAG_LAYER_TYPE.BASE_VARIANT:
+        3,
+    DIAG_LAYER_TYPE.ECU_VARIANT:
+        4,
+    # Inherited services from ECU Shared Data always override inherited services from other diag layers
+    DIAG_LAYER_TYPE.ECU_SHARED_DATA:
+        5,
+}
+
+
+class ParentRef:
+
+    def __init__(
+        self,
+        *,
+        parent: Union[OdxLinkRef, "DiagLayer"],
+        ref_type: str,
+        not_inherited_diag_comms: List[str],  # short_name references
+        not_inherited_dops: List[str],
+    ):  # short_name references
+        """
+        Parameters
+        ----------
+        parent: OdxLinkRef | DiagLayer
+            A reference to the or the parent DiagLayer
+        ref_type: str
+        not_inherited_diag_comms: List[str]
+            short names of not inherited diag comms
+        not_inherited_dops: List[str]
+            short names of not inherited DOPs
+        """
+        if ref_type not in [
+                "PROTOCOL-REF",
+                "BASE-VARIANT-REF",
+                "ECU-SHARED-DATA-REF",
+                "FUNCTIONAL-GROUP-REF",
+        ]:
+            warnings.warn(f"Unknown parent ref type {ref_type}", OdxWarning)
+        if isinstance(parent, OdxLinkRef):
+            self.parent_ref = parent
+            self.parent_diag_layer = None
+        else:
+            assert isinstance(parent, DiagLayer)
+
+            self.parent_ref = OdxLinkRef.from_id(parent.odx_id)
+            self.parent_diag_layer = parent
+        self.not_inherited_diag_comms = not_inherited_diag_comms
+        self.not_inherited_dops = not_inherited_dops
+        self.ref_type = ref_type
+
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
+
+        parent_ref = OdxLinkRef.from_et(et_element, doc_frags)
+        assert parent_ref is not None
+
+        not_inherited_diag_comms = [
+            el.get("SHORT-NAME") for el in et_element.iterfind(
+                "NOT-INHERITED-DIAG-COMMS/NOT-INHERITED-DIAG-COMM/DIAG-COMM-SNREF")
+        ]
+        not_inherited_dops = [
+            el.get("SHORT-NAME")
+            for el in et_element.iterfind("NOT-INHERITED-DOPS/NOT-INHERITED-DOP/DOP-BASE-SNREF")
+        ]
+        ref_type = et_element.get(f"{xsi}type")
+
+        return ParentRef(
+            parent=parent_ref,
+            ref_type=ref_type,
+            not_inherited_diag_comms=not_inherited_diag_comms,
+            not_inherited_dops=not_inherited_dops,
+        )
+
+    def _resolve_references(self, odxlinks: OdxLinkDatabase):
+        self.parent_diag_layer = odxlinks.resolve(self.parent_ref)
+
+    def get_inheritance_priority(self):
+        return PRIORITY_OF_DIAG_LAYER_TYPE[self.parent_diag_layer.variant_type]
+
+    def get_inherited_services(self) -> List[Union[DiagService, SingleEcuJob]]:
+
+        if self.parent_diag_layer is None:
+            return []
+
+        services = dict()
+        for service in self.parent_diag_layer._services:
+            assert isinstance(service, (DiagService, SingleEcuJob))
+
+            if service.short_name not in self.not_inherited_diag_comms:
+                services[service.short_name] = service
+
+        return list(services.values())
+
+    def get_inherited_data_object_properties(self) -> List[DopBase]:
+        if self.parent_diag_layer is None:
+            return []
+
+        dops = {
+            dop.short_name: dop
+            for dop in self.parent_diag_layer._data_object_properties
+            if dop.short_name not in self.not_inherited_dops
+        }
+        return list(dops.values())
+
+    def get_inherited_communication_parameters(self):
+        return self.parent_diag_layer._communication_parameters

--- a/odxtools/templates/macros/printComparamRef.xml.jinja2
+++ b/odxtools/templates/macros/printComparamRef.xml.jinja2
@@ -37,7 +37,7 @@
   {%- if cp.prot_stack_snref is not none %}
   <PROT-STACK-SNREF SHORT-NAME="{{cp.prot_stack_snref}}"/>
   {%- endif %}
-  {%- if cp.prot_stack_snref is not none %}
+  {%- if cp.protocol_snref is not none %}
   <PROTOCOL-SNREF SHORT-NAME="{{cp.protocol_snref}}"/>
   {%- endif %}
 </COMPARAM-REF>

--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -5,9 +5,12 @@ import inspect
 import os
 import time
 import zipfile
-import jinja2
-import odxtools
 from typing import Any, Dict, List, Optional, Tuple
+
+import jinja2
+
+import odxtools
+
 from .odxtypes import bool_to_odxstr
 
 odxdatabase = None

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -6,7 +6,7 @@ from odxtools.compumethods import IdenticalCompuMethod, LinearCompuMethod
 from odxtools.dataobjectproperty import DataObjectProperty, DiagnosticTroubleCode, DtcDop
 from odxtools.diagcodedtypes import LeadingLengthInfoType, MinMaxLengthType, StandardLengthType
 from odxtools.diaglayer import DiagLayer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.endofpdufield import EndOfPduField
 from odxtools.exceptions import DecodeError
 from odxtools.message import Message
@@ -153,7 +153,7 @@ class TestIdentifyingService(unittest.TestCase):
         )
 
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,
@@ -255,7 +255,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,
@@ -379,7 +379,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,
@@ -549,7 +549,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,
@@ -730,7 +730,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,
@@ -869,7 +869,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,
@@ -1038,7 +1038,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
             short_name="dl_sn",
             long_name=None,

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -10,7 +10,7 @@ from odxtools.decodestate import ParameterValuePair
 from odxtools.diagcodedtypes import *
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 from odxtools.diaglayer import DiagLayer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.nameditemlist import NamedItemList
 from odxtools.odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
 from odxtools.parameters import CodedConstParameter, LengthKeyParameter, ValueParameter
@@ -220,7 +220,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
 
         # Dummy diag layer to resolve references from request parameters to DOPs
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
             short_name="dummy_DL",
             long_name=None,
@@ -489,7 +489,7 @@ class TestParamLengthInfoType(unittest.TestCase):
 
         # Dummy diag layer to resolve references from request parameters to DOPs
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
             short_name="dummy_DL",
             long_name=None,
@@ -780,7 +780,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
         # Dummy diag layer to resolve references from request parameters to DOPs
         diag_layer = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
             short_name="dummy_DL",
             long_name=None,

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Union
 import pytest
 
 from odxtools.diaglayer import DiagLayer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.ecu_variant_matcher import EcuVariantMatcher
 from odxtools.ecu_variant_patterns import EcuVariantPattern, MatchingParameter
 from odxtools.exceptions import OdxError
@@ -167,7 +167,7 @@ def ecu_variant_1(
     ecu_variant_pattern1: EcuVariantPattern,
 ) -> DiagLayer:
     result = DiagLayer(
-        variant_type=DIAG_LAYER_TYPE.ECU_VARIANT,
+        variant_type=DiagLayerType.ECU_VARIANT,
         odx_id=OdxLinkId(local_id="ecu_variant1", doc_fragments=doc_frags),
         short_name="ecu_variant1",
         long_name=None,
@@ -199,7 +199,7 @@ def ecu_variant_2(
     ecu_variant_pattern2: EcuVariantPattern,
 ) -> DiagLayer:
     result = DiagLayer(
-        variant_type=DIAG_LAYER_TYPE.ECU_VARIANT,
+        variant_type=DiagLayerType.ECU_VARIANT,
         odx_id=OdxLinkId(local_id="ecu_variant2", doc_fragments=doc_frags),
         short_name="ecu_variant2",
         long_name=None,
@@ -232,7 +232,7 @@ def ecu_variant_3(
     ecu_variant_pattern3: EcuVariantPattern,
 ) -> DiagLayer:
     result = DiagLayer(
-        variant_type=DIAG_LAYER_TYPE.ECU_VARIANT,
+        variant_type=DiagLayerType.ECU_VARIANT,
         odx_id=OdxLinkId(local_id="ecu_variant3", doc_fragments=doc_frags),
         short_name="ecu_variant3",
         long_name=None,

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -14,7 +14,7 @@ from odxtools.compumethods import CompuScale, Limit, LinearCompuMethod, Texttabl
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.diaglayer import DiagLayer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.functionalclass import FunctionalClass
 from odxtools.nameditemlist import NamedItemList
 from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -341,7 +341,7 @@ class TestSingleEcuJob(unittest.TestCase):
 
     def test_resolve_references(self):
         dl = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("ID.bv", doc_frags),
             short_name="bv",
             long_name=None,

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -8,7 +8,7 @@ from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 from odxtools.diaglayer import DiagLayer
-from odxtools.diaglayertype import DIAG_LAYER_TYPE
+from odxtools.diaglayertype import DiagLayerType
 from odxtools.nameditemlist import NamedItemList
 from odxtools.odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
 from odxtools.parameters import CodedConstParameter, ValueParameter
@@ -116,7 +116,7 @@ class TestUnitSpec(unittest.TestCase):
             sdgs=[],
         )
         dl = DiagLayer(
-            variant_type=DIAG_LAYER_TYPE.BASE_VARIANT,
+            variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("BV_id", doc_frags),
             short_name="BaseVariant",
             long_name=None,


### PR DESCRIPTION
This PR marks the start a small quest of mine to untangle the code spaghetti that is currently located in `diaglayer.py`. This PR moves the `ParentRef` and `DiagLayerContainer` classes into their separate files, renames the `DIAG_LAYER_TYPE` enum to `DiagLayerType` and fixes a small copy-and-pasto in the writing code for communication parameters.

Since all patches are self-contained and simple but some are fairly big, I recommend reviewing this PR by looking at the individual commits instead of the aggregate changes of the whole PR.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)