### PR TITLE
clean up the `ParentRef` class

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1792,14 +1792,18 @@ somersault_lazy_diaglayer_raw = DiagLayerRaw(
     sdgs=[],
     parent_refs=[
         ParentRef(
-            parent=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
-            ref_type=DiagLayerType.BASE_VARIANT,
+            parent_layer_ref=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
+            self_layer_type=DiagLayerType.ECU_VARIANT,
+            parent_layer_type=DiagLayerType.BASE_VARIANT,
             # this variant does not do backflips
             not_inherited_diag_comms=[
                 somersault_requests["backward_flips"].short_name,
                 somersault_requests["set_operation_params"].short_name,
             ],
             not_inherited_dops=[],
+            not_inherited_variables=[],
+            not_inherited_tables=[],
+            not_inherited_global_neg_responses=[],
         )
     ],
     communication_parameters=somersault_communication_parameters,
@@ -2006,12 +2010,16 @@ somersault_assiduous_diaglayer_raw = DiagLayerRaw(
     additional_audiences=NamedItemList(short_name_as_id),
     sdgs=[],
     parent_refs=[
-        ParentRef(  # <- TODO: this is a bit sketchy IMO
-            parent=somersault_diaglayer,
-            ref_type=DiagLayerType.BASE_VARIANT,
+        ParentRef(
+            parent_layer_ref=OdxLinkRef.from_id(somersault_diaglayer.odx_id),
+            self_layer_type=DiagLayerType.ECU_VARIANT,
+            parent_layer_type=DiagLayerType.BASE_VARIANT,
             # this variant does everything which the base variant does
             not_inherited_diag_comms=[],
             not_inherited_dops=[],
+            not_inherited_variables=[],
+            not_inherited_tables=[],
+            not_inherited_global_neg_responses=[],
         )
     ],
     communication_parameters=somersault_communication_parameters,

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -175,7 +175,7 @@ class DiagLayer:
         result_dict: Dict[str, DiagLayer] = dict()
 
         for parent_ref in self._get_parent_refs_sorted_by_priority():
-            for prot in parent_ref.parent_diag_layer.protocols:
+            for prot in parent_ref.parent_layer.protocols:
                 result_dict[prot.short_name] = prot
 
         if self.diag_layer_raw.variant_type == DiagLayerType.PROTOCOL:

--- a/odxtools/diaglayerraw.py
+++ b/odxtools/diaglayerraw.py
@@ -163,7 +163,7 @@ class DiagLayerRaw:
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         parent_refs = [
-            ParentRef.from_et(pr_el, doc_frags)
+            ParentRef.from_et(pr_el, variant_type, doc_frags)
             for pr_el in et_element.iterfind("PARENT-REFS/PARENT-REF")
         ]
 

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT
-import warnings
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from .dataobjectproperty import DopBase
 from .diaglayertype import DiagLayerType
-from .exceptions import OdxWarning
 from .globals import xsi
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .service import DiagService
@@ -15,101 +14,106 @@ if TYPE_CHECKING:
 
 # Defines priority of overriding objects
 PRIORITY_OF_DIAG_LAYER_TYPE: Dict[DiagLayerType, int] = {
-    DiagLayerType.PROTOCOL:
-        1,
-    DiagLayerType.FUNCTIONAL_GROUP:
-        2,
-    DiagLayerType.BASE_VARIANT:
-        3,
-    DiagLayerType.ECU_VARIANT:
-        4,
-    # Inherited services from ECU Shared Data always override inherited services from other diag layers
-    DiagLayerType.ECU_SHARED_DATA:
-        5,
+    DiagLayerType.ECU_SHARED_DATA: 0,
+    DiagLayerType.PROTOCOL: 1,
+    DiagLayerType.FUNCTIONAL_GROUP: 2,
+    DiagLayerType.BASE_VARIANT: 3,
+    DiagLayerType.ECU_VARIANT: 4,
 }
 
 
+@dataclass
 class ParentRef:
+    parent_layer_ref: OdxLinkRef
+    self_layer_type: DiagLayerType
+    parent_layer_type: DiagLayerType
+    not_inherited_diag_comms: List[str]  # short_name references
+    not_inherited_variables: List[str]  # short_name references
+    not_inherited_dops: List[str]  # short_name references
+    not_inherited_tables: List[str]  # short_name references
+    not_inherited_global_neg_responses: List[str]  # short_name references
 
-    def __init__(
-        self,
-        *,
-        parent: Union[OdxLinkRef, "DiagLayer"],
-        ref_type: DiagLayerType,
-        not_inherited_diag_comms: List[str],  # short_name references
-        not_inherited_dops: List[str],
-    ):  # short_name references
-        """
-        Parameters
-        ----------
-        parent: OdxLinkRef | DiagLayer
-            A reference to the or the parent DiagLayer
-        ref_type: str
-        not_inherited_diag_comms: List[str]
-            short names of not inherited diag comms
-        not_inherited_dops: List[str]
-            short names of not inherited DOPs
-        """
-        if ref_type.value not in [
-                "PROTOCOL",
-                "BASE-VARIANT",
-                "ECU-SHARED-DATA",
-                "FUNCTIONAL-GROUP",
-        ]:
-            warnings.warn(f"Unknown parent ref type {ref_type}", OdxWarning)
-        if isinstance(parent, OdxLinkRef):
-            self.parent_ref = parent
-            self.parent_diag_layer = None
-        else:
-            from .diaglayer import DiagLayer
-            assert isinstance(parent, DiagLayer)
+    def __post_init__(self) -> None:
+        # make sure that the layer from which we inherit are of lower
+        # priority than us.
+        self_prio = PRIORITY_OF_DIAG_LAYER_TYPE[self.self_layer_type]
+        parent_prio = PRIORITY_OF_DIAG_LAYER_TYPE[self.parent_layer_type]
+        assert self_prio > parent_prio, "diagnostic layers can only inherit from layers of lower priority"
 
-            self.parent_ref = OdxLinkRef.from_id(parent.diag_layer_raw.odx_id)
-            self.parent_diag_layer = parent
-        self.not_inherited_diag_comms = not_inherited_diag_comms
-        self.not_inherited_dops = not_inherited_dops
-        self.ref_type = ref_type
+    @property
+    def parent_layer(self) -> "DiagLayer":
+        return self._parent_layer
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
+    def from_et(et_element, self_layer_type: DiagLayerType,
+                doc_frags: List[OdxDocFragment]) -> "ParentRef":
 
-        parent_ref = OdxLinkRef.from_et(et_element, doc_frags)
-        assert parent_ref is not None
+        parent_layer_ref = OdxLinkRef.from_et(et_element, doc_frags)
+        assert parent_layer_ref is not None
 
         not_inherited_diag_comms = [
-            el.get("SHORT-NAME") for el in et_element.iterfind(
-                "NOT-INHERITED-DIAG-COMMS/NOT-INHERITED-DIAG-COMM/DIAG-COMM-SNREF")
+            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-DIAG-COMMS/"
+                                                               "NOT-INHERITED-DIAG-COMM/"
+                                                               "DIAG-COMM-SNREF")
         ]
         not_inherited_dops = [
-            el.get("SHORT-NAME")
-            for el in et_element.iterfind("NOT-INHERITED-DOPS/NOT-INHERITED-DOP/DOP-BASE-SNREF")
+            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-DOPS/"
+                                                               "NOT-INHERITED-DOP/"
+                                                               "DOP-BASE-SNREF")
         ]
-        ref_type = et_element.get(f"{xsi}type")
-        ref_type = ref_type[:-len("-REF")]
+        not_inherited_tables = [
+            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-TABLES/"
+                                                               "NOT-INHERITED-TABLE/"
+                                                               "TABLE-SNREF")
+        ]
+        not_inherited_variables = [
+            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-VARIABLES/"
+                                                               "NOT-INHERITED-VARIABLE/"
+                                                               "DIAG-VARIABLE-SNREF")
+        ]
+
+        not_inherited_global_neg_responses = [
+            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-GLOBAL-NEG-RESPONSES/"
+                                                               "NOT-INHERITED-GLOBAL-NEG-RESPONSE/"
+                                                               "GLOBAL-NEG-RESPONSE-SNREF")
+        ]
+
+        # determine the type of the referenced diag layer. for
+        # this, we need to strip the '-REF' suffix of the
+        # element's {xsi}type attribute
+        parent_layer_type_str = et_element.get(f"{xsi}type")
+        assert parent_layer_type_str is not None and parent_layer_type_str.endswith("-REF")
+        parent_layer_type = DiagLayerType(parent_layer_type_str[:-4])
 
         return ParentRef(
-            parent=parent_ref,
-            ref_type=DiagLayerType(ref_type),
+            parent_layer_ref=parent_layer_ref,
+            self_layer_type=self_layer_type,
+            parent_layer_type=DiagLayerType(parent_layer_type),
             not_inherited_diag_comms=not_inherited_diag_comms,
+            not_inherited_variables=not_inherited_variables,
             not_inherited_dops=not_inherited_dops,
+            not_inherited_tables=not_inherited_tables,
+            not_inherited_global_neg_responses=not_inherited_global_neg_responses,
         )
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_references(self, odxlinks: OdxLinkDatabase) -> None:
-        self.parent_diag_layer = odxlinks.resolve(self.parent_ref)
+        self._parent_layer = odxlinks.resolve(self.parent_layer_ref)
+
+        assert self._parent_layer.variant_type == self.parent_layer_type, \
+            "Incorrect PARENT-REF"
 
     def get_inheritance_priority(self):
-        return PRIORITY_OF_DIAG_LAYER_TYPE[self.parent_diag_layer.diag_layer_raw.variant_type]
+        return PRIORITY_OF_DIAG_LAYER_TYPE[self.parent_layer_type]
 
     def get_inherited_services(self) -> List[Union[DiagService, SingleEcuJob]]:
-
-        if self.parent_diag_layer is None:
+        if self.parent_layer is None:
             return []
 
         services = dict()
-        for service in self.parent_diag_layer._services:
+        for service in self.parent_layer._services:
             assert isinstance(service, (DiagService, SingleEcuJob))
 
             if service.short_name not in self.not_inherited_diag_comms:
@@ -118,15 +122,15 @@ class ParentRef:
         return list(services.values())
 
     def get_inherited_data_object_properties(self) -> List[DopBase]:
-        if self.parent_diag_layer is None:
+        if self.parent_layer is None:
             return []
 
         dops = {
             dop.short_name: dop
-            for dop in self.parent_diag_layer._data_object_properties
+            for dop in self.parent_layer._data_object_properties
             if dop.short_name not in self.not_inherited_dops
         }
         return list(dops.values())
 
     def get_inherited_communication_parameters(self):
-        return self.parent_diag_layer._communication_parameters
+        return self.parent_layer._communication_parameters

--- a/odxtools/templates/macros/printParentRef.xml.jinja2
+++ b/odxtools/templates/macros/printParentRef.xml.jinja2
@@ -5,10 +5,10 @@
 -#}
 
 {%- macro printParentRef(par) -%}
-<PARENT-REF ID-REF="{{par.parent_ref.ref_id}}"
-            DOCREF="{{par.parent_diag_layer.short_name}}"
+<PARENT-REF ID-REF="{{par.parent_layer_ref.ref_id}}"
+            DOCREF="{{par.parent_layer.short_name}}"
             DOCTYPE="CONTAINER"
-            xsi:type="{{par.ref_type.value}}-REF">
+            xsi:type="{{par.parent_layer_type.value}}-REF">
 {%- if par.not_inherited_diag_comms %}
  <NOT-INHERITED-DIAG-COMMS>
 {%-  for nidc in par.not_inherited_diag_comms %}


### PR DESCRIPTION
this cleans up the internals of the `ParentRef` class to make it consistent with the information provided by the XML, use (IMO) slightly more descriptive names, changes the inheritance priority of ECU-SHARED-DATA from the highest to lowest (i.e., everbody can derive from it instead of nobody) and converts the class to be a dataclass to make it clearer which attributes are supposed to be available and slightly reduce the amount of boiler-plate code.

In this context, note that the inheritance scheme which we implement is not 100% conformant with the specification: We allow a more specific (e.g., ECU-VARIANT) layer to inherit from any more generic layer (e.g., PROTOCOL), but the spec only allows to inherit from more generic layers that are once removed (i.e., BASE-VARIANT for ECU-VARIANT) plus from ECU-SHARED-DATA. Since we allow all inheritance possibilities of the spec (plus some more), I doubt that this will be a problem anywere except -- maybe -- for ODX editors build on top of odxtools...


Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)