### PR TITLE
clean up the example implementation of the lazy somersault ECU

### DIFF
--- a/examples/somersaultlazy.py
+++ b/examples/somersaultlazy.py
@@ -488,9 +488,6 @@ async def main(args):
     else:
         assert args.mode == "unittest"
 
-        logging.basicConfig(level=logging.DEBUG)
-        logging.getLogger("odxtools").setLevel(logging.WARNING)
-
         # run both tasks in parallel. Since the server task does not
         # complete, we need to wait until the first task is completed
         # and then manually that this was the server task
@@ -531,7 +528,10 @@ parser.add_argument(
 
 args = parser.parse_args()  # deals with the help message handling
 
-#logging.basicConfig(level=logging.INFO)
+# set the verbosity of the log output
+logging.basicConfig(level=logging.DEBUG)  # log messages from the ECU itself
+logging.getLogger("odxtools").setLevel(
+    logging.WARNING)  # log messages stemming from the odxtools library
 
 can_channel = args.channel
 


### PR DESCRIPTION
this code has suffered from mild bitrot, and this commit thus changes the following things:

- no deprecated functions are used anymore (e.g. `get_receive_id()` -> `get_can_receive_id()`)
- take advantage of `NamedItemList`'s capability to access items by short name as attributes instead of resolving them manually.
- Use the appropriate helper functions of `DiagLayer` to receive communication parameters instead of doing this manually.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)