### PR TITLE
Untangle diaglayer (Part 6)

### DIFF
--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -41,9 +41,7 @@ def print_summary(
         all_services: List[Union[DiagService, SingleEcuJob]] = sorted(
             dl.services, key=lambda x: x.short_name)
 
-        data_object_properties: Collection[DopBase] = []
-        if dl.local_diag_data_dictionary_spec is not None:
-            data_object_properties = dl.local_diag_data_dictionary_spec.data_object_props
+        data_object_properties = dl.diag_data_dictionary_spec.data_object_props
         com_params = dl.communication_parameters
 
         print(f"{dl.variant_type} '{dl.short_name}'")

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from .dataobjectproperty import DataObjectProperty, DtcDop
+from .dataobjectproperty import DataObjectProperty, DopBase, DtcDop
 from .endofpdufield import EndOfPduField
 from .envdata import EnvironmentData
 from .envdatadesc import EnvironmentDataDescription
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 @dataclass
 class DiagDataDictionarySpec:
     dtc_dops: NamedItemList[DtcDop]
-    data_object_props: NamedItemList[DataObjectProperty]
+    data_object_props: NamedItemList[DopBase]
     structures: NamedItemList[BasicStructure]
     end_of_pdu_fields: NamedItemList[EndOfPduField]
     tables: NamedItemList[Table]

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from .dataobjectproperty import DataObjectProperty, DopBase, DtcDop
+from .dataobjectproperty import DataObjectProperty, DtcDop
 from .endofpdufield import EndOfPduField
 from .envdata import EnvironmentData
 from .envdatadesc import EnvironmentDataDescription
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 @dataclass
 class DiagDataDictionarySpec:
     dtc_dops: NamedItemList[DtcDop]
-    data_object_props: NamedItemList[DopBase]
+    data_object_props: NamedItemList[DataObjectProperty]
     structures: NamedItemList[BasicStructure]
     end_of_pdu_fields: NamedItemList[EndOfPduField]
     tables: NamedItemList[Table]

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -618,7 +618,6 @@ class DiagLayer:
         """Timeout on inactivity in seconds.
 
         This is defined by the communication parameter "CP_TesterPresentTime".
-        If the variant does not define this parameter, the default value 3.0 is returned.
 
         Description of the comparam: "Time between a response and the
         next subsequent tester present message (if no other request is

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -12,7 +12,7 @@ from .admindata import AdminData
 from .audience import AdditionalAudience, Audience
 from .communicationparameter import CommunicationParameterRef
 from .companydata import CompanyData, create_company_datas_from_et
-from .dataobjectproperty import DopBase, DtcDop
+from .dataobjectproperty import DataObjectProperty, DtcDop
 from .diagdatadictionaryspec import DiagDataDictionarySpec
 from .diaglayerraw import DiagLayerRaw
 from .diaglayertype import DiagLayerType
@@ -65,7 +65,8 @@ class DiagLayer:
         # Properties that include inherited objects
         self._services: NamedItemList[Union[DiagService,
                                             SingleEcuJob]] = NamedItemList(short_name_as_id)
-        self._data_object_properties: NamedItemList[DopBase] = NamedItemList(short_name_as_id)
+        self._data_object_properties: NamedItemList[DataObjectProperty] = NamedItemList(
+            short_name_as_id)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagLayer":
@@ -115,8 +116,8 @@ class DiagLayer:
         services = sorted(self._compute_available_services(odxlinks), key=short_name_as_id)
         self._services = NamedItemList[Union[DiagService, SingleEcuJob]](short_name_as_id, services)
 
-        dops = NamedItemList[DopBase](short_name_as_id,
-                                      self._compute_available_data_object_properties())
+        dops = NamedItemList[DataObjectProperty](short_name_as_id,
+                                                 self._compute_available_data_object_properties())
         dtc_dops: NamedItemList[DtcDop]
         structures: NamedItemList[BasicStructure]
         end_of_pdu_fields: NamedItemList[EndOfPduField]
@@ -293,7 +294,7 @@ class DiagLayer:
 
         return list(result_dict.values())
 
-    def _compute_available_data_object_properties(self) -> List[DopBase]:
+    def _compute_available_data_object_properties(self) -> List[DataObjectProperty]:
         """Returns the locally defined and inherited DOPs."""
         result_dict = {}
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -40,11 +40,7 @@ class DiagLayer:
     encoding/decoding of data, etc.
     """
 
-    def __init__(
-        self,
-        *,
-        diag_layer_raw: DiagLayerRaw,
-    ):
+    def __init__(self, *, diag_layer_raw: DiagLayerRaw) -> None:
         self.diag_layer_raw = diag_layer_raw
 
         # diagnostic communications. For convenience, we create

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -763,12 +763,5 @@ class DiagLayer:
     # </PDU decoding>
     #####
 
-    def __repr__(self) -> str:
-        return f"""DiagLayer(variant_type={self.diag_layer_raw.variant_type.value},
-          odx_id={repr(self.diag_layer_raw.odx_id)},
-          short_name={repr(self.diag_layer_raw.short_name)})"""
-
     def __str__(self) -> str:
-        return \
-            f"DiagLayer('{self.diag_layer_raw.short_name}', " \
-            f"type='{self.diag_layer_raw.variant_type.value}')"
+        return f"DiagLayer('{self.short_name}', type='{self.variant_type.value}')"

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -33,6 +33,12 @@ from .utils import create_description_from_et, short_name_as_id
 
 
 class DiagLayer:
+    """This class represents a "logical view" upon a diagnostic layer
+    according to the ODX standard.
+
+    i.e. it handles the value inheritance, communication parameters,
+    encoding/decoding of data, etc.
+    """
 
     def __init__(
         self,

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -46,14 +46,13 @@ class DiagLayerContainer:
 
         self._diag_layers = NamedItemList[DiagLayer](
             short_name_as_id,
-            list(
-                chain(
-                    self.ecu_shared_datas,
-                    self.protocols,
-                    self.functional_groups,
-                    self.base_variants,
-                    self.ecu_variants,
-                )),
+            chain(
+                self.ecu_shared_datas,
+                self.protocols,
+                self.functional_groups,
+                self.base_variants,
+                self.ecu_variants,
+            ),
         )
 
     @staticmethod

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -156,12 +156,12 @@ class EndOfPduField(DopBase):
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         """Recursively resolve any short-name references"""
         if self.structure_snref is not None:
-            self._structure = diag_layer.diag_data_dictionary_spec.data_object_props[
-                self.structure_snref]
+            dops = diag_layer.diag_data_dictionary_spec.data_object_props
+            self._structure = dops[self.structure_snref]
 
         if self.env_data_desc_snref is not None:
-            self._env_data_desc = diag_layer.diag_data_dictionary_spec.data_object_props[
-                self.env_data_desc_snref]
+            dops = diag_layer.diag_data_dictionary_spec.data_object_props
+            self._env_data_desc = dops[self.env_data_desc_snref]
 
     def __repr__(self) -> str:
         return f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_id}')"

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -156,10 +156,12 @@ class EndOfPduField(DopBase):
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         """Recursively resolve any short-name references"""
         if self.structure_snref is not None:
-            self._structure = diag_layer.data_object_properties[self.structure_snref]
+            self._structure = diag_layer.diag_data_dictionary_spec.data_object_props[
+                self.structure_snref]
 
         if self.env_data_desc_snref is not None:
-            self._env_data_desc = diag_layer.data_object_properties[self.env_data_desc_snref]
+            self._env_data_desc = diag_layer.diag_data_dictionary_spec.data_object_props[
+                self.env_data_desc_snref]
 
     def __repr__(self) -> str:
         return f"EndOfPduField(short_name='{self.short_name}', ref='{self.structure.odx_id}')"

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -46,7 +46,7 @@ class ParameterWithDOP(Parameter):
         super()._resolve_snrefs(diag_layer)
 
         if self.dop_snref:
-            self._dop = diag_layer.data_object_properties[self.dop_snref]
+            self._dop = diag_layer.diag_data_dictionary_spec.data_object_props[self.dop_snref]
 
     @property
     def dop(self) -> Optional[DopBase]:


### PR DESCRIPTION
This PR collects various smaller fixes for the diaglayer code (in that sense, it consists purely of "drive-by" fixes). The most notable of those changes is that the "logical" view now exposes all objects that are contained by the DIAG-DATA-DICTIONARY-SPEC tag using a separate `.data_dictionary_spec` attribute instead of providing e.g. the `.data_object_properties` directly. (This is not completely trivial because some of the sub-objects of the diag data dictionary spec are subject to value inheritance).

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)