### PR TITLE
CommunicationParameterRef: add a `_build_odxlinks()` method

### DIFF
--- a/odxtools/communicationparameter.py
+++ b/odxtools/communicationparameter.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 import warnings
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from .comparam_subset import (BaseComparam, Comparam, ComplexComparam, ComplexValue,
                               create_complex_value_from_et)
 from .diaglayertype import DiagLayerType
 from .exceptions import OdxWarning
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .utils import create_description_from_et
 
 
@@ -75,6 +75,9 @@ class CommunicationParameterRef:
 
     def __str__(self) -> str:
         return self.__repr__()
+
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+        return {}
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase):
         # Temporary lenient until tests are updated

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -292,6 +292,7 @@ class DiagLayer:
         for obj in chain(
                 self._local_services,
                 self._local_single_ecu_jobs,
+                self._local_communication_parameters,
                 self.requests,
                 self.positive_responses,
                 self.negative_responses,


### PR DESCRIPTION
this allows to get rid of some special treatment of comparams in the diaglayer. (i.e., all objects featured by `DiagLayer` which have a `._resolve_references()` should now also have `.build_odxlinks()`)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)