### PR TITLE
diaglayer: refactor the communication parameter handling

### DIFF
--- a/odxtools/comparam_subset.py
+++ b/odxtools/comparam_subset.py
@@ -108,6 +108,7 @@ class ComplexComparam(BaseComparam):
             if cp_el.tag in ("COMPARAM", "COMPLEX-COMPARAM"):
                 self.comparams.append(create_any_comparam_from_et(cp_el, doc_frags))
 
+        self.complex_physical_default_value = None
         if cpdv_elem := et_element.find("COMPLEX-PHYSICAL-DEFAULT-VALUE"):
             self.complex_physical_default_value = create_complex_value_from_et(cpdv_elem)
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -521,8 +521,7 @@ class DiagLayer:
 
     def get_can_func_req_id(self, protocol_name: Optional[str] = None) -> Optional[int]:
         """CAN Functional Request Id."""
-        com_param = self.get_communication_parameter(
-            "ISO_15765_2.CP_CanFuncReqId", protocol_name=protocol_name)
+        com_param = self.get_communication_parameter("CP_CanFuncReqId", protocol_name=protocol_name)
         if com_param is None:
             return None
 

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -100,6 +100,3 @@ class ParentRef:
             if dop.short_name not in self.not_inherited_dops
         }
         return list(dops.values())
-
-    def get_inherited_communication_parameters(self):
-        return self.layer._communication_parameters


### PR DESCRIPTION
This continues the long quest to clean up `DiagLayer`:

it turns out that the names of the communication parameters are not unambiguous: e.g., "CP_UniqueRespIdTable" parameter is not so unique in the sense that it exists for CAN (comparam subset "ISO_15765_2") as well as for DoIP (CP subset "ISO_13400_2_DIS_2015") and both parameters have a completely different definition. (The same issue applies to e.g., "CP_TesterPresentTime", but this being a simple integer parameter, at least the returned value is of the same type.)

To get out of that pickle, the full parameter ID now has to be specified for `DiagLayer.get_communication_parameter()` (e.g., "ISO_15765_2.CP_UniqueRespIdTable").

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)