### PR TITLE
Convert Literal string to Enum classes

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -61,7 +61,7 @@ from odxtools.table import Table
 from odxtools.tablerow import TableRow
 from odxtools.teammember import TeamMember
 from odxtools.unit import Unit
-from odxtools.unitgroup import UnitGroup
+from odxtools.unitgroup import UnitGroup, UnitGroupCategory
 from odxtools.unitspec import UnitSpec
 from odxtools.utils import short_name_as_id
 from odxtools.xdoc import XDoc
@@ -405,7 +405,7 @@ somersault_unit_groups = {
         UnitGroup(
             oid=None,
             short_name="european_duration",
-            category="COUNTRY",
+            category=UnitGroupCategory.COUNTRY,
             unit_refs=[
                 OdxLinkRef.from_id(somersault_units["second"].odx_id),
                 OdxLinkRef.from_id(somersault_units["minute"].odx_id),

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -52,7 +52,6 @@ class SingleEcuJob:
     odx_id: OdxLinkId
     short_name: str
     prog_codes: List[ProgCode]
-    """Pointers to the code that is executed when calling this job."""
     # optional xsd:elements inherited from DIAG-COMM (and thus shared with DIAG-SERVICE)
     oid: Optional[str]
     long_name: Optional[str]

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from enum import Enum
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from xml.etree.ElementTree import Element
 
 from .admindata import AdminData
 from .audience import Audience
 from .createsdgs import create_sdgs_from_et
-from .exceptions import DecodeError, EncodeError, odxrequire
+from .exceptions import DecodeError, EncodeError, odxraise, odxrequire
 from .functionalclass import FunctionalClass
 from .globals import logger
 from .inputparam import InputParam
@@ -24,14 +25,14 @@ from .utils import create_description_from_et, short_name_as_id
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
 
-DiagClassType = Literal[
-    "STARTCOMM",
-    "STOPCOMM",
-    "VARIANTIDENTIFICATION",
-    "READ-DYN-DEFINED-MESSAGE",
-    "DYN-DEF-MESSAGE",
-    "CLEAR-DYN-DEF-MESSAGE",
-]
+
+class DiagClassType(Enum):
+    STARTCOMM = "STARTCOMM"
+    STOPCOMM = "STOPCOMM"
+    VARIANTIDENTIFICATION = "VARIANTIDENTIFICATION"
+    READ_DYN_DEFINED_MESSAGE = "READ-DYN-DEFINED-MESSAGE"
+    DYN_DEF_MESSAGE = "DYN-DEF-MESSAGE"
+    CLEAR_DYN_DEF_MESSAGE = "CLEAR-DYN-DEF-MESSAGE"
 
 
 @dataclass
@@ -136,12 +137,18 @@ class SingleEcuJob:
             for el in et_element.iterfind("NEG-OUTPUT-PARAMS/NEG-OUTPUT-PARAM")
         ]
 
+        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
+
         # Read boolean flags. Note that the "else" clause contains the default value.
         is_mandatory_raw = odxstr_to_bool(et_element.get("IS-MANDATORY"))
         is_executable_raw = odxstr_to_bool(et_element.get("IS-MANDATORY"))
         is_final_raw = odxstr_to_bool(et_element.get("IS-FINAL"))
 
-        sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
+        diag_class_type: Optional[DiagClassType] = None
+        if (diag_class_type_str := et_element.get("DIAGNOSTIC-CLASS")) is not None:
+            if diag_class_type_str not in DiagClassType.__members__:
+                odxraise(f"Encountered unknown diagnostic class type '{diag_class_type_str}'")
+            diag_class_type = DiagClassType(diag_class_type_str)
 
         return SingleEcuJob(
             odx_id=odx_id,

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -11,7 +11,7 @@
 <SINGLE-ECU-JOB ID="{{job.odx_id.local_id}}"
                 {{-make_xml_attrib("OID", job.oid)}}
                 {{-make_xml_attrib("SEMANTIC", job.semantic)}}
-                {{-make_xml_attrib("DIAGNOSTIC-CLASS", job.diagnostic_class)}}
+                {{-make_xml_attrib("DIAGNOSTIC-CLASS", job.diagnostic_class and job.diagnostic_class.value)}}
                 {{-make_bool_xml_attrib("IS-MANDATORY", job.is_mandatory_raw)}}
                 {{-make_bool_xml_attrib("IS-EXECUTABLE", job.is_executable_raw)}}
                 {{-make_bool_xml_attrib("IS-FINAL", job.is_final_raw)}}>

--- a/odxtools/templates/macros/printUnitSpec.xml.jinja2
+++ b/odxtools/templates/macros/printUnitSpec.xml.jinja2
@@ -54,7 +54,7 @@
 {%- macro printUnitGroup(group) -%}
 <UNIT-GROUP {%- if group.oid %} OID="{{group.oid}}" {%- endif %}>
  {{ peid.printElementID(group) }}
- <CATEGORY>{{ group.category }}</CATEGORY>
+ <CATEGORY>{{ group.category.value }}</CATEGORY>
  {%- if group.unit_refs %}
  <UNIT-REFS>
  {%- for ref in group.unit_refs %}

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from enum import Enum
 
-from .exceptions import odxassert
+from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .unit import Unit
@@ -11,7 +12,10 @@ from .utils import create_description_from_et, short_name_as_id
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
 
-UnitGroupCategory = Literal["COUNTRY", "EQUIV-UNITS"]
+
+class UnitGroupCategory(Enum):
+    COUNTRY = "COUNTRY"
+    EQUIV_UNITS = "EQUIV-UNITS"
 
 
 @dataclass
@@ -37,16 +41,15 @@ class UnitGroup:
         short_name = et_element.findtext("SHORT-NAME")
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
-        category = et_element.findtext("CATEGORY")
-        odxassert(
-            category in ["COUNTRY", "EQUIV-UNITS"],
-            f'A UNIT-GROUP-CATEGORY must be "COUNTRY" or "EQUIV-UNITS". It was "{category}".')
-        unit_refs = []
+        category_str = et_element.findtext("CATEGORY")
+        if category_str not in UnitGroupCategory.__members__:
+            odxraise(f"Encountered unknown unit group category '{category_str}'")
+        category = UnitGroupCategory(category_str)
 
-        for el in et_element.iterfind("UNIT-REFS/UNIT-REF"):
-            ref = OdxLinkRef.from_et(el, doc_frags)
-            odxassert(isinstance(ref, OdxLinkRef))
-            unit_refs.append(ref)
+        unit_refs: List[OdxLinkRef] = [
+            odxrequire(OdxLinkRef.from_et(el, doc_frags))
+            for el in et_element.iterfind("UNIT-REFS/UNIT-REF")
+        ]
 
         return UnitGroup(
             short_name=short_name,


### PR DESCRIPTION
Since the values of these objects are read from the XML (i.e., at runtime), using `typing.Literal` for them does not work very well: While loading a dataset it is currently not verified that the specified values are valid, and mypy must be instructed to ignore converting the dynamic string to the literal strings. Using `Enum` classes fixes these issues...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)