### PR TITLE
refactor exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,30 @@ python3 -m odxtools list -a "$YOUR_PDX_FILE"
   # -> decoded response: [session()]
   ```
 
+## Using the non-strict mode
+
+By default, odxtools raises exceptions if it suspects that it cannot
+fulfill a requested operation correctly. For example, if the dataset
+it is instructed to load is detected to be not conformant with the ODX
+specification, or if completing the operation requires missing
+features of odxtools. To be able to deal with such cases, odxtools
+provides a "non-strict" mode where such issues are ignored, but where
+the results are undefined. The following snippet shows how to instruct
+odxtools to load a non-conforming file in non-strict mode, and after
+this is done, enables the safety checks again:
+
+  ```python
+  import odxtools
+
+  [...]
+
+  odxtools.exceptions.strict_mode = False
+  botched_db = odxtools.load_file("my_non-conforming_database.pdx")
+  odxtools.exceptions.strict_mode = True
+
+  [...]
+  ```
+
 ## Interactive Usage
 
 ### Python REPL

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -647,7 +647,8 @@ somersault_positive_responses = {
                         description=None,
                         diag_coded_type=somersault_diagcodedtypes["uint8"],
                         byte_position=0,
-                        coded_value=uds.positive_response_id(SID.ForwardFlip.value),  # type: ignore
+                        coded_value=uds.positive_response_id(
+                            SID.ForwardFlip.value),  # type: ignore[attr-defined]
                         bit_position=None,
                         sdgs=[],
                     ),

--- a/odxtools/__init__.py
+++ b/odxtools/__init__.py
@@ -63,12 +63,14 @@ References
 - _`[ISO22901]` The ISO 22901 Standard: https://www.iso.org/standard/41207.html
 
 """
+import odxtools.exceptions as exceptions
+
 from . import database
 from .compumethods import (IdenticalCompuMethod, LinearCompuMethod, ScaleLinearCompuMethod,
                            TexttableCompuMethod)
 from .database import Database
 from .diaglayer import DiagLayer
-from .exceptions import *
+from .exceptions import DecodeError, EncodeError, OdxError, OdxWarning
 from .load_file import load_file
 from .load_odx_d_file import load_odx_d_file
 from .load_pdx_file import load_pdx_file

--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -100,8 +100,6 @@ class CompanyRevisionInfo:
 
     @property
     def company_data(self) -> CompanyData:
-        if self._company_data is None:
-            odxraise()
         return self._company_data
 
     @staticmethod

--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from xml.etree import ElementTree
 
 from .companydata import CompanyData, TeamMember
+from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
@@ -33,8 +34,8 @@ class CompanyDocInfo:
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "CompanyDocInfo":
         # the company data reference is mandatory
-        company_data_ref = OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags)
-        assert company_data_ref is not None
+        company_data_ref = odxrequire(
+            OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags))
         team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
         doc_label = et_element.findtext("DOC-LABEL")
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
@@ -99,15 +100,16 @@ class CompanyRevisionInfo:
 
     @property
     def company_data(self) -> CompanyData:
-        assert self._company_data is not None
+        if self._company_data is None:
+            odxraise()
         return self._company_data
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "CompanyRevisionInfo":
 
-        company_data_ref = OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags)
-        assert company_data_ref is not None
+        company_data_ref = odxrequire(
+            OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags))
         revision_label = et_element.findtext("REVISION_LABEL")
         state = et_element.findtext("STATE")
 
@@ -148,8 +150,7 @@ class DocRevision:
         team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
         revision_label = et_element.findtext("REVISION-LABEL")
         state = et_element.findtext("STATE")
-        date = et_element.findtext("DATE")
-        assert date is not None
+        date = odxrequire(et_element.findtext("DATE"))
         tool = et_element.findtext("TOOL")
 
         crilist = [

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2022 MBition GmbH
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree.ElementTree import Element
 
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import odxstr_to_bool
 from .utils import create_description_from_et
@@ -23,12 +25,10 @@ class AdditionalAudience:
     description: Optional[str]
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "AdditionalAudience":
+    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "AdditionalAudience":
 
-        short_name = et_element.findtext("SHORT-NAME")
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
 

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -4,8 +4,8 @@ import re
 
 import markdownify
 
-from odxtools import DiagService
-from odxtools.structures import Request, Response
+from ..service import DiagService
+from ..structures import Request, Response
 
 
 def format_desc(desc, ident=0):

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from xml.etree import ElementTree
 
+from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
@@ -148,19 +149,12 @@ class TeamMember:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "TeamMember":
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
 
-        roles = list()
-        if (roles_elem := et_element.find("ROLES")) is not None:
-            for role_elem in roles_elem.iterfind("ROLE"):
-                role = role_elem.text
-                assert role is not None
-                roles.append(role)
+        roles = [odxrequire(role_elem.text) for role_elem in et_element.iterfind("ROLES/ROLE")]
 
         department = et_element.findtext("DEPARTMENT")
         address = et_element.findtext("ADDRESS")
@@ -210,8 +204,7 @@ class CompanyData:
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "CompanyData":
 
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -3,7 +3,7 @@
 import warnings
 from typing import Any, Dict, List, Optional, Type, Union
 
-from ..exceptions import OdxWarning
+from ..exceptions import OdxWarning, odxassert
 from ..globals import logger
 from ..odxlink import OdxDocFragment
 from ..odxtypes import DataType
@@ -26,18 +26,18 @@ def _parse_compu_scale_to_linear_compu_method(
     is_scale_linear=False,
     **kwargs,
 ):
-    assert physical_type in [
+    odxassert(physical_type in [
         DataType.A_FLOAT32,
         DataType.A_FLOAT64,
         DataType.A_INT32,
         DataType.A_UINT32,
-    ]
-    assert internal_type in [
+    ])
+    odxassert(internal_type in [
         DataType.A_FLOAT32,
         DataType.A_FLOAT64,
         DataType.A_INT32,
         DataType.A_UINT32,
-    ]
+    ])
 
     if physical_type.as_python_type() == float:
         computation_python_type = physical_type.from_string
@@ -78,8 +78,8 @@ def _parse_compu_scale_to_linear_compu_method(
         if not is_scale_linear:
             internal_upper_limit = Limit(float("inf"), IntervalType.INFINITE)
         else:
-            assert (internal_lower_limit is not None and
-                    internal_lower_limit.interval_type == IntervalType.CLOSED)
+            odxassert(internal_lower_limit is not None and
+                      internal_lower_limit.interval_type == IntervalType.CLOSED)
             logger.info("Scale linear without UPPER-LIMIT")
             internal_upper_limit = internal_lower_limit
     kwargs["internal_upper_limit"] = internal_upper_limit
@@ -94,7 +94,7 @@ def create_any_compu_method_from_et(et_element, doc_frags: List[OdxDocFragment],
                                     internal_type: DataType,
                                     physical_type: DataType) -> CompuMethod:
     compu_category = et_element.findtext("CATEGORY")
-    assert compu_category in [
+    odxassert(compu_category in [
         "IDENTICAL",
         "LINEAR",
         "SCALE-LINEAR",
@@ -103,7 +103,7 @@ def create_any_compu_method_from_et(et_element, doc_frags: List[OdxDocFragment],
         "TAB-INTP",
         "RAT-FUNC",
         "SCALE-RAT-FUNC",
-    ]
+    ])
 
     if et_element.find("COMPU-PHYS-TO-INTERNAL") is not None:  # TODO: Is this never used?
         raise NotImplementedError(f"Found COMPU-PHYS-TO-INTERNAL for category {compu_category}")
@@ -111,15 +111,16 @@ def create_any_compu_method_from_et(et_element, doc_frags: List[OdxDocFragment],
     kwargs: Dict[str, Any] = {"internal_type": internal_type}
 
     if compu_category == "IDENTICAL":
-        assert internal_type == physical_type or (
-            internal_type in [DataType.A_ASCIISTRING, DataType.A_UTF8STRING] and
-            physical_type == DataType.A_UNICODE2STRING), (
-                f"Internal type '{internal_type}' and physical type '{physical_type}'"
-                f" must be the same for compu methods of category '{compu_category}'")
+        odxassert(
+            internal_type == physical_type or
+            (internal_type in [DataType.A_ASCIISTRING, DataType.A_UTF8STRING] and
+             physical_type == DataType.A_UNICODE2STRING),
+            f"Internal type '{internal_type}' and physical type '{physical_type}'"
+            f" must be the same for compu methods of category '{compu_category}'")
         return IdenticalCompuMethod(internal_type=internal_type, physical_type=physical_type)
 
     if compu_category == "TEXTTABLE":
-        assert physical_type == DataType.A_UNICODE2STRING
+        odxassert(physical_type == DataType.A_UNICODE2STRING)
         compu_internal_to_phys = et_element.find("COMPU-INTERNAL-TO-PHYS")
 
         internal_to_phys: List[CompuScale] = []

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -3,6 +3,7 @@
 from enum import Enum
 from typing import NamedTuple, Optional, Union
 
+from ..exceptions import odxassert
 from ..odxtypes import DataType
 
 
@@ -31,7 +32,7 @@ class Limit(NamedTuple):
             if et_element.tag == "LOWER-LIMIT":
                 return Limit(float("-inf"), interval_type)
             else:
-                assert et_element.tag == "UPPER-LIMIT"
+                odxassert(et_element.tag == "UPPER-LIMIT")
                 return Limit(float("inf"), interval_type)
         elif internal_type == DataType.A_BYTEFIELD:
             hex_text = et_element.text

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 from typing import Optional, Union
 
+from ..exceptions import odxassert
 from ..odxtypes import DataType
 from .compumethodbase import CompuMethod
 from .limit import IntervalType, Limit
@@ -82,8 +83,8 @@ class LinearCompuMethod(CompuMethod):
                 internal_upper_limit.interval_type == IntervalType.INFINITE):
             self.internal_upper_limit = Limit(float("inf"), IntervalType.INFINITE)
 
-        assert self.internal_lower_limit is not None and self.internal_upper_limit is not None
-        assert denominator > 0 and isinstance(denominator, (int, float))
+        odxassert(self.internal_lower_limit is not None and self.internal_upper_limit is not None)
+        odxassert(denominator > 0 and isinstance(denominator, (int, float)))
 
         self.__compute_physical_limits()
 
@@ -111,7 +112,7 @@ class LinearCompuMethod(CompuMethod):
             is_upper_limit
                 True iff limit is the internal upper limit
             """
-            assert isinstance(limit.value, (int, float))
+            odxassert(isinstance(limit.value, (int, float)))
             if limit.interval_type == IntervalType.INFINITE:
                 return limit
             elif (limit.interval_type == limit.interval_type.OPEN and
@@ -159,13 +160,15 @@ class LinearCompuMethod(CompuMethod):
         return self.physical_type.make_from(result)
 
     def convert_internal_to_physical(self, internal_value) -> Union[int, float]:
-        assert self.is_valid_internal_value(internal_value)
+        odxassert(self.is_valid_internal_value(internal_value))
         return self._convert_internal_to_physical(internal_value)
 
     def convert_physical_to_internal(self, physical_value):
-        assert self.is_valid_physical_value(
-            physical_value
-        ), f"physical value {physical_value} of type {type(physical_value)} is not valid. Expected type {self.physical_type} with internal range {self.internal_lower_limit} to {self.internal_upper_limit}"
+        odxassert(
+            self.is_valid_physical_value(physical_value),
+            f"physical value {physical_value} of type {type(physical_value)} "
+            f"is not valid. Expected type {self.physical_type} with internal "
+            f"range {self.internal_lower_limit} to {self.internal_upper_limit}")
         if self.denominator is None:
             result = (physical_value - self.offset) / self.factor
         else:

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 from typing import Iterable
 
+from ..exceptions import odxassert
 from ..globals import logger
 from .compumethodbase import CompuMethod
 from .linearcompumethod import LinearCompuMethod
@@ -19,9 +20,10 @@ class ScaleLinearCompuMethod(CompuMethod):
         logger.debug("Created scale linear compu method!")
 
     def convert_physical_to_internal(self, physical_value):
-        assert self.is_valid_physical_value(
-            physical_value
-        ), f"cannot convert the invalid physical value {physical_value} of type {type(physical_value)}"
+        odxassert(
+            self.is_valid_physical_value(physical_value),
+            f"cannot convert the invalid physical value {physical_value} "
+            f"of type {type(physical_value)}")
         lin_method = next(
             scale for scale in self.linear_methods if scale.is_valid_physical_value(physical_value))
         return lin_method.convert_physical_to_internal(physical_value)

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 from typing import List, Tuple, Union
 
-from ..exceptions import DecodeError, EncodeError
+from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
 from ..globals import logger
 from ..odxtypes import DataType
 from .compumethodbase import CompuMethod
@@ -94,22 +94,24 @@ class TabIntpCompuMethod(CompuMethod):
         return self._physical_upper_limit
 
     def _assert_validity(self) -> None:
-        assert len(self.internal_points) == len(self.physical_points)
+        odxassert(len(self.internal_points) == len(self.physical_points))
 
-        assert self.internal_type in [
-            DataType.A_INT32,
-            DataType.A_UINT32,
-            DataType.A_FLOAT32,
-            DataType.A_FLOAT64,
-        ], ("Internal data type of tab-intp compumethod must be one of"
-            " [DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64]")
-        assert self.physical_type in [
-            DataType.A_INT32,
-            DataType.A_UINT32,
-            DataType.A_FLOAT32,
-            DataType.A_FLOAT64,
-        ], ("Physical data type of tab-intp compumethod must be one of"
-            " [DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64]")
+        odxassert(
+            self.internal_type in [
+                DataType.A_INT32,
+                DataType.A_UINT32,
+                DataType.A_FLOAT32,
+                DataType.A_FLOAT64,
+            ], "Internal data type of tab-intp compumethod must be one of"
+            " [A_INT32, A_UINT32, A_FLOAT32, A_FLOAT64]")
+        odxassert(
+            self.physical_type in [
+                DataType.A_INT32,
+                DataType.A_UINT32,
+                DataType.A_FLOAT32,
+                DataType.A_FLOAT64,
+            ], "Physical data type of tab-intp compumethod must be one of"
+            " [A_INT32, A_UINT32, A_FLOAT32, A_FLOAT64]")
 
     def _piecewise_linear_interpolate(self, x: Union[int, float],
                                       points: List[Tuple[Union[int, float],
@@ -128,7 +130,8 @@ class TabIntpCompuMethod(CompuMethod):
             raise EncodeError(f"Internal value {physical_value} must be inside the range"
                               f" [{min(self.physical_points)}, {max(self.physical_points)}]")
         res = self.internal_type.make_from(result)
-        assert isinstance(res, (int, float))
+        if not isinstance(res, (int, float)):
+            odxraise()
         return res
 
     def convert_internal_to_physical(self, internal_value: Union[int, float]) -> Union[int, float]:
@@ -139,7 +142,8 @@ class TabIntpCompuMethod(CompuMethod):
             raise DecodeError(f"Internal value {internal_value} must be inside the range"
                               f" [{min(self.internal_points)}, {max(self.internal_points)}]")
         res = self.physical_type.make_from(result)
-        assert isinstance(res, (int, float))
+        if not isinstance(res, (int, float)):
+            odxraise()
         return res
 
     def is_valid_physical_value(self, physical_value: Union[int, float]) -> bool:

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 from typing import List
 
-from ..exceptions import DecodeError
+from ..exceptions import DecodeError, odxassert
 from ..odxtypes import DataType
 from .compumethodbase import CompuMethod
 from .compuscale import CompuScale
@@ -18,8 +18,10 @@ class TexttableCompuMethod(CompuMethod):
         )
         self.internal_to_phys = internal_to_phys
 
-        assert all(scale.lower_limit is not None or scale.upper_limit is not None for scale in
-                   self.internal_to_phys), "Text table compu method doesn't have expected format!"
+        odxassert(
+            all(scale.lower_limit is not None or scale.upper_limit is not None
+                for scale in self.internal_to_phys),
+            "Text table compu method doesn't have expected format!")
 
     def convert_physical_to_internal(self, physical_value):
         scale = next(
@@ -28,7 +30,7 @@ class TexttableCompuMethod(CompuMethod):
             res = (
                 scale.compu_inverse_value
                 if scale.compu_inverse_value is not None else scale.lower_limit.value)
-            assert self.internal_type.isinstance(res)
+            odxassert(self.internal_type.isinstance(res))
             return res
 
     def __is_internal_in_scale(self, internal_value, scale: CompuScale):

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -8,6 +8,7 @@ from .dataobjectproperty import DataObjectProperty, DtcDop
 from .endofpdufield import EndOfPduField
 from .envdata import EnvironmentData
 from .envdatadesc import EnvironmentDataDescription
+from .exceptions import odxraise, odxrequire
 from .globals import logger
 from .multiplexer import Multiplexer
 from .nameditemlist import NamedItemList
@@ -55,11 +56,10 @@ class DiagDataDictionarySpec:
             for dop_element in et_element.iterfind("DATA-OBJECT-PROPS/DATA-OBJECT-PROP")
         ]
 
-        structures = []
-        for structure_element in et_element.iterfind("STRUCTURES/STRUCTURE"):
-            structure = create_any_structure_from_et(structure_element, doc_frags)
-            assert structure is not None
-            structures.append(structure)
+        structures = [
+            odxrequire(create_any_structure_from_et(structure_element, doc_frags))
+            for structure_element in et_element.iterfind("STRUCTURES/STRUCTURE")
+        ]
 
         end_of_pdu_fields = [
             EndOfPduField.from_et(eofp_element, doc_frags)
@@ -67,10 +67,11 @@ class DiagDataDictionarySpec:
         ]
 
         dtc_dops = []
-        for dop_element in et_element.iterfind("DTC-DOPS/DTC-DOP"):
-            dop = DtcDop.from_et(dop_element, doc_frags)
-            assert isinstance(dop, DtcDop)
-            dtc_dops.append(dop)
+        for dtc_dop_elem in et_element.iterfind("DTC-DOPS/DTC-DOP"):
+            dtc_dop = DtcDop.from_et(dtc_dop_elem, doc_frags)
+            if not isinstance(dtc_dop, DtcDop):
+                odxraise()
+            dtc_dops.append(dtc_dop)
 
         tables = [
             Table.from_et(table_element, doc_frags)

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -21,7 +21,7 @@ from .ecu_variant_patterns import EcuVariantPattern, create_ecu_variant_patterns
 from .endofpdufield import EndOfPduField
 from .envdata import EnvironmentData
 from .envdatadesc import EnvironmentDataDescription
-from .exceptions import DecodeError, OdxWarning
+from .exceptions import DecodeError, OdxWarning, odxassert
 from .functionalclass import FunctionalClass
 from .globals import logger
 from .message import Message
@@ -415,8 +415,9 @@ class DiagLayer:
             else:
                 dc = dc_proxy
 
-            assert isinstance(dc, (DiagService, SingleEcuJob))
-            assert dc.short_name not in result_dict, (
+            odxassert(isinstance(dc, (DiagService, SingleEcuJob)))
+            odxassert(
+                dc.short_name not in result_dict,
                 f"Multiple definitions of DIAG-COMM '{dc.short_name}' in "
                 f"layer '{self.short_name}'")
             result_dict[dc.short_name] = dc
@@ -596,9 +597,9 @@ class DiagLayer:
             # warning and simply return None...
             warnings.simplefilter("ignore", category=OdxWarning)
             result = com_param.get_subvalue("CP_CanPhysReqId")
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -626,9 +627,9 @@ class DiagLayer:
             # warning and simply return None...
             warnings.simplefilter("ignore", category=OdxWarning)
             result = com_param.get_subvalue("CP_CanRespUSDTId")
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -643,9 +644,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -695,9 +696,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -714,9 +715,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -736,9 +737,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -754,9 +755,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return float(result) / 1e6
 
@@ -780,9 +781,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         return int(result)
 
@@ -804,9 +805,9 @@ class DiagLayer:
             return None
 
         result = com_param.get_value()
-        if not result:
+        if result is None:
             return None
-        assert isinstance(result, str)
+        odxassert(isinstance(result, str))
 
         # the comparam specifies microseconds. convert this to seconds
         return float(result) / 1e6
@@ -897,7 +898,7 @@ class DiagLayer:
         possible_services: List[DiagService] = []
         for b in message:
             if b in prefix_tree:
-                assert isinstance(prefix_tree[b], dict)
+                odxassert(isinstance(prefix_tree[b], dict))
                 prefix_tree = cast(PrefixTree, prefix_tree[b])
             else:
                 break

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -2,10 +2,12 @@
 
 from itertools import chain
 from typing import List, Optional, Union
+from xml.etree.ElementTree import Element
 
 from .admindata import AdminData
 from .companydata import CompanyData, create_company_datas_from_et
 from .diaglayer import DiagLayer
+from .exceptions import odxassert, odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
@@ -56,17 +58,15 @@ class DiagLayerContainer:
         )
 
     @staticmethod
-    def from_et(et_element) -> "DiagLayerContainer":
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
+    def from_et(et_element: Element) -> "DiagLayerContainer":
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
 
         # create the current ODX "document fragment" (description of the
         # current document for references and IDs)
         doc_frags = [OdxDocFragment(short_name, "CONTAINER")]
 
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         description = create_description_from_et(et_element.find("DESC"))
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
         company_datas = create_company_datas_from_et(et_element.find("COMPANY-DATAS"), doc_frags)

--- a/odxtools/ecu_variant_matcher.py
+++ b/odxtools/ecu_variant_matcher.py
@@ -7,7 +7,7 @@ from typing import Dict, Generator, List, Optional, Union
 from .diaglayer import DiagLayer
 from .diaglayertype import DiagLayerType
 from .ecu_variant_patterns import MatchingParameter
-from .exceptions import OdxError
+from .exceptions import OdxError, odxassert
 from .odxtypes import ParameterValue
 from .service import DiagService
 from .structures import Response
@@ -44,10 +44,9 @@ class EcuVariantMatcher:
     @staticmethod
     def get_ident_service(diag_layer: DiagLayer, matching_param: MatchingParameter) -> DiagService:
         service_name = matching_param.diag_comm_snref
-        # TODO this is not working since NamedItemList.__contains__() is not implemented
-        # assert service_name in diag_layer.services
+        odxassert(service_name in [x.short_name for x in diag_layer.services])
         service = diag_layer.services[service_name]
-        assert isinstance(service, DiagService)
+        odxassert(isinstance(service, DiagService))
         return service
 
     @staticmethod
@@ -96,7 +95,7 @@ class EcuVariantMatcher:
 
         self.ecus = ecu_variant_candidates
         for ecu in self.ecus:
-            assert ecu.variant_type == DiagLayerType.ECU_VARIANT
+            odxassert(ecu.variant_type == DiagLayerType.ECU_VARIANT)
 
         self.use_cache = use_cache
         self.req_resp_cache: Dict[bytes, bytes] = {}
@@ -161,7 +160,7 @@ class EcuVariantMatcher:
 
     def get_active_ecu_variant(self) -> DiagLayer:
         """Returns the matched, i.e., active ecu variant if such a variant has been found."""
-        assert self.has_match()
+        odxassert(self.has_match())
         return self._match
 
     def _update_cache(self, req_bytes: bytes, resp_bytes: bytes) -> None:

--- a/odxtools/envdata.py
+++ b/odxtools/envdata.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from .exceptions import odxrequire
 from .globals import logger
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .odxtypes import odxstr_to_bool
@@ -29,8 +30,7 @@ class EnvironmentData(BasicStructure):
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "EnvironmentData":
         """Reads Environment Data from Diag Layer."""
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))

--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 import warnings
+from typing import TYPE_CHECKING, NoReturn, Optional, Type, TypeVar
 
 
 class OdxError(Exception):
     """Any error that happens during interacting with diagnostic objects."""
 
 
-class EncodeError(OdxError):
+class EncodeError(Warning, OdxError):
     """Encoding of a message to raw data failed."""
 
 
@@ -19,5 +20,61 @@ class OdxWarning(Warning):
     """Any warning that happens during interacting with diagnostic objects."""
 
 
-# Mark DecodeError warnings as errors by default
+# Mark DecodeError and EncodeErrpr warnings as errors by default
 warnings.simplefilter("error", DecodeError)
+warnings.simplefilter("error", EncodeError)
+
+#: Specify whether violations of the ODX specification or failed
+#: assumptions in the ODX library code should cause the routine in
+#: question to abort or whether it should continue anyway. Be aware that
+#: in non-strict mode, the behavior of odxtools is undefined and it
+#: might start eating children...
+strict_mode = True
+
+
+def odxraise(message: Optional[str] = None, error_type: Type[Exception] = OdxError) -> NoReturn:
+    """
+    Raise an exception but only if in strict mode.
+
+    Also, convince type checkers that the exception is always raised.
+    """
+    if TYPE_CHECKING or strict_mode:
+        if message is None:
+            raise error_type()
+        else:
+            raise error_type(message)
+
+
+def odxassert(condition: bool,
+              message: Optional[str] = None,
+              error_type: Type[Exception] = OdxError) -> None:
+    """
+    This method works similar as the build-in `assert` statement
+
+    The differences are that instead of raising an `AssertationError`,
+    an `OdxError` is raised by default and that is possible to not
+    raise any exception by setting `odxtools.exceptions.strict_mode` to
+    `False`. The latter is convenient when having to deal with files
+    that do not comply to the ODX specification, but it may lead to
+    undefined behavior. (Use the non-strict mode with great care.)
+    """
+    if not condition:
+        odxraise(message, error_type)
+
+
+T = TypeVar("T")
+
+
+def odxrequire(obj: Optional[T], message: Optional[str] = None) -> T:
+    """This function ensures that an object required by the ODX
+    specification is actually present.
+
+    In other words, that the object in question is not `None`. If such
+    a mandatory object is not present, an `OdxError` is raised if the
+    `odxtools.exceptions.strict_mode` flag is `True`. (Note that this
+    function is pretty useful for type checking.)
+    """
+    if obj is None:
+        odxraise(message)
+
+    return obj

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2022 MBition GmbH
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree.ElementTree import Element
 
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .utils import create_description_from_et
 
@@ -22,10 +24,9 @@ class FunctionalClass:
     description: Optional[str]
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]):
-        short_name = et_element.findtext("SHORT-NAME")
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "FunctionalClass":
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
 
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type, TypeVar, overload
 from xml.etree.ElementTree import Element
 
-from .exceptions import OdxWarning
+from .exceptions import OdxWarning, odxassert
 
 
 @dataclass(frozen=True)
@@ -120,9 +120,9 @@ class OdxLinkRef:
         doc_ref = et.attrib.get("DOCREF")
         doc_type = et.attrib.get("DOCTYPE")
 
-        assert (doc_ref is not None and doc_type is not None) or (
-            doc_ref is None and
-            doc_type is None), "DOCREF and DOCTYPE must both either be specified or omitted"
+        odxassert((doc_ref is not None and doc_type is not None) or
+                  (doc_ref is None and doc_type is None),
+                  "DOCREF and DOCTYPE must both either be specified or omitted")
 
         # if the target document fragment is specified by the
         # reference, use it, else use the document fragment containing
@@ -184,8 +184,6 @@ class OdxLinkDatabase:
         If the database does not contain any object which is referred to, a
         KeyError exception is raised.
         """
-        assert isinstance(ref, OdxLinkRef)
-
         odx_id = OdxLinkId(ref.ref_id, ref.ref_docs)
         for ref_frag in reversed(ref.ref_docs):
             doc_frag_db = self._db.get(ref_frag)
@@ -203,7 +201,7 @@ class OdxLinkDatabase:
             obj = doc_frag_db.get(odx_id)
             if obj is not None:
                 if expected_type is not None:
-                    assert isinstance(obj, expected_type)
+                    odxassert(isinstance(obj, expected_type))
 
                 return obj
 
@@ -227,7 +225,6 @@ class OdxLinkDatabase:
         If the database does not contain any object which is referred to, None
         is returned.
         """
-        assert isinstance(ref, OdxLinkRef)
 
         odx_id = OdxLinkId(ref.ref_id, ref.ref_docs)
         for ref_frag in reversed(ref.ref_docs):
@@ -246,7 +243,7 @@ class OdxLinkDatabase:
             obj = doc_frag_db.get(odx_id)
             if obj is not None:
                 if expected_type is not None:
-                    assert isinstance(obj, expected_type)
+                    odxassert(isinstance(obj, expected_type))
 
                 return obj
 

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -5,6 +5,8 @@ from enum import Enum
 from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union,
                     overload)
 
+from .exceptions import odxassert, odxraise
+
 if TYPE_CHECKING:
     from odxtools.parameters.parameterbase import Parameter
 
@@ -46,12 +48,12 @@ def odxstr_to_bool(str_val: Optional[str]) -> Optional[bool]:
         return None
 
     str_val = str_val.strip()
-    assert str_val in [
+    odxassert(str_val in [
         "0",
         "1",
         "false",
         "true",
-    ], f"String '{str_val}' cannot be converted to a boolean"
+    ], f"String '{str_val}' cannot be converted to a boolean")
 
     return str_val in ["1", "true"]
 
@@ -64,8 +66,13 @@ def parse_int(value: str) -> int:
     try:
         return int(value)
     except ValueError:
-        v = float(value)
-        assert v.is_integer()
+        try:
+            v = float(value)
+        except Exception as e:
+            odxraise(f"Error parsing numerical value '{value}': {e}")
+
+        if not v.is_integer():
+            odxraise(f"Expected an integer value, got {v}")
         return int(v)
 
 

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 from ..decodestate import DecodeState
 from ..diagcodedtypes import DiagCodedType
 from ..encodestate import EncodeState
-from ..exceptions import DecodeError
+from ..exceptions import DecodeError, odxraise
 from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import DataType
 from .parameterbase import Parameter
@@ -22,7 +22,8 @@ class CodedConstParameter(Parameter):
         super().__init__(parameter_type="CODED-CONST", **kwargs)
 
         self.diag_coded_type = diag_coded_type
-        assert isinstance(coded_value, (int, bytes, bytearray))
+        if not isinstance(coded_value, (int, bytes, bytearray)):
+            odxraise()
         self.coded_value = coded_value
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
+from ..exceptions import odxrequire
 from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .parameterwithdop import ParameterWithDOP
 
@@ -48,8 +49,8 @@ class LengthKeyParameter(ParameterWithDOP):
         physical_value = encode_state.parameter_values.get(self.short_name, 0)
 
         bit_pos = self.bit_position or 0
-        dop = super().dop
-        assert dop is not None, f"A DOP is required for length key parameter {self.short_name}"
+        dop = odxrequire(super().dop,
+                         f"A DOP is required for length key parameter {self.short_name}")
         return dop.convert_physical_to_bytes(physical_value, encode_state, bit_position=bit_pos)
 
     def encode_into_pdu(self, encode_state: EncodeState) -> bytes:

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -8,10 +8,8 @@ from .parameterbase import Parameter
 
 class MatchingRequestParameter(Parameter):
 
-    def __init__(self, *, request_byte_position, byte_length, **kwargs):
+    def __init__(self, *, request_byte_position: int, byte_length: int, **kwargs):
         super().__init__(parameter_type="MATCHING-REQUEST-PARAM", **kwargs)
-        assert byte_length is not None
-        assert request_byte_position is not None
         self.request_byte_position = request_byte_position
         self._byte_length = byte_length
 

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 from ..decodestate import DecodeState
 from ..diagcodedtypes import DiagCodedType
 from ..encodestate import EncodeState
-from ..exceptions import DecodeError, EncodeError
+from ..exceptions import DecodeError, EncodeError, odxassert
 from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import DataType
 from .parameterbase import Parameter
@@ -31,7 +31,7 @@ class NrcConstParameter(Parameter):
 
         self.diag_coded_type = diag_coded_type
         # TODO: Does it have to be an integer or is that just common practice?
-        assert all(isinstance(coded_value, int) for coded_value in coded_values)
+        odxassert(all(isinstance(coded_value, int) for coded_value in coded_values))
         self.coded_values = coded_values
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -4,16 +4,16 @@ import warnings
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
-from ..exceptions import DecodeError
+from ..exceptions import DecodeError, odxassert, odxrequire
+from ..odxtypes import ParameterValue
 from .parameterwithdop import ParameterWithDOP
 
 
 class PhysicalConstantParameter(ParameterWithDOP):
 
-    def __init__(self, *, physical_constant_value, **kwargs):
+    def __init__(self, *, physical_constant_value: ParameterValue, **kwargs) -> None:
         super().__init__(parameter_type="PHYS-CONST", **kwargs)
 
-        assert physical_constant_value is not None
         self._physical_constant_value = physical_constant_value
 
     @property
@@ -31,7 +31,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
         return self.dop.convert_physical_to_internal(self.physical_constant_value)
 
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
-        assert self.dop is not None, "Reference to DOP is not resolved"
+        dop = odxrequire(self.dop, "Reference to DOP is not resolved")
         if (self.short_name in encode_state.parameter_values and
                 encode_state.parameter_values[self.short_name] != self.physical_constant_value):
             raise TypeError(
@@ -39,7 +39,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
                 " and thus can not be changed.")
 
         bit_position_int = self.bit_position if self.bit_position is not None else 0
-        return self.dop.convert_physical_to_bytes(
+        return dop.convert_physical_to_bytes(
             self.physical_constant_value, encode_state, bit_position=bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState):

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
+from ..exceptions import odxassert
 from ..odxlink import OdxLinkRef
 from .parameterbase import Parameter
 
@@ -9,7 +10,7 @@ class TableEntryParameter(Parameter):
     def __init__(self, *, target: str, table_row_ref: OdxLinkRef, **kwargs):
         super().__init__(parameter_type="TABLE-ENTRY", **kwargs)
 
-        assert target in ["KEY", "STRUCT"]
+        odxassert(target in ["KEY", "STRUCT"])
         self.target = target
         self.table_row_ref = table_row_ref
 

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 from ..dataobjectproperty import DataObjectProperty
 from ..encodestate import EncodeState
+from ..exceptions import odxrequire
 from .parameterwithdop import ParameterWithDOP
 
 
@@ -38,11 +39,12 @@ class ValueParameter(ParameterWithDOP):
         if physical_value is None:
             raise TypeError(f"A value for parameter '{self.short_name}' must be specified"
                             f" as the parameter does not exhibit a default.")
-        assert (self.dop is not None
-               ), f"Param {self.short_name} does not have a DOP. Maybe resolving references failed?"
+        dop = odxrequire(
+            self.dop,
+            f"Param {self.short_name} does not have a DOP. Maybe resolving references failed?")
 
         bit_position_int = self.bit_position if self.bit_position is not None else 0
-        return self.dop.convert_physical_to_bytes(
+        return dop.convert_physical_to_bytes(
             physical_value, encode_state=encode_state, bit_position=bit_position_int)
 
     def get_valid_physical_values(self):

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Union
+from xml.etree.ElementTree import Element
 
 from .dataobjectproperty import DopBase
 from .diaglayertype import DiagLayerType
+from .exceptions import odxrequire
 from .globals import xsi
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .service import DiagService
@@ -27,36 +29,38 @@ class ParentRef:
         return self._layer
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
+    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
 
-        layer_ref = OdxLinkRef.from_et(et_element, doc_frags)
-        assert layer_ref is not None
+        layer_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
 
         not_inherited_diag_comms = [
-            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-DIAG-COMMS/"
-                                                               "NOT-INHERITED-DIAG-COMM/"
-                                                               "DIAG-COMM-SNREF")
+            odxrequire(el.get("SHORT-NAME"))
+            for el in et_element.iterfind("NOT-INHERITED-DIAG-COMMS/"
+                                          "NOT-INHERITED-DIAG-COMM/"
+                                          "DIAG-COMM-SNREF")
         ]
         not_inherited_dops = [
-            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-DOPS/"
-                                                               "NOT-INHERITED-DOP/"
-                                                               "DOP-BASE-SNREF")
+            odxrequire(el.get("SHORT-NAME")) for el in et_element.iterfind("NOT-INHERITED-DOPS/"
+                                                                           "NOT-INHERITED-DOP/"
+                                                                           "DOP-BASE-SNREF")
         ]
         not_inherited_tables = [
-            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-TABLES/"
-                                                               "NOT-INHERITED-TABLE/"
-                                                               "TABLE-SNREF")
+            odxrequire(el.get("SHORT-NAME")) for el in et_element.iterfind("NOT-INHERITED-TABLES/"
+                                                                           "NOT-INHERITED-TABLE/"
+                                                                           "TABLE-SNREF")
         ]
         not_inherited_variables = [
-            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-VARIABLES/"
-                                                               "NOT-INHERITED-VARIABLE/"
-                                                               "DIAG-VARIABLE-SNREF")
+            odxrequire(el.get("SHORT-NAME"))
+            for el in et_element.iterfind("NOT-INHERITED-VARIABLES/"
+                                          "NOT-INHERITED-VARIABLE/"
+                                          "DIAG-VARIABLE-SNREF")
         ]
 
         not_inherited_global_neg_responses = [
-            el.get("SHORT-NAME") for el in et_element.iterfind("NOT-INHERITED-GLOBAL-NEG-RESPONSES/"
-                                                               "NOT-INHERITED-GLOBAL-NEG-RESPONSE/"
-                                                               "GLOBAL-NEG-RESPONSE-SNREF")
+            odxrequire(el.get("SHORT-NAME"))
+            for el in et_element.iterfind("NOT-INHERITED-GLOBAL-NEG-RESPONSES/"
+                                          "NOT-INHERITED-GLOBAL-NEG-RESPONSE/"
+                                          "GLOBAL-NEG-RESPONSE-SNREF")
         ]
 
         return ParentRef(

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
+from .exceptions import odxassert
 from .odxlink import OdxDocFragment
 from .odxtypes import DataType
 
@@ -58,7 +59,7 @@ class PhysicalType:
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]):
         base_data_type = et_element.get("BASE-DATA-TYPE")
-        assert base_data_type in [
+        odxassert(base_data_type in [
             "A_INT32",
             "A_UINT32",
             "A_FLOAT32",
@@ -67,7 +68,7 @@ class PhysicalType:
             "A_UTF8STRING",
             "A_UNICODE2STRING",
             "A_BYTEFIELD",
-        ]
+        ])
         display_radix = et_element.get("DISPLAY-RADIX")
         precision = et_element.findtext("PRECISION")
         if precision is not None:

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from xml.etree import ElementTree
 
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .utils import create_description_from_et, short_name_as_id
 
@@ -22,11 +23,8 @@ class SpecialDataGroupCaption:
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "SpecialDataGroupCaption":
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
 

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2022 MBition GmbH
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree.ElementTree import Element
 
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .utils import create_description_from_et
 
@@ -22,11 +24,9 @@ class State:
     description: Optional[str]
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "State":
-        short_name = et_element.findtext("SHORT-NAME")
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-
+    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "State":
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
 

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2022 MBition GmbH
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree.ElementTree import Element
 
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .state import State
 from .utils import create_description_from_et
@@ -34,21 +36,18 @@ class StateTransition:
         return self._target_state
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "StateTransition":
+    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "StateTransition":
 
-        short_name = et_element.findtext("SHORT-NAME")
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
 
-        source_snref_elem = et_element.find("SOURCE-SNREF")
-        assert source_snref_elem is not None
-        source_snref = source_snref_elem.attrib["SHORT-NAME"]
+        source_snref_elem = odxrequire(et_element.find("SOURCE-SNREF"))
+        source_snref = odxrequire(source_snref_elem.attrib["SHORT-NAME"])
 
-        target_snref_elem = et_element.find("TARGET-SNREF")
-        assert target_snref_elem is not None
-        target_snref = target_snref_elem.attrib["SHORT-NAME"]
+        target_snref_elem = odxrequire(et_element.find("TARGET-SNREF"))
+        target_snref = odxrequire(target_snref_elem.attrib["SHORT-NAME"])
 
         return StateTransition(
             odx_id=odx_id,

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, OrderedDi
 from .dataobjectproperty import DataObjectProperty, DopBase
 from .decodestate import DecodeState
 from .encodestate import EncodeState
-from .exceptions import DecodeError, EncodeError, OdxError, OdxWarning
+from .exceptions import DecodeError, EncodeError, OdxError, OdxWarning, odxassert
 from .globals import logger
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -167,8 +167,9 @@ class BasicStructure(DopBase):
 
         if self.byte_size is not None:
             # We definitely broke something if we didn't respect the explicit byte_size
-            assert len(coded_message) == self.byte_size, self._get_encode_error_str(
-                "was", coded_message, self.byte_size * 8)
+            odxassert(
+                len(coded_message) == self.byte_size,
+                self._get_encode_error_str("was", coded_message, self.byte_size * 8))
             # No need to check further
             return
 
@@ -260,8 +261,9 @@ class BasicStructure(DopBase):
 
         The values are parameters for simple types or a nested dict for structures.
         """
-        assert all(not isinstance(p, ParameterWithDOP) or isinstance(p.dop, DataObjectProperty) or
-                   isinstance(p.dop, Structure) for p in self.parameters)
+        odxassert(
+            all(not isinstance(p, ParameterWithDOP) or isinstance(p.dop, DataObjectProperty) or
+                isinstance(p.dop, Structure) for p in self.parameters))
         param_dict: ParameterDict = {
             p.short_name: p
             for p in self.parameters
@@ -352,7 +354,7 @@ class BasicStructure(DopBase):
                 f"{(len(indent_for_byte_numbering) - 1 - len(str(byte_idx))) * ' '}{byte_idx} ")
 
             for bit_idx in range(8):
-                assert 8 * byte_idx + bit_idx <= stop_bit
+                odxassert(8 * byte_idx + bit_idx <= stop_bit)
 
                 if 8 * byte_idx + bit_idx == stop_bit:
                     # END-OF-PDU fields do not exhibit a fixed bit

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
 from .admindata import AdminData
 from .dataobjectproperty import DataObjectProperty
+from .exceptions import odxassert, odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
@@ -36,10 +37,8 @@ class Table:
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "Table":
         """Reads a TABLE."""
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name: str = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         semantic = et_element.get("SEMANTIC")
         description = create_description_from_et(et_element.find("DESC"))
@@ -102,7 +101,7 @@ class Table:
                 table_row = table_row_wrapper
                 table_row._resolve_odxlinks(odxlinks)
             else:
-                assert isinstance(table_row_wrapper, OdxLinkRef)
+                odxassert(isinstance(table_row_wrapper, OdxLinkRef))
                 table_row = odxlinks.resolve(table_row_wrapper, TableRow)
 
             table_rows.append(table_row)

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
 from .dataobjectproperty import DataObjectProperty
+from .exceptions import odxassert, odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import AtomicOdxType
@@ -37,18 +38,22 @@ class TableRow:
         self._dop: Optional[DataObjectProperty] = None
 
         n = sum([0 if x is None else 1 for x in (self.structure_ref, self.structure_snref)])
-        assert n <= 1, f"Table row {self.short_name}: The structure can either be defined using ODXLINK or SNREF but not both."
+        odxassert(
+            n <= 1,
+            f"Table row {self.short_name}: The structure can either be defined using ODXLINK or SNREF but not both."
+        )
         n = sum([0 if x is None else 1 for x in (self.dop_ref, self.dop_snref)])
-        assert n <= 1, f"Table row {self.short_name}: The dop can either be defined using ODXLINK or SNREF but not both."
+        odxassert(
+            n <= 1,
+            f"Table row {self.short_name}: The dop can either be defined using ODXLINK or SNREF but not both."
+        )
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment], *,
                 table_ref: OdxLinkRef) -> "TableRow":
         """Reads a TABLE-ROW."""
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
-        short_name = et_element.findtext("SHORT-NAME")
-        assert short_name is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        short_name: str = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         semantic = et_element.get("SEMANTIC")
         description = create_description_from_et(et_element.find("DESC"))

--- a/odxtools/uds.py
+++ b/odxtools/uds.py
@@ -6,6 +6,8 @@ from typing import Optional, Union
 
 import odxtools.obd as obd
 
+from .exceptions import odxassert
+
 
 class UDSSID(IntEnum):
     """The service IDs standardized by UDS.
@@ -87,10 +89,9 @@ class NegativeResponseCodes(IntEnum):
 
 
 # get the ID of a positive response
-def positive_response_id(service_id: int) -> int:
+def positive_response_id(request_service_id: int) -> int:
     """Given a service ID of a request, return the corresponding SID for a positive response"""
-    assert service_id != 0x7F - 0x40
-    return service_id + 0x40
+    return request_service_id + 0x40
 
 
 NegativeResponseId = 0x7F
@@ -98,7 +99,6 @@ NegativeResponseId = 0x7F
 
 def negative_response_id(service_id: int) -> int:
     """Given a service ID of a request, return the corresponding SID for a negative response"""
-    assert service_id != 0x7F - 0x40  # TODO: What is this assert supposed to do?
     return NegativeResponseId
 
 

--- a/odxtools/units.py
+++ b/odxtools/units.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
+from .exceptions import odxassert, odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .specialdata import SpecialDataGroup, create_sdgs_from_et
@@ -62,8 +63,7 @@ class PhysicalDimension:
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "PhysicalDimension":
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         oid = et_element.get("OID")
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
@@ -165,8 +165,7 @@ class Unit:
 
     @staticmethod
     def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "Unit":
-        odx_id = OdxLinkId.from_et(et_element, doc_frags)
-        assert odx_id is not None
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         oid = et_element.get("OID")
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
@@ -207,7 +206,8 @@ class Unit:
         if self.physical_dimension_ref:
             self._physical_dimension = odxlinks.resolve(self.physical_dimension_ref)
 
-            assert isinstance(self._physical_dimension, PhysicalDimension), (
+            odxassert(
+                isinstance(self._physical_dimension, PhysicalDimension),
                 f"The physical_dimension_ref must be resolved to a PhysicalDimension."
                 f" {self.physical_dimension_ref} referenced {self._physical_dimension}")
 
@@ -239,15 +239,14 @@ class UnitGroup:
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
         category = et_element.findtext("CATEGORY")
-        assert category in [
-            "COUNTRY",
-            "EQUIV-UNITS",
-        ], f'A UNIT-GROUP-CATEGORY must be "COUNTRY" or "EQUIV-UNITS". It was {category}.'
+        odxassert(
+            category in ["COUNTRY", "EQUIV-UNITS"],
+            f'A UNIT-GROUP-CATEGORY must be "COUNTRY" or "EQUIV-UNITS". It was "{category}".')
         unit_refs = []
 
         for el in et_element.iterfind("UNIT-REFS/UNIT-REF"):
             ref = OdxLinkRef.from_et(el, doc_frags)
-            assert isinstance(ref, OdxLinkRef)
+            odxassert(isinstance(ref, OdxLinkRef))
             unit_refs.append(ref)
 
         return UnitGroup(

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -36,7 +36,9 @@ def short_name_as_id(obj: Any) -> str:
     prepends an underscore to such such shortnames.
     """
 
-    sn: str = odxrequire(obj.short_name)
+    sn = obj.short_name
+    if not isinstance(sn, str):
+        odxraise()
 
     if sn[0].isdigit():
         return f"_{sn}"

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -4,6 +4,8 @@ import re
 from typing import Any, Optional
 from xml.etree import ElementTree
 
+from .exceptions import odxraise, odxrequire
+
 
 def create_description_from_et(et_element: Optional[ElementTree.Element],) -> Optional[str]:
     """Read a description tag.
@@ -34,8 +36,7 @@ def short_name_as_id(obj: Any) -> str:
     prepends an underscore to such such shortnames.
     """
 
-    sn = obj.short_name
-    assert isinstance(sn, str)
+    sn: str = odxrequire(obj.short_name)
 
     if sn[0].isdigit():
         return f"_{sn}"

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -356,7 +356,7 @@ def test_no_match(ecu_variants: List[DiagLayer], use_cache: bool):
         resp = req_resp_mapping[req]
         matcher.evaluate(resp)
     assert not matcher.has_match()
-    with pytest.raises(AssertionError):
+    with pytest.raises(OdxError):
         matcher.get_active_ecu_variant()
 
 

--- a/tests/test_ecu_variant_patterns.py
+++ b/tests/test_ecu_variant_patterns.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree
 import pytest
 
 from odxtools.ecu_variant_patterns import create_ecu_variant_patterns_from_et
+from odxtools.exceptions import OdxError
 from odxtools.odxlink import OdxDocFragment
 
 doc_frags = [OdxDocFragment(doc_name="pytest", doc_type="WinneThePoh")]
@@ -65,5 +66,5 @@ def test_create_evp_from_et(valid_evp_et: ElementTree.Element) -> None:
 
 
 def test_create_invalid_evp_from_et(invalid_evp_et: ElementTree.Element) -> None:
-    with pytest.raises(AssertionError):
+    with pytest.raises(OdxError):
         _ = create_ecu_variant_patterns_from_et(invalid_evp_et, doc_frags)

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2022 MBition GmbH
 import unittest
 
+import odxtools
+from odxtools.exceptions import OdxError
 from odxtools.load_pdx_file import load_pdx_file
 from odxtools.odxlink import OdxDocFragment, OdxLinkRef
 
@@ -10,6 +12,40 @@ odxdb = load_pdx_file("./examples/somersault.pdx")
 # use the diag layer container's document fragments as the default for
 # resolving references
 container_doc_frags = odxdb.diag_layer_containers.somersault.odx_id.doc_fragments
+
+
+class TestStrictMode(unittest.TestCase):
+
+    def test_strict_mode(self):
+        # by default, we must be in strict mode
+        self.assertTrue(odxtools.exceptions.strict_mode)
+
+        # in strict mode, odxraise() must raise OdxError ...
+        with self.assertRaises(OdxError):
+            odxtools.exceptions.odxraise()
+        # ... odxassert() must raise OdxError for failed
+        # assertations ...
+        odxtools.exceptions.odxassert(True)  # nothing happens
+        with self.assertRaises(OdxError):
+            odxtools.exceptions.odxassert(False)
+        # ... and odxrequire() raises OdxError if passed `None` and
+        # passes through everything else.
+        with self.assertRaises(OdxError):
+            odxtools.exceptions.odxrequire(None)
+        self.assertEqual(odxtools.exceptions.odxrequire(123), 123)
+
+        # change to non-strict mode
+        odxtools.exceptions.strict_mode = False
+
+        # in non-strict mode none of the above functions raises anything
+        odxtools.exceptions.odxraise()
+        odxtools.exceptions.odxassert(True)  # nothing happens
+        odxtools.exceptions.odxassert(False)
+        odxtools.exceptions.odxrequire(None)
+        self.assertEqual(odxtools.exceptions.odxrequire(123), 123)
+
+        # go back to strict mode
+        odxtools.exceptions.strict_mode = True
 
 
 class TestDataObjectProperty(unittest.TestCase):


### PR DESCRIPTION
These changes make it possible to continue the program execution if a deviation from the ODX specification was detected or a hard-coded assumption was violated. (If any of this happens, the behavior after that point is undefined.) The new mechanism consists of the following parts:

- The `odxtools.exceptions.strict_mode` variable indicates whether program execution should be attempted to be continued if a violation is detected or not. The default is to not continue. Switching to non-strict mode can be achieved using
  ```python
  import odxtools

  odxtools.exceptions.strict_mode = False
  ```
- The `odxraise()` function raises an exception in strict mode and does nothing in non-strict mode. For type checkers, it looks like it always raises an exception.
- The `odxassert()` function is very similar to the build-in `assert`  statement, except that if the asserted condition is not met and if odxtools is in non-strict mode, program execution will continue. Unfortunately, this does not work well with type checkers as these do not consider the internal behavior of functions, so `assert` statements which's purpose is to narrow the type of a given object for the benefit of type checkers must be replaced by `if...odxraise()` constructs. E.g.
  ```python
  # prevent mypy from complaining
  assert isinstance(x, int)
  ```
  becomes
  ```python
  # prevent mypy from complaining
  if not isinstance(x, int): odxraise()
  ```
- In strict mode, the `odxrequire()` function raises an exception if its argument is `None`, in all other cases it passes through its argument without modifications. This allows to conveniently ensure that a given object was specified whilst convincing type checkers that it is not `None`. E.g., ensuring that a `SHORT-NAME` exists for an `ElementTree` node can be achieved using
  ```python
  short_name = odxrequire(et_element.findtext("SHORT-NAME"))
  ```

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)