### PR TITLE
Fix linear compumethod

### DIFF
--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -52,9 +52,10 @@ def _parse_compu_scale_to_linear_compu_method(
     offset = computation_python_type(next(nums).text)
     factor_el = next(nums, None)
     factor = computation_python_type(factor_el.text if factor_el is not None else "0")
+    denominator = 1.0
     if coeffs.find("COMPU-DENOMINATOR/V") is not None:
-        kwargs["denominator"] = float(coeffs.findtext("COMPU-DENOMINATOR/V"))
-        assert kwargs["denominator"] > 0
+        denominator = float(coeffs.findtext("COMPU-DENOMINATOR/V"))
+        assert denominator > 0
 
     # Read lower limit
     internal_lower_limit = Limit.from_et(
@@ -79,7 +80,7 @@ def _parse_compu_scale_to_linear_compu_method(
             logger.info("Scale linear without UPPER-LIMIT")
             internal_upper_limit = internal_lower_limit
     kwargs["internal_upper_limit"] = internal_upper_limit
-    kwargs["denominator"] = 1.0
+    kwargs["denominator"] = denominator
     kwargs["factor"] = factor
     kwargs["offset"] = offset
 

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -53,9 +53,9 @@ def _parse_compu_scale_to_linear_compu_method(
     factor_el = next(nums, None)
     factor = computation_python_type(factor_el.text if factor_el is not None else "0")
     denominator = 1.0
-    if coeffs.find("COMPU-DENOMINATOR/V") is not None:
-        denominator = float(coeffs.findtext("COMPU-DENOMINATOR/V"))
-        assert denominator > 0
+    if (string := coeffs.findtext("COMPU-DENOMINATOR/V")) is not None:
+        denominator = float(string)
+        assert denominator != 0
 
     # Read lower limit
     internal_lower_limit = Limit.from_et(

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
+import warnings
 from typing import Any, Dict, List, Optional, Type, Union
 
+from ..exceptions import OdxWarning
 from ..globals import logger
 from ..odxlink import OdxDocFragment
 from ..odxtypes import DataType
@@ -55,8 +57,9 @@ def _parse_compu_scale_to_linear_compu_method(
     denominator = 1.0
     if (string := coeffs.findtext("COMPU-DENOMINATOR/V")) is not None:
         denominator = float(string)
-        assert denominator != 0
-
+        if denominator == 0:
+            warnings.warn("CompuMethod: A denominator of zero will lead to divisions by zero.",
+                          OdxWarning)
     # Read lower limit
     internal_lower_limit = Limit.from_et(
         scale_element.find("LOWER-LIMIT"),

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -72,11 +72,11 @@
    {%- endif %}
    {%- if cs.compu_inverse_value is not none %}
     <COMPU-INVERSE-VALUE>
-     <V>{{cs.compu_inverse_value | int }}</V>
+     <V>{{cs.compu_inverse_value}}</V>
     </COMPU-INVERSE-VALUE>
    {%- endif %}
     <COMPU-CONST>
-     <VT>{{cs.compu_const | e }}</VT>
+     <VT>{{cs.compu_const | e}}</VT>
     </COMPU-CONST>
    </COMPU-SCALE>
   {%- endfor %}
@@ -94,12 +94,12 @@
    {%- endif %}
 				<COMPU-RATIONAL-COEFFS>
 					<COMPU-NUMERATOR>
-						<V>{{cm.offset | int}}</V>
-						<V>{{(cm.factor) | int}}</V>
+						<V>{{cm.offset}}</V>
+						<V>{{cm.factor}}</V>
 					</COMPU-NUMERATOR>
    {%- if cm.denominator != 1 %}
 					<COMPU-DENOMINATOR>
-							<V>{{cm.denominator | int}}</V>
+							<V>{{cm.denominator}}</V>
 					</COMPU-DENOMINATOR>
    {%- endif %}
 				</COMPU-RATIONAL-COEFFS>
@@ -119,13 +119,12 @@
    {%- endif %}
 				<COMPU-RATIONAL-COEFFS>
 					<COMPU-NUMERATOR>
-							<V>{{(lm.offset) | int}}</V>
-							<V>{{(lm.factor*lm.denominator) | int}}</V>
+							<V>{{lm.offset}}</V>
+							<V>{{lm.factor}}</V>
 					</COMPU-NUMERATOR>
    {%- if lm.denominator != 1 %}
 					<COMPU-DENOMINATOR>
-							<V>1</V>{# TODO: currently we always assume the offset to be an integer #}
-							<V>{{lm.denominator | int}}</V>
+							<V>{{lm.denominator}}</V>
 					</COMPU-DENOMINATOR>
    {%- endif %}
 				</COMPU-RATIONAL-COEFFS>

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -95,11 +95,10 @@
 				<COMPU-RATIONAL-COEFFS>
 					<COMPU-NUMERATOR>
 						<V>{{cm.offset | int}}</V>
-						<V>{{(cm.factor*cm.denominator) | int}}</V>
+						<V>{{(cm.factor) | int}}</V>
 					</COMPU-NUMERATOR>
    {%- if cm.denominator != 1 %}
 					<COMPU-DENOMINATOR>
-							<V>1</V>{# TODO: currently we always assume the offset to be an integer #}
 							<V>{{cm.denominator | int}}</V>
 					</COMPU-DENOMINATOR>
    {%- endif %}

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -23,9 +23,9 @@ class TestLinearCompuMethod(unittest.TestCase):
         """Prepares the jinja environment and the sample linear compumethod"""
 
         def _get_jinja_environment():
-            __module_filname = inspect.getsourcefile(odxtools)
-            assert isinstance(__module_filname, str)
-            templates_dir = os.path.sep.join([os.path.dirname(__module_filname), "templates"])
+            __module_filename = inspect.getsourcefile(odxtools)
+            assert isinstance(__module_filename, str)
+            templates_dir = os.path.sep.join([os.path.dirname(__module_filename), "templates"])
 
             jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
 
@@ -98,8 +98,6 @@ class TestLinearCompuMethod(unittest.TestCase):
             return "".join(string.split())
 
         self.assertEqual(remove_spaces(out), remove_spaces(expected_odx))
-
-
 
     def test_linear_compu_method_type_denom_not_one(self):
         compu_method = LinearCompuMethod(
@@ -246,9 +244,9 @@ class TestTabIntpCompuMethod(unittest.TestCase):
         """Prepares the jinja environment and the sample tab-intp compumethod"""
 
         def _get_jinja_environment():
-            __module_filname = inspect.getsourcefile(odxtools)
-            assert isinstance(__module_filname, str)
-            templates_dir = os.path.sep.join([os.path.dirname(__module_filname), "templates"])
+            __module_filename = inspect.getsourcefile(odxtools)
+            assert isinstance(__module_filename, str)
+            templates_dir = os.path.sep.join([os.path.dirname(__module_filename), "templates"])
 
             jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
 

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -19,28 +19,9 @@ doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
 
 class TestLinearCompuMethod(unittest.TestCase):
 
-    def setUp(self) -> None:
-        """Prepares the jinja environment and the sample tab-intp compumethod"""
-
-        def _get_jinja_environment():
-            __module_filname = inspect.getsourcefile(odxtools)
-            assert isinstance(__module_filname, str)
-            templates_dir = os.path.sep.join([os.path.dirname(__module_filname), "templates"])
-
-            jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
-
-            # allows to put XML attributes on a separate line while it is
-            # collapsed with the previous line in the rendering
-            jinja_env.filters["odxtools_collapse_xml_attribute"] = (lambda x: " " + x.strip()
-                                                                    if x.strip() else "")
-
-            jinja_env.globals["hasattr"] = hasattr
-            return jinja_env
-
-        self.jinja_env = _get_jinja_environment()
-
     def test_read_odx(self):
-        compumethod = LinearCompuMethod(
+        """Test parsing of linear compumethod"""
+        expected = LinearCompuMethod(
             offset=0,
             factor=1,
             denominator=3600,
@@ -58,11 +39,11 @@ class TestLinearCompuMethod(unittest.TestCase):
                     <COMPU-SCALE>
                         <COMPU-RATIONAL-COEFFS>
                             <COMPU-NUMERATOR>
-                                <V>{compumethod.offset}</V>
-                                <V>{compumethod.factor}</V>
+                                <V>{expected.offset}</V>
+                                <V>{expected.factor}</V>
                             </COMPU-NUMERATOR>
                             <COMPU-DENOMINATOR>
-                                <V>{compumethod.denominator}</V>
+                                <V>{expected.denominator}</V>
                             </COMPU-DENOMINATOR>
                         </COMPU-RATIONAL-COEFFS>
                     </COMPU-SCALE>
@@ -70,8 +51,6 @@ class TestLinearCompuMethod(unittest.TestCase):
             </COMPU-INTERNAL-TO-PHYS>
         </COMPU-METHOD>
         """
-
-        expected = compumethod
 
         et_element = ElementTree.fromstring(compumethod_odx)
         actual = create_any_compu_method_from_et(et_element, doc_frags, expected.internal_type,

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -39,7 +39,8 @@ class TestLinearCompuMethod(unittest.TestCase):
 
         self.jinja_env = _get_jinja_environment()
 
-        self.compumethod = LinearCompuMethod(
+    def test_read_odx(self):
+        compumethod = LinearCompuMethod(
             offset=0,
             factor=1,
             denominator=3600,
@@ -49,7 +50,7 @@ class TestLinearCompuMethod(unittest.TestCase):
             internal_upper_limit=None,
         )
 
-        self.compumethod_odx = f"""
+        compumethod_odx = f"""
         <COMPU-METHOD>
             <CATEGORY>LINEAR</CATEGORY>
             <COMPU-INTERNAL-TO-PHYS>
@@ -57,11 +58,11 @@ class TestLinearCompuMethod(unittest.TestCase):
                     <COMPU-SCALE>
                         <COMPU-RATIONAL-COEFFS>
                             <COMPU-NUMERATOR>
-                                <V>{self.compumethod.offset}</V>
-                                <V>{self.compumethod.factor}</V>
+                                <V>{compumethod.offset}</V>
+                                <V>{compumethod.factor}</V>
                             </COMPU-NUMERATOR>
                             <COMPU-DENOMINATOR>
-                                <V>{self.compumethod.denominator}</V>
+                                <V>{compumethod.denominator}</V>
                             </COMPU-DENOMINATOR>
                         </COMPU-RATIONAL-COEFFS>
                     </COMPU-SCALE>
@@ -70,10 +71,9 @@ class TestLinearCompuMethod(unittest.TestCase):
         </COMPU-METHOD>
         """
 
-    def test_read_odx(self):
-        expected = self.compumethod
+        expected = compumethod
 
-        et_element = ElementTree.fromstring(self.compumethod_odx)
+        et_element = ElementTree.fromstring(compumethod_odx)
         actual = create_any_compu_method_from_et(et_element, doc_frags, expected.internal_type,
                                                  expected.physical_type)
         self.assertIsInstance(actual, LinearCompuMethod)


### PR DESCRIPTION
this is based on @JoSglch's https://github.com/mercedes-benz/odxtools/pull/130, i.e. all praise for this belongs to @JoSglch, while all remaining bugs are my own fault: the differences to the original are that this is rebased on top of the latest version of the `main` branch, some spurious `| int` filters are removed in the writing code, and a small typo in new the unit test has been fixed.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)