### PR TITLE
Refactor table classes

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1026,51 +1026,67 @@ somersault_global_negative_responses = {
 }
 
 # tables
+flip_quality_table_id = OdxLinkId("somersault.table.flip_quality", doc_frags)
+flip_quality_table_ref = OdxLinkRef.from_id(flip_quality_table_id)
 somersault_tables = {
     "flip_quality":
         Table(
-            odx_id=OdxLinkId("somersault.table.flip_quality", doc_frags),
+            odx_id=flip_quality_table_id,
             short_name="flip_quality",
             long_name="Flip Quality",
             description="<p>The quality the flip (average, good or best)</p>",
             semantic="QUALITY",
+            key_label="key",
+            admin_data=None,
+            struct_label="response",
             key_dop_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
-            table_rows=[
+            table_rows_raw=[
                 TableRow(
+                    table_ref=flip_quality_table_ref,
                     odx_id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
                     short_name="average",
                     long_name="Average",
-                    key=3,
-                    structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
                     description="<p>The quality of the flip is average</p>",
                     semantic="QUALITY-KEY",
+                    key_raw="3",
+                    structure_ref=OdxLinkRef.from_id(
+                        somersault_positive_responses["forward_flips_grudgingly_done"].odx_id),
+                    structure_snref=None,
                     dop_ref=None,
+                    dop_snref=None,
                     sdgs=[],
                 ),
                 TableRow(
+                    table_ref=flip_quality_table_ref,
                     odx_id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
                     short_name="good",
                     long_name="Good",
                     description=None,
                     semantic=None,
-                    key=5,
-                    structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
+                    key_raw="5",
+                    structure_ref=OdxLinkRef.from_id(
+                        somersault_positive_responses["forward_flips_happily_done"].odx_id),
+                    structure_snref=None,
                     dop_ref=None,
+                    dop_snref=None,
                     sdgs=[],
                 ),
                 TableRow(
+                    table_ref=flip_quality_table_ref,
                     odx_id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
                     short_name="best",
                     long_name="Best",
                     description=None,
                     semantic=None,
-                    key=10,
-                    structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
+                    key_raw="10",
+                    structure_ref=OdxLinkRef.from_id(
+                        somersault_positive_responses["backward_flips_grudgingly_done"].odx_id),
+                    structure_snref=None,
                     dop_ref=None,
+                    dop_snref=None,
                     sdgs=[],
                 ),
             ],
-            table_row_refs=[],
             sdgs=[],
         )
 }

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -109,9 +109,6 @@ class DiagLayer:
         global_negative_responses = self._compute_available_global_neg_responses(odxlinks)
         self._global_negative_responses = NamedItemList(short_name_as_id, global_negative_responses)
 
-        tables = self._compute_available_tables()
-        self._tables = NamedItemList(short_name_as_id, tables)
-
         functional_classes = self._compute_available_functional_classes()
         self._functional_classes = NamedItemList(short_name_as_id, functional_classes)
 
@@ -157,6 +154,7 @@ class DiagLayer:
         ############
 
         dops = NamedItemList(short_name_as_id, self._compute_available_data_object_props())
+        tables = NamedItemList(short_name_as_id, self._compute_available_tables())
         dtc_dops: NamedItemList[DtcDop]
         structures: NamedItemList[BasicStructure]
         end_of_pdu_fields: NamedItemList[EndOfPduField]
@@ -190,7 +188,7 @@ class DiagLayer:
                 dtc_dops=dtc_dops,
                 structures=structures,
                 end_of_pdu_fields=end_of_pdu_fields,
-                tables=NamedItemList(short_name_as_id, tables),
+                tables=tables,
                 env_data_descs=env_data_descs,
                 env_datas=env_datas,
                 muxs=muxs,
@@ -312,11 +310,6 @@ class DiagLayer:
     def global_negative_responses(self) -> NamedItemList[Response]:
         """All global negative responses applicable to this DiagLayer"""
         return self._global_negative_responses
-
-    @property
-    def tables(self) -> NamedItemList[Table]:
-        """All tables applicable to this DiagLayer"""
-        return self._tables
 
     @property
     def functional_classes(self) -> NamedItemList[FunctionalClass]:

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -312,6 +312,11 @@ class DiagLayer:
         return self._global_negative_responses
 
     @property
+    @deprecated(details="use diag_data_dictionary_spec.tables")
+    def tables(self) -> NamedItemList[Table]:
+        return self.diag_data_dictionary_spec.tables
+
+    @property
     def functional_classes(self) -> NamedItemList[FunctionalClass]:
         """All functional classes applicable to this DiagLayer"""
         return self._functional_classes

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -9,17 +9,7 @@ from .odxtypes import AtomicOdxType
 
 @dataclass
 class EncodeState:
-    """Utility class to be used while encoding a message.
-
-    While encoding parameters may update the dicts with new keys
-    but this is the only allowed change.
-    In particular the coded_message is not updated in-place.
-    Instead the new encode state can be constructed with::
-
-        for p in self.parameters:
-            prefix = p.encode_into_pdu(encode_state)
-            encode_state = encode_state._replace(coded_message=prefix)
-
+    """Utility class to holding the state variables needed for encoding a message.
     """
 
     #: payload that is constructed so far

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -112,7 +112,7 @@ class EndOfPduField(DopBase):
         physical_value: ParameterValueDict,
         encode_state: EncodeState,
         bit_position: int = 0,
-    ):
+    ) -> bytes:
         assert (bit_position == 0
                ), "End of PDU field must be byte aligned. Is there an error in reading the .odx?"
         if isinstance(physical_value, dict):
@@ -124,7 +124,6 @@ class EndOfPduField(DopBase):
             # If the value is given as a list, each list element is a encoded seperately using the structure.
             coded_rpc = bytes()
             for value in physical_value:
-                encode_state = encode_state._replace(coded_message=bytes())
                 coded_rpc += self.structure.convert_physical_to_bytes(value, encode_state)
             return coded_rpc
 

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -7,7 +7,8 @@ from ..odxtypes import AtomicOdxType
 from .parameterbase import Parameter
 
 if TYPE_CHECKING:
-    from ..table import Table, TableRow
+    from ..table import Table
+    from ..tablerow import TableRow
     from .diaglayer import DiagLayer
 
 

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -2,80 +2,36 @@
 # Copyright (c) 2022 MBition GmbH
 import abc
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
-from .dataobjectproperty import DopBase
-from .globals import logger
+from .admindata import AdminData
+from .dataobjectproperty import DataObjectProperty
+from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
-from .utils import create_description_from_et
 from .tablerow import TableRow
+from .utils import create_description_from_et, short_name_as_id
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
 
 
-class TableBase(abc.ABC):
-    """Base class for all Tables."""
-
-    def __init__(
-        self,
-        *,
-        odx_id: OdxLinkId,
-        short_name: str,
-        long_name: Optional[str],
-        sdgs: List[SpecialDataGroup],
-    ):
-        self.odx_id = odx_id
-        self.short_name = short_name
-        self.long_name = long_name
-        self.sdgs = sdgs
-
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result = {self.odx_id: self}
-
-        for sdg in self.sdgs:
-            result.update(sdg._build_odxlinks())
-
-        return result
-
-    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        for sdg in self.sdgs:
-            sdg._resolve_odxlinks(odxlinks)
-
-    def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
-        for sdg in self.sdgs:
-            sdg._resolve_snrefs(diag_layer)
-
-class Table(TableBase):
+@dataclass
+class Table:
     """This class represents a TABLE."""
 
-    def __init__(
-        self,
-        *,
-        odx_id: OdxLinkId,
-        short_name: str,
-        table_rows: List[TableRow],
-        table_row_refs: List[OdxLinkRef],
-        long_name: Optional[str],
-        key_dop_ref: Optional[OdxLinkRef],
-        description: Optional[str],
-        semantic: Optional[str],
-        sdgs: List[SpecialDataGroup],
-    ):
-        super().__init__(
-            odx_id=odx_id,
-            short_name=short_name,
-            long_name=long_name,
-            sdgs=sdgs,
-        )
-        self._local_table_rows = table_rows
-        self._ref_table_rows: List[TableRow] = []
-        self._table_row_refs = table_row_refs
-        self.key_dop_ref = key_dop_ref
-        self._key_dop = None
-        self.description = description
-        self.semantic = semantic
+    odx_id: OdxLinkId
+    semantic: Optional[str]
+    short_name: str
+    long_name: Optional[str]
+    description: Optional[str]
+    key_label: Optional[str]
+    struct_label: Optional[str]
+    admin_data: Optional[AdminData]
+    key_dop_ref: Optional[OdxLinkRef]
+    table_rows_raw: List[Union[TableRow, OdxLinkRef]]
+    # TODO: table_diag_comm_connectors
+    sdgs: List[SpecialDataGroup]
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "Table":
@@ -87,72 +43,76 @@ class Table(TableBase):
         long_name = et_element.findtext("LONG-NAME")
         semantic = et_element.get("SEMANTIC")
         description = create_description_from_et(et_element.find("DESC"))
-        key_dop_ref = None
-        if et_element.find("KEY-DOP-REF") is not None:
-            key_dop_ref = OdxLinkRef.from_et(et_element.find("KEY-DOP-REF"), doc_frags)
-        logger.debug("Parsing TABLE " + short_name)
+        key_label = et_element.findtext("KEY-LABEL")
+        struct_label = et_element.findtext("STRUCT-LABEL")
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        key_dop_ref = OdxLinkRef.from_et(et_element.find("KEY-DOP-REF"), doc_frags)
 
-        table_rows = [
-            TableRow.from_et(tr_elem, doc_frags) for tr_elem in et_element.iterfind("TABLE-ROW")
-        ]
+        table_rows_raw: List[Union[OdxLinkRef, TableRow]] = []
+        for sub_elem in et_element:
+            if sub_elem.tag == "TABLE-ROW":
+                table_rows_raw.append(
+                    TableRow.from_et(sub_elem, doc_frags, table_ref=OdxLinkRef.from_id(odx_id)))
+            elif sub_elem.tag == "TABLE-ROW-REF":
+                table_rows_raw.append(OdxLinkRef.from_et(sub_elem, doc_frags))
 
-        table_row_refs = []
-        for el in et_element.iterfind("TABLE-ROW-REF"):
-            ref = OdxLinkRef.from_et(el, doc_frags)
-            assert ref is not None
-            table_row_refs.append(ref)
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return Table(
             odx_id=odx_id,
+            semantic=semantic,
             short_name=short_name,
             long_name=long_name,
-            semantic=semantic,
             description=description,
+            key_label=key_label,
+            struct_label=struct_label,
+            admin_data=admin_data,
             key_dop_ref=key_dop_ref,
-            table_rows=table_rows,
-            table_row_refs=table_row_refs,
+            table_rows_raw=table_rows_raw,
             sdgs=sdgs,
         )
 
     @property
-    def key_dop(self) -> Optional[DopBase]:
+    def key_dop(self) -> Optional[DataObjectProperty]:
         """The key data object property associated with this table."""
         return self._key_dop
 
     @property
-    def table_rows(self) -> Iterable[TableRow]:
+    def table_rows(self) -> NamedItemList[TableRow]:
         """The table rows (both local and referenced) in this table."""
-        return self._local_table_rows + self._ref_table_rows
+        return self._table_rows
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result = super()._build_odxlinks()
+        result = {self.odx_id: self}
 
-        for tr in self._local_table_rows:
-            result.update(tr._build_odxlinks())
+        for table_row_wrapper in self.table_rows_raw:
+            if isinstance(table_row_wrapper, TableRow):
+                result.update(table_row_wrapper._build_odxlinks())
 
         return result
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        super()._resolve_odxlinks(odxlinks)
-
+        self._key_dop: Optional[DataObjectProperty] = None
         if self.key_dop_ref is not None:
-            self._key_dop = odxlinks.resolve(self.key_dop_ref)
+            self._key_dop = odxlinks.resolve(self.key_dop_ref, DataObjectProperty)
 
-        for table_row in self._local_table_rows:
-            table_row._resolve_odxlinks(odxlinks)
+        table_rows = []
+        for table_row_wrapper in self.table_rows_raw:
+            if isinstance(table_row_wrapper, TableRow):
+                table_row = table_row_wrapper
+                table_row._resolve_odxlinks(odxlinks)
+            else:
+                assert isinstance(table_row_wrapper, OdxLinkRef)
+                table_row = odxlinks.resolve(table_row_wrapper, TableRow)
 
-        self._ref_table_rows = []
-        for ref in self._table_row_refs:
-            tr = odxlinks.resolve(ref)
-            assert isinstance(tr, TableRow)
-            self._ref_table_rows.append(tr)
+            table_rows.append(table_row)
+
+        self._table_rows = NamedItemList(short_name_as_id, table_rows)
 
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
-        super()._resolve_snrefs(diag_layer)
-
-        for table_row in self._local_table_rows:
-            table_row._resolve_snrefs(diag_layer)
+        for table_row_wrapper in self.table_rows_raw:
+            if isinstance(table_row_wrapper, TableRow):
+                table_row_wrapper._resolve_snrefs(diag_layer)
 
     def __repr__(self) -> str:
         return (f"Table('{self.short_name}', " + ", ".join(

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -9,6 +9,7 @@ from .globals import logger
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
 from .utils import create_description_from_et
+from .tablerow import TableRow
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
@@ -45,95 +46,6 @@ class TableBase(abc.ABC):
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         for sdg in self.sdgs:
             sdg._resolve_snrefs(diag_layer)
-
-
-@dataclass
-class TableRow:
-    """This class represents a TABLE-ROW."""
-
-    odx_id: OdxLinkId
-    short_name: str
-    long_name: str
-    key: int
-    structure_ref: Optional[OdxLinkRef]
-    dop_ref: Optional[OdxLinkRef]
-    description: Optional[str]
-    semantic: Optional[str]
-    sdgs: List[SpecialDataGroup]
-
-    def __post_init__(self) -> None:
-        self._structure: Optional[DopBase] = None
-        self._dop: Optional[DopBase] = None
-
-    @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "TableRow":
-        """Reads a TABLE-ROW."""
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
-        long_name = et_element.findtext("LONG-NAME")
-        semantic = et_element.get("SEMANTIC")
-        description = create_description_from_et(et_element.find("DESC"))
-        key = et_element.findtext("KEY")
-        structure_ref = None
-        if et_element.find("STRUCTURE-REF") is not None:
-            structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
-        dop_ref = None
-        if et_element.find("DATA-OBJECT-PROP-REF") is not None:
-            dop_ref = OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags)
-        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
-
-        return TableRow(
-            odx_id=odx_id,
-            short_name=short_name,
-            long_name=long_name,
-            semantic=semantic,
-            description=description,
-            key=key,
-            structure_ref=structure_ref,
-            dop_ref=dop_ref,
-            sdgs=sdgs,
-        )
-
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result = {self.odx_id: self}
-
-        for sdg in self.sdgs:
-            result.update(sdg._build_odxlinks())
-
-        return result
-
-    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        if self.structure_ref is not None:
-            self._structure = odxlinks.resolve(self.structure_ref)
-        if self.dop_ref is not None:
-            self._dop = odxlinks.resolve(self.dop_ref)
-
-        for sdg in self.sdgs:
-            sdg._resolve_odxlinks(odxlinks)
-
-    def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
-        for sdg in self.sdgs:
-            sdg._resolve_snrefs(diag_layer)
-
-    @property
-    def structure(self) -> Optional[DopBase]:
-        """The structure associated with this table row."""
-        return self._structure
-
-    @property
-    def dop(self) -> Optional[DopBase]:
-        """The dop object resolved by dop_ref."""
-        return self._dop
-
-    def __repr__(self) -> str:
-        return (f"TableRow('{self.short_name}', " + ", ".join([
-            f"key='{self.key}'",
-            f"structure_ref='{self.structure_ref}'",
-            f"dop_ref='{self.dop_ref}'",
-        ]) + ")")
-
 
 class Table(TableBase):
     """This class represents a TABLE."""

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+
+from .dataobjectproperty import DopBase
+from .nameditemlist import NamedItemList
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxtypes import AtomicOdxType
+from .specialdata import SpecialDataGroup, create_sdgs_from_et
+from .structures import BasicStructure
+from .utils import create_description_from_et, short_name_as_id
+
+if TYPE_CHECKING:
+    from .diaglayer import DiagLayer
+    from .table import Table
+
+
+@dataclass
+class TableRow:
+    """This class represents a TABLE-ROW."""
+
+    odx_id: OdxLinkId
+    short_name: str
+    long_name: str
+    key: int
+    structure_ref: Optional[OdxLinkRef]
+    dop_ref: Optional[OdxLinkRef]
+    description: Optional[str]
+    semantic: Optional[str]
+    sdgs: List[SpecialDataGroup]
+
+    def __post_init__(self) -> None:
+        self._structure: Optional[DopBase] = None
+        self._dop: Optional[DopBase] = None
+
+    @staticmethod
+    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "TableRow":
+        """Reads a TABLE-ROW."""
+        odx_id = OdxLinkId.from_et(et_element, doc_frags)
+        assert odx_id is not None
+        short_name = et_element.findtext("SHORT-NAME")
+        assert short_name is not None
+        long_name = et_element.findtext("LONG-NAME")
+        semantic = et_element.get("SEMANTIC")
+        description = create_description_from_et(et_element.find("DESC"))
+        key = et_element.findtext("KEY")
+        structure_ref = None
+        if et_element.find("STRUCTURE-REF") is not None:
+            structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
+        dop_ref = None
+        if et_element.find("DATA-OBJECT-PROP-REF") is not None:
+            dop_ref = OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags)
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
+
+        return TableRow(
+            odx_id=odx_id,
+            short_name=short_name,
+            long_name=long_name,
+            semantic=semantic,
+            description=description,
+            key=key,
+            structure_ref=structure_ref,
+            dop_ref=dop_ref,
+            sdgs=sdgs,
+        )
+
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+        result = {self.odx_id: self}
+
+        for sdg in self.sdgs:
+            result.update(sdg._build_odxlinks())
+
+        return result
+
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
+        if self.structure_ref is not None:
+            self._structure = odxlinks.resolve(self.structure_ref)
+        if self.dop_ref is not None:
+            self._dop = odxlinks.resolve(self.dop_ref)
+
+        for sdg in self.sdgs:
+            sdg._resolve_odxlinks(odxlinks)
+
+    def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
+        for sdg in self.sdgs:
+            sdg._resolve_snrefs(diag_layer)
+
+    @property
+    def structure(self) -> Optional[DopBase]:
+        """The structure associated with this table row."""
+        return self._structure
+
+    @property
+    def dop(self) -> Optional[DopBase]:
+        """The dop object resolved by dop_ref."""
+        return self._dop
+
+    def __repr__(self) -> str:
+        return (f"TableRow('{self.short_name}', " + ", ".join([
+            f"key='{self.key}'",
+            f"structure_ref='{self.structure_ref}'",
+            f"dop_ref='{self.dop_ref}'",
+        ]) + ")")

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
-from .dataobjectproperty import DopBase
+from .dataobjectproperty import DataObjectProperty
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import AtomicOdxType
@@ -22,19 +22,28 @@ class TableRow:
     odx_id: OdxLinkId
     short_name: str
     long_name: str
-    key: int
+    table_ref: OdxLinkRef
+    key_raw: str
     structure_ref: Optional[OdxLinkRef]
+    structure_snref: Optional[str]
     dop_ref: Optional[OdxLinkRef]
+    dop_snref: Optional[str]
     description: Optional[str]
     semantic: Optional[str]
     sdgs: List[SpecialDataGroup]
 
     def __post_init__(self) -> None:
-        self._structure: Optional[DopBase] = None
-        self._dop: Optional[DopBase] = None
+        self._structure: Optional[BasicStructure] = None
+        self._dop: Optional[DataObjectProperty] = None
+
+        n = sum([0 if x is None else 1 for x in (self.structure_ref, self.structure_snref)])
+        assert n <= 1, f"Table row {self.short_name}: The structure can either be defined using ODXLINK or SNREF but not both."
+        n = sum([0 if x is None else 1 for x in (self.dop_ref, self.dop_snref)])
+        assert n <= 1, f"Table row {self.short_name}: The dop can either be defined using ODXLINK or SNREF but not both."
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "TableRow":
+    def from_et(et_element, doc_frags: List[OdxDocFragment], *,
+                table_ref: OdxLinkRef) -> "TableRow":
         """Reads a TABLE-ROW."""
         odx_id = OdxLinkId.from_et(et_element, doc_frags)
         assert odx_id is not None
@@ -43,24 +52,29 @@ class TableRow:
         long_name = et_element.findtext("LONG-NAME")
         semantic = et_element.get("SEMANTIC")
         description = create_description_from_et(et_element.find("DESC"))
-        key = et_element.findtext("KEY")
-        structure_ref = None
-        if et_element.find("STRUCTURE-REF") is not None:
-            structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
-        dop_ref = None
-        if et_element.find("DATA-OBJECT-PROP-REF") is not None:
-            dop_ref = OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags)
+        key_raw = et_element.findtext("KEY")
+        structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
+        structure_snref: Optional[str] = None
+        if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:
+            structure_snref = structure_snref_elem.attrib["SHORT-NAME"]
+        dop_ref = OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags)
+        dop_snref: Optional[str] = None
+        if (dop_snref_elem := et_element.find("DATA-OBJECT-PROP-SNREF")) is not None:
+            dop_snref = dop_snref_elem.attrib["SHORT-NAME"]
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         return TableRow(
             odx_id=odx_id,
             short_name=short_name,
             long_name=long_name,
+            table_ref=table_ref,
             semantic=semantic,
             description=description,
-            key=key,
+            key_raw=key_raw,
             structure_ref=structure_ref,
+            structure_snref=structure_snref,
             dop_ref=dop_ref,
+            dop_snref=dop_snref,
             sdgs=sdgs,
         )
 
@@ -74,30 +88,66 @@ class TableRow:
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
         if self.structure_ref is not None:
-            self._structure = odxlinks.resolve(self.structure_ref)
+            self._structure = odxlinks.resolve(self.structure_ref, BasicStructure)
         if self.dop_ref is not None:
-            self._dop = odxlinks.resolve(self.dop_ref)
+            self._dop = odxlinks.resolve(self.dop_ref, DataObjectProperty)
+
+        self._table = odxlinks.resolve(self.table_ref)
 
         for sdg in self.sdgs:
             sdg._resolve_odxlinks(odxlinks)
 
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
+        # convert the raw key into the proper internal
+        # representation. note that we cannot do this earlier because
+        # the table's ODXLINKs must be resolved and the order of
+        # ODXLINK resolution between tables and table-rows is
+        # undefined.
+        key_dop = self.table.key_dop
+        self._key: AtomicOdxType
+        if key_dop is None:
+            # if the table does not define a DOP for the keys: though
+            # luck, expose the raw key string. This is probably a gap
+            # in the ODX specification because table-rows must exhibit
+            # a "KEY" sub-tag, while the KEY-DOP-REF is optional for
+            # tables (and non-existant for table rows...)
+            self._key = self.key_raw
+        else:
+            self._key = key_dop.physical_type.base_data_type.from_string(self.key_raw)
+
+        ddd_spec = diag_layer.diag_data_dictionary_spec
+
+        if self.structure_snref is not None:
+            self._structure = ddd_spec.structures[self.structure_snref]
+        if self.dop_snref is not None:
+            self._dop = ddd_spec.data_object_props[self.dop_snref]
+
         for sdg in self.sdgs:
             sdg._resolve_snrefs(diag_layer)
 
     @property
-    def structure(self) -> Optional[DopBase]:
+    def table(self) -> "Table":
+        return self._table
+
+    # the value of the key expressed in the type represented by the
+    # referenced DOP
+    @property
+    def key(self) -> Optional[AtomicOdxType]:
+        return self._key
+
+    @property
+    def structure(self) -> Optional[BasicStructure]:
         """The structure associated with this table row."""
         return self._structure
 
     @property
-    def dop(self) -> Optional[DopBase]:
-        """The dop object resolved by dop_ref."""
+    def dop(self) -> Optional[DataObjectProperty]:
+        """The data object property object resolved by dop_ref."""
         return self._dop
 
     def __repr__(self) -> str:
         return (f"TableRow('{self.short_name}', " + ", ".join([
-            f"key='{self.key}'",
+            f"key='{str(self.key)}'",
             f"structure_ref='{self.structure_ref}'",
             f"dop_ref='{self.dop_ref}'",
         ]) + ")")

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -19,7 +19,8 @@
 {%- if table.key_dop_ref %}
  <KEY-DOP-REF ID-REF="{{ table.key_dop_ref.ref_id }}" />
 {%- endif %}
-{%- for table_row in table.table_rows %}
+ {%- for table_row in table.table_rows_raw %}
+ {%- if hasattr(table_row, "key") %}
  <TABLE-ROW ID="{{table_row.odx_id.local_id}}"
             {{-make_xml_attrib("SEMANTIC", table_row.semantic)}}>
   <SHORT-NAME>{{table_row.short_name}}</SHORT-NAME>
@@ -35,6 +36,9 @@
   {%- endif %}
   {{- psd.printSpecialDataGroups(table_row.sdgs)|indent(2, first=True) }}
  </TABLE-ROW>
+ {%- else %}
+ <TABLE-ROW-REF ID-REF="{{ table_row.ref_id }}" />
+ {%- endif %}
 {%- endfor %}
  {{- psd.printSpecialDataGroups(table.sdgs)|indent(1, first=True) }}
 </TABLE>

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -12,7 +12,7 @@ from odxtools.envdatadesc import EnvironmentDataDescription
 from odxtools.multiplexer import (Multiplexer, MultiplexerCase, MultiplexerDefaultCase,
                                   MultiplexerSwitchKey)
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.physicaltype import PhysicalType
 from odxtools.table import Table, TableRow
 from odxtools.utils import short_name_as_id
@@ -87,50 +87,63 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             sdgs=[],
         )
 
+        flip_quality_id = OdxLinkId("somersault.table.flip_quality", doc_frags)
+        flip_quality_ref = OdxLinkRef.from_id(flip_quality_id)
         table = Table(
-            odx_id=OdxLinkId("somersault.table.flip_quality", doc_frags),
+            odx_id=flip_quality_id,
             short_name="flip_quality",
             long_name="Flip Quality",
             description=None,
-            key_dop_ref="",
+            key_label=None,
+            struct_label=None,
+            admin_data=None,
+            key_dop_ref=None,
             semantic=None,
-            table_rows=[
+            table_rows_raw=[
                 TableRow(
                     odx_id=OdxLinkId("somersault.table.flip_quality.average", doc_frags),
+                    table_ref=flip_quality_ref,
                     short_name="average",
                     long_name="Average",
                     description=None,
                     semantic=None,
                     dop_ref=None,
-                    key=3,
+                    dop_snref=None,
+                    key_raw="3",
                     structure_ref=None,
+                    structure_snref=None,
                     sdgs=[],
                 ),
                 TableRow(
                     odx_id=OdxLinkId("somersault.table.flip_quality.good", doc_frags),
+                    table_ref=flip_quality_ref,
                     short_name="good",
                     long_name="Good",
                     description=None,
                     semantic=None,
                     dop_ref=None,
-                    key=5,
+                    dop_snref=None,
+                    key_raw="5",
                     structure_ref=None,
+                    structure_snref=None,
                     sdgs=[],
                 ),
                 TableRow(
                     odx_id=OdxLinkId("somersault.table.flip_quality.best", doc_frags),
+                    table_ref=flip_quality_ref,
                     short_name="best",
                     long_name="Best",
                     description=None,
                     semantic=None,
                     dop_ref=None,
-                    key=10,
+                    dop_snref=None,
+                    key_raw="10",
                     structure_ref=None,
+                    structure_snref=None,
                     sdgs=[],
                 ),
             ],
-            table_row_refs=[],
-            sdgs=None,
+            sdgs=[],
         )
 
         env_data = EnvironmentData(
@@ -147,7 +160,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     description=None,
                     semantic="DATA",
                     byte_position=0,
-                    dop_ref="dop-ref",
+                    dop_ref=OdxLinkRef("somersault.DOP.float", doc_frags),
                     dop_snref=None,
                     physical_default_value_raw=None,
                     bit_position=None,
@@ -160,7 +173,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     semantic="DATA",
                     byte_position=1,
                     physical_constant_value=1,
-                    dop_ref="dop-ref",
+                    dop_ref=OdxLinkRef("somersault.DOP.boolean", doc_frags),
                     dop_snref=None,
                     bit_position=None,
                     sdgs=[],
@@ -194,7 +207,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             switch_key=MultiplexerSwitchKey(
                 byte_position=0,
                 bit_position=0,
-                dop_ref="dop-ref",
+                dop_ref=OdxLinkRef("somersault.DOP.boolean", doc_frags),
             ),
             default_case=MultiplexerDefaultCase(
                 short_name="default_case",
@@ -243,7 +256,10 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         self.assertEqual(len(ddds.structures), 0)
         self.assertEqual(len(ddds.end_of_pdu_fields), 0)
 
-        self.assertEqual(set(ddds.all_data_object_properties), set([dtc_dop, dop_1, dop_2, table]))
+        self.assertEqual({x.short_name
+                          for x in ddds.all_data_object_properties},
+                         {x.short_name
+                          for x in (dtc_dop, dop_1, dop_2, table)})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this PR refactors the table classes once more:

- Table rows now get a reference to the table which contains them. This is required to resolve SNREFs in table rows.
- In Tables, the table rows are now specified as a mixed list of ODXLINK references and table row objects. The approach is identical to the one for diagnostic communication objects for diagnostic layer. The reason for this is that the XML specification defines rows this way (as with the diagnostic services, `table.table_rows` provides a fully resolved view, while `table.table_rows_raw` is the table row specification as it is found in the XML)
-  The `TableRow` class is put to a separate file and `TableBase` is subsumed into its only user, `Table`.
- The `DiagLayer` class does not hold the table objects directly anymore. instead, they are moved to the `DiagDataDictionarySpec` like in the XML.
- various smaller cleanups and refactorings

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)