### PR TITLE
Add type annotations to all `from_et()` and `create_*_from_et()` functions

### DIFF
--- a/examples/somersaultlazy.py
+++ b/examples/somersaultlazy.py
@@ -175,8 +175,6 @@ class SomersaultLazyEcu:
         assert cp.value == "Response expected" or cp.value == "1"
 
     async def _handle_requests_task(self):
-        loop = asyncio.get_running_loop()
-
         while True:
             data = await ecu_recv(self.isotp_socket)
 
@@ -201,7 +199,6 @@ class SomersaultLazyEcu:
                 return
 
     async def _handle_request(self, message):
-        loop = asyncio.get_running_loop()
         service = message.service
 
         ecu_logger.info(f"received UDS message: {service.short_name}")
@@ -263,7 +260,6 @@ class SomersaultLazyEcu:
             return
 
     async def _handle_forward_flip_request(self, message):
-        loop = asyncio.get_running_loop()
         service = message.service
         # TODO: the need for .param_dict is quite ugly IMO,
         # i.e. provide a __getitem__() method for the Message class() (?)
@@ -352,8 +348,6 @@ class SomersaultLazyEcu:
 
 
 async def tester_await_response(isotp_socket, raw_message, timeout=0.5):
-    loop = asyncio.get_running_loop()
-
     # await the answer from the server (be aware that the maximum
     # length of ISO-TP telegrams over the CAN bus is 4095 bytes)
     raw_response = await tester_recv(isotp_socket)
@@ -397,8 +391,6 @@ async def tester_await_response(isotp_socket, raw_message, timeout=0.5):
 
 
 async def tester_main():
-    loop = asyncio.get_running_loop()
-
     tester_logger.info("running diagnostic tester")
 
     # note that ODX specifies the CAN IDs from the ECU's point of

--- a/odxtools/additionalaudience.py
+++ b/odxtools/additionalaudience.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -23,7 +23,8 @@ class AdditionalAudience:
     description: Optional[str]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "AdditionalAudience":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "AdditionalAudience":
 
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .additionalaudience import AdditionalAudience
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -55,7 +55,7 @@ class Audience:
         return self._disabled_audiences
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "Audience":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Audience":
 
         enabled_audience_refs = [
             OdxLinkRef.from_et(ref, doc_frags)

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -37,7 +37,8 @@ class BaseComparam:
     cpusage: Usage
     display_level: Optional[int]
 
-    def __init_from_et__(self, et_element: Element, doc_frags: List[OdxDocFragment]) -> None:
+    def __init_from_et__(self, et_element: ElementTree.Element,
+                         doc_frags: List[OdxDocFragment]) -> None:
         self.odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         self.short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         self.long_name = et_element.findtext("LONG-NAME")

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 from xml.etree import ElementTree
 
-from .exceptions import odxrequire
+from .exceptions import odxraise, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .utils import create_description_from_et
 
@@ -44,8 +44,21 @@ class BaseComparam:
         self.long_name = et_element.findtext("LONG-NAME")
         self.description = create_description_from_et(et_element.find("DESC"))
         self.param_class = odxrequire(et_element.attrib.get("PARAM-CLASS"))
-        self.cptype = StandardizationLevel(odxrequire(et_element.attrib.get("CPTYPE")))
-        self.cpusage = Usage(odxrequire(et_element.attrib.get("CPUSAGE")))
+
+        cptype_str = odxrequire(et_element.attrib.get("CPTYPE"))
+        try:
+            self.cptype = StandardizationLevel(cptype_str)
+        except ValueError:
+            self.cptype = cast(StandardizationLevel, None)
+            odxraise(f"Encountered unknown CPTYPE '{cptype_str}'")
+
+        cpusage_str = odxrequire(et_element.attrib.get("CPUSAGE"))
+        try:
+            self.cpusage = Usage(cpusage_str)
+        except ValueError:
+            self.cpusage = cast(Usage, None)
+            odxraise(f"Encountered unknown CPUSAGE '{cpusage_str}'")
+
         dl = et_element.attrib.get("DISPLAY_LEVEL")
         self.display_level = None if dl is None else int(dl)
 

--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -19,7 +19,7 @@ class DummyTool:
         self._error = error
 
     def add_subparser(self, subparser_list):
-        parser = subparser_list.add_parser(
+        subparser_list.add_parser(
             self._odxtools_tool_name_,
             description=f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}",
             help="Dummy tool",

--- a/odxtools/communicationparameterref.py
+++ b/odxtools/communicationparameterref.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
 from .comparam import Comparam
@@ -37,7 +37,7 @@ class CommunicationParameterRef:
         self._comparam: BaseComparam
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment],
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment],
                 dl_type: DiagLayerType) -> "CommunicationParameterRef":
         id_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
 

--- a/odxtools/communicationparameterref.py
+++ b/odxtools/communicationparameterref.py
@@ -50,7 +50,7 @@ class CommunicationParameterRef:
         elif et_element.find("SIMPLE-VALUE") is not None:
             value = odxrequire(et_element.findtext("SIMPLE-VALUE"))
         else:
-            value = odxrequire(create_complex_value_from_et(et_element.find("COMPLEX-VALUE")))
+            value = create_complex_value_from_et(odxrequire(et_element.find("COMPLEX-VALUE")))
 
         is_functional = dl_type == DiagLayerType.FUNCTIONAL_GROUP
         description = create_description_from_et(et_element.find("DESC"))

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .companyspecificinfo import CompanySpecificInfo
 from .exceptions import odxrequire
@@ -25,7 +25,7 @@ class CompanyData:
     company_specific_info: Optional[CompanySpecificInfo]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "CompanyData":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "CompanyData":
 
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
@@ -79,17 +79,3 @@ class CompanyData:
 
         if self.company_specific_info:
             self.company_specific_info._resolve_snrefs(diag_layer)
-
-
-def create_company_datas_from_et(et_element,
-                                 doc_frags: List[OdxDocFragment]) -> NamedItemList[CompanyData]:
-    if et_element is None:
-        return NamedItemList(short_name_as_id)
-
-    return NamedItemList(
-        short_name_as_id,
-        [
-            CompanyData.from_et(cd_elem, doc_frags)
-            for cd_elem in et_element.iterfind("COMPANY-DATA")
-        ],
-    )

--- a/odxtools/companyspecificinfo.py
+++ b/odxtools/companyspecificinfo.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .createsdgs import create_sdgs_from_et
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -18,7 +18,8 @@ class CompanySpecificInfo:
     sdgs: List[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "CompanySpecificInfo":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "CompanySpecificInfo":
         related_docs = [
             RelatedDoc.from_et(rd) for rd in et_element.iterfind("RELATED-DOCS/RELATED-DOC")
         ]

--- a/odxtools/comparam.py
+++ b/odxtools/comparam.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
 from .dataobjectproperty import DataObjectProperty
@@ -18,7 +18,7 @@ class Comparam(BaseComparam):
     physical_default_value: Optional[str]
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "Comparam":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Comparam":
         # create an "empty" Comparam object without calling the
         # "official" constructor. We need to do this because we need
         # all data attributes of the class to call the constructor,
@@ -31,7 +31,8 @@ class Comparam(BaseComparam):
 
         return result
 
-    def __init_from_et__(self, et_element: Element, doc_frags: List[OdxDocFragment]) -> None:
+    def __init_from_et__(self, et_element: ElementTree.Element,
+                         doc_frags: List[OdxDocFragment]) -> None:
         super().__init_from_et__(et_element, doc_frags)
 
         dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags))

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .companydata import CompanyData
@@ -38,7 +38,7 @@ class ComparamSubset:
     sdgs: List[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: Element) -> "ComparamSubset":
+    def from_et(et_element: ElementTree.Element) -> "ComparamSubset":
 
         category = et_element.get("CATEGORY")
 

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
 from .nameditemlist import NamedItemList
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 ComplexValue = List[Union[str, "ComplexValue"]]
 
 
-def create_complex_value_from_et(et_element: Element) -> ComplexValue:
+def create_complex_value_from_et(et_element: ElementTree.Element) -> ComplexValue:
     result: ComplexValue = []
     for el in et_element:
         if el.tag == "SIMPLE-VALUE":
@@ -36,7 +36,8 @@ class ComplexComparam(BaseComparam):
         return self.allow_multiple_values_raw == True
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "ComplexComparam":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "ComplexComparam":
         # create an "empty" ComplexComparam object without calling the
         # "official" constructor. We need to do this because we need
         # all data attributes of the class to call the constructor,
@@ -49,7 +50,8 @@ class ComplexComparam(BaseComparam):
 
         return result
 
-    def __init_from_et__(self, et_element: Element, doc_frags: List[OdxDocFragment]) -> None:
+    def __init_from_et__(self, et_element: ElementTree.Element,
+                         doc_frags: List[OdxDocFragment]) -> None:
         super().__init_from_et__(et_element, doc_frags)
 
         # to avoid a cyclic import, create_any_comparam_from_et cannot

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 ComplexValue = List[Union[str, "ComplexValue"]]
 
 
-def create_complex_value_from_et(et_element) -> ComplexValue:
-    result = []
+def create_complex_value_from_et(et_element: Element) -> ComplexValue:
+    result: ComplexValue = []
     for el in et_element:
         if el.tag == "SIMPLE-VALUE":
             result.append("" if el.text is None else el.text)
@@ -49,7 +49,7 @@ class ComplexComparam(BaseComparam):
 
         return result
 
-    def __init_from_et__(self, et_element, doc_frags: List[OdxDocFragment]) -> None:
+    def __init_from_et__(self, et_element: Element, doc_frags: List[OdxDocFragment]) -> None:
         super().__init_from_et__(et_element, doc_frags)
 
         # to avoid a cyclic import, create_any_comparam_from_et cannot

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple, Optional, Union, cast
 from xml.etree import ElementTree
 
-from ..exceptions import odxassert, odxrequire
+from ..exceptions import odxassert, odxraise, odxrequire
 from ..odxtypes import DataType
 
 
@@ -24,8 +24,12 @@ class Limit(NamedTuple):
         if et_element is None:
             return None
 
-        if et_element.get("INTERVAL-TYPE"):
-            interval_type = IntervalType(et_element.get("INTERVAL-TYPE"))
+        if (interval_type_str := et_element.get("INTERVAL-TYPE")) is not None:
+            try:
+                interval_type = IntervalType(interval_type_str)
+            except ValueError:
+                interval_type = IntervalType.CLOSED
+                odxraise(f"Encountered unknown interval type '{interval_type_str}'")
         else:
             interval_type = IntervalType.CLOSED
 

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
 from typing import NamedTuple, Optional, Union
+from xml.etree import ElementTree
 
-from ..exceptions import odxassert
+from ..exceptions import odxassert, odxrequire
 from ..odxtypes import DataType
 
 
@@ -17,7 +18,8 @@ class Limit(NamedTuple):
     interval_type: IntervalType = IntervalType.CLOSED
 
     @staticmethod
-    def from_et(et_element, internal_type: DataType) -> Optional["Limit"]:
+    def from_et(et_element: Optional[ElementTree.Element],
+                internal_type: DataType) -> Optional["Limit"]:
 
         if et_element is None:
             return None
@@ -34,12 +36,12 @@ class Limit(NamedTuple):
                 odxassert(et_element.tag == "UPPER-LIMIT")
                 return Limit(float("inf"), interval_type)
         elif internal_type == DataType.A_BYTEFIELD:
-            hex_text = et_element.text
+            hex_text = odxrequire(et_element.text)
             if len(hex_text) % 2 == 1:
                 hex_text = "0" + hex_text
             return Limit(bytes.fromhex(hex_text), interval_type)
         else:
-            return Limit(internal_type.from_string(et_element.text), interval_type)
+            return Limit(internal_type.from_string(odxrequire(et_element.text)), interval_type)
 
     def complies_to_upper(self, value):
         """Checks if the value is in the range w.r.t. the upper limit.

--- a/odxtools/createanycomparam.py
+++ b/odxtools/createanycomparam.py
@@ -1,5 +1,5 @@
 from typing import List
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
 from .comparam import Comparam
@@ -7,7 +7,7 @@ from .complexcomparam import ComplexComparam
 from .odxlink import OdxDocFragment
 
 
-def create_any_comparam_from_et(et_element: Element,
+def create_any_comparam_from_et(et_element: ElementTree.Element,
                                 doc_frags: List[OdxDocFragment]) -> BaseComparam:
     if et_element.tag == "COMPARAM":
         return Comparam.from_et(et_element, doc_frags)

--- a/odxtools/createanydiagcodedtype.py
+++ b/odxtools/createanydiagcodedtype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from typing import List
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .diagcodedtype import DiagCodedType
 from .exceptions import odxassert, odxrequire
@@ -13,7 +13,7 @@ from .paramlengthinfotype import ParamLengthInfoType
 from .standardlengthtype import StandardLengthType
 
 
-def create_any_diag_coded_type_from_et(et_element: Element,
+def create_any_diag_coded_type_from_et(et_element: ElementTree.Element,
                                        doc_frags: List[OdxDocFragment]) -> DiagCodedType:
     base_type_encoding = et_element.get("BASE-TYPE-ENCODING")
 
@@ -44,7 +44,6 @@ def create_any_diag_coded_type_from_et(et_element: Element,
     elif dct_type == "MIN-MAX-LENGTH-TYPE":
         min_length = int(odxrequire(et_element.findtext("MIN-LENGTH")))
         max_length = None
-        # comparison has to be 'is not None' as Element overwrites __bool__(), and always returns false for MAX-LENGTH elements
         if et_element.find("MAX-LENGTH") is not None:
             max_length = int(odxrequire(et_element.findtext("MAX-LENGTH")))
         termination = odxrequire(et_element.get("TERMINATION"))

--- a/odxtools/createanystructure.py
+++ b/odxtools/createanystructure.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 from typing import TYPE_CHECKING, List, Union
+from xml.etree import ElementTree
 
 from .createsdgs import create_sdgs_from_et
 from .globals import logger
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
     from .response import Response
 
 
-def create_any_structure_from_et(et_element, doc_frags: List[OdxDocFragment]
+def create_any_structure_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]
                                 ) -> Union[Structure, "Request", "Response", None]:
     from .request import Request
     from .response import Response

--- a/odxtools/createcompanydatas.py
+++ b/odxtools/createcompanydatas.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
-from typing import List
+from typing import List, Optional
+from xml.etree import ElementTree
 
 from .companydata import CompanyData
 from .nameditemlist import NamedItemList
@@ -7,7 +8,7 @@ from .odxlink import OdxDocFragment
 from .utils import short_name_as_id
 
 
-def create_company_datas_from_et(et_element,
+def create_company_datas_from_et(et_element: Optional[ElementTree.Element],
                                  doc_frags: List[OdxDocFragment]) -> NamedItemList[CompanyData]:
     if et_element is None:
         return NamedItemList(short_name_as_id)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -3,7 +3,6 @@ from itertools import chain
 from pathlib import Path
 from typing import List, Optional
 from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
 from zipfile import ZipFile
 
 from .comparamsubset import ComparamSubset
@@ -39,7 +38,7 @@ class Database:
         if pdx_zip is not None and odx_d_file_name is not None:
             raise TypeError("The 'pdx_zip' and 'odx_d_file_name' parameters are mutually exclusive")
 
-        documents: List[Element] = []
+        documents: List[ElementTree.Element] = []
         if pdx_zip is not None:
             names = list(pdx_zip.namelist())
             names.sort()

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .compumethods.compumethod import CompuMethod
 from .compumethods.createanycompumethod import create_any_compu_method_from_et
@@ -43,7 +43,8 @@ class DataObjectProperty(DopBase):
         self.unit_ref = unit_ref
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "DataObjectProperty":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "DataObjectProperty":
         """Reads a DATA-OBJECT-PROP or a DTC-DOP."""
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -55,9 +55,10 @@ class DataObjectProperty(DopBase):
         diag_coded_type = create_any_diag_coded_type_from_et(
             odxrequire(et_element.find("DIAG-CODED-TYPE")), doc_frags)
 
-        physical_type = PhysicalType.from_et(et_element.find("PHYSICAL-TYPE"), doc_frags)
+        physical_type = PhysicalType.from_et(
+            odxrequire(et_element.find("PHYSICAL-TYPE")), doc_frags)
         compu_method = create_any_compu_method_from_et(
-            et_element.find("COMPU-METHOD"),
+            odxrequire(et_element.find("COMPU-METHOD")),
             doc_frags,
             diag_coded_type.base_data_type,
             physical_type.base_data_type,

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .createanystructure import create_any_structure_from_et
@@ -51,7 +52,8 @@ class DiagDataDictionarySpec:
         )
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "DiagDataDictionarySpec":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "DiagDataDictionarySpec":
         # Parse DOP-BASEs
         data_object_props = [
             DataObjectProperty.from_et(dop_element, doc_frags)
@@ -100,8 +102,8 @@ class DiagDataDictionarySpec:
             for mux_element in et_element.iterfind("MUXS/MUX")
         ]
 
-        if et_element.find("UNIT-SPEC") is not None:
-            unit_spec = UnitSpec.from_et(et_element.find("UNIT-SPEC"), doc_frags)
+        if (spec_elem := et_element.find("UNIT-SPEC")) is not None:
+            unit_spec = UnitSpec.from_et(spec_elem, doc_frags)
         else:
             unit_spec = None
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -437,48 +437,88 @@ class DiagLayer:
 
     def _compute_available_diag_comms(self, odxlinks: OdxLinkDatabase
                                      ) -> Iterable[Union[DiagService, SingleEcuJob]]:
-        get_local_objects_fn = lambda dl: dl._get_local_diag_comms(odxlinks)
-        not_inherited_fn = lambda parent_ref: parent_ref.not_inherited_diag_comms
+
+        def get_local_objects_fn(dl):
+            return dl._get_local_diag_comms(odxlinks)
+
+        def not_inherited_fn(parent_ref):
+            return parent_ref.not_inherited_diag_comms
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_global_neg_responses(self, odxlinks: OdxLinkDatabase) \
             -> Iterable[Response]:
-        get_local_objects_fn = lambda dl: dl.diag_layer_raw.global_negative_responses
-        not_inherited_fn = lambda parent_ref: parent_ref.not_inherited_global_neg_responses
+
+        def get_local_objects_fn(dl):
+            return dl.diag_layer_raw.global_negative_responses
+
+        def not_inherited_fn(parent_ref):
+            return parent_ref.not_inherited_global_neg_responses
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_data_object_props(self) -> Iterable[DataObjectProperty]:
-        get_local_objects_fn = lambda dl: \
-            [] if dl.diag_layer_raw.diag_data_dictionary_spec is None \
-            else dl.diag_layer_raw.diag_data_dictionary_spec.data_object_props
-        not_inherited_fn = lambda parent_ref: parent_ref.not_inherited_dops
+
+        def get_local_objects_fn(dl):
+            if dl.diag_layer_raw.diag_data_dictionary_spec is None:
+                return []
+            return dl.diag_layer_raw.diag_data_dictionary_spec.data_object_props
+
+        def not_inherited_fn(parent_ref):
+            return parent_ref.not_inherited_dops
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_tables(self) -> Iterable[Table]:
-        get_local_objects_fn = lambda dl: \
-            [] if dl.diag_layer_raw.diag_data_dictionary_spec is None \
-            else dl.diag_layer_raw.diag_data_dictionary_spec.tables
-        not_inherited_fn = lambda parent_ref: parent_ref.not_inherited_tables
+
+        def get_local_objects_fn(dl):
+            if dl.diag_layer_raw.diag_data_dictionary_spec is None:
+                return []
+            return dl.diag_layer_raw.diag_data_dictionary_spec.tables
+
+        def not_inherited_fn(parent_ref):
+            return parent_ref.not_inherited_tables
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_functional_classes(self) -> Iterable[FunctionalClass]:
-        get_local_objects_fn = lambda dl: dl.diag_layer_raw.functional_classes
-        not_inherited_fn: Callable[[ParentRef], List[str]] = lambda parent_ref: []
+
+        def get_local_objects_fn(dl):
+            return dl.diag_layer_raw.functional_classes
+
+        def not_inherited_fn(parent_ref):
+            return []
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_additional_audiences(self) -> Iterable[AdditionalAudience]:
-        get_local_objects_fn = lambda dl: dl.diag_layer_raw.additional_audiences
-        not_inherited_fn: Callable[[ParentRef], List[str]] = lambda parent_ref: []
+
+        def get_local_objects_fn(dl):
+            return dl.diag_layer_raw.additional_audiences
+
+        def not_inherited_fn(parent_ref):
+            return []
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_state_charts(self) -> Iterable[StateChart]:
-        get_local_objects_fn = lambda dl: dl.diag_layer_raw.state_charts
-        not_inherited_fn: Callable[[ParentRef], List[str]] = lambda parent_ref: []
+
+        def get_local_objects_fn(dl):
+            return dl.diag_layer_raw.state_charts
+
+        def not_inherited_fn(parent_ref):
+            return []
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_unit_groups(self) -> Iterable[UnitGroup]:
-        get_local_objects_fn = lambda dl: dl._get_local_unit_groups()
-        not_inherited_fn: Callable[[ParentRef], List[str]] = lambda parent_ref: []
+
+        def get_local_objects_fn(dl):
+            return dl._get_local_unit_groups()
+
+        def not_inherited_fn(parent_ref):
+            return []
+
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     #####
@@ -913,7 +953,7 @@ class DiagLayer:
         for service in candidate_services:
             try:
                 decoded_messages.append(service.decode_message(message))
-            except DecodeError as e:
+            except DecodeError:
                 # check if the message can be decoded as a global
                 # negative response for the service
                 for gnr in self.global_negative_responses:

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -25,7 +25,7 @@ class DiagLayerContainer:
         long_name: Optional[str],
         description: Optional[str],
         admin_data: Optional[AdminData],
-        company_datas: Optional[NamedItemList[CompanyData]],
+        company_datas: NamedItemList[CompanyData],
         ecu_shared_datas: List[DiagLayer],
         protocols: List[DiagLayer],
         functional_groups: List[DiagLayer],

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from itertools import chain
 from typing import List, Optional, Union
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .companydata import CompanyData
@@ -59,7 +59,7 @@ class DiagLayerContainer:
         )
 
     @staticmethod
-    def from_et(et_element: Element) -> "DiagLayerContainer":
+    def from_et(et_element: ElementTree.Element) -> "DiagLayerContainer":
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
 

--- a/odxtools/diaglayerraw.py
+++ b/odxtools/diaglayerraw.py
@@ -101,9 +101,8 @@ class DiagLayerRaw:
         ]
 
         diag_data_dictionary_spec = None
-        if et_element.find("DIAG-DATA-DICTIONARY-SPEC"):
-            diag_data_dictionary_spec = DiagDataDictionarySpec.from_et(
-                et_element.find("DIAG-DATA-DICTIONARY-SPEC"), doc_frags)
+        if (ddds_elem := et_element.find("DIAG-DATA-DICTIONARY-SPEC")) is not None:
+            diag_data_dictionary_spec = DiagDataDictionarySpec.from_et(ddds_elem, doc_frags)
 
         diag_comms: List[Union[OdxLinkRef, DiagService, SingleEcuJob]] = []
         if (dc_elems := et_element.find("DIAG-COMMS")) is not None:

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union, cast
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .audience import Audience
@@ -115,7 +115,7 @@ class DiagService:
         self.sdgs = sdgs
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "DiagService":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagService":
 
         # logger.info(f"Parsing service based on ET DiagService element: {et_element}")
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -20,6 +20,7 @@ from .utils import create_description_from_et, short_name_as_id
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
+    from .endofpdufield import EndOfPduField
 
 
 class DiagService:

--- a/odxtools/docrevision.py
+++ b/odxtools/docrevision.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .companyrevisioninfo import CompanyRevisionInfo
 from .exceptions import odxrequire
@@ -32,7 +32,7 @@ class DocRevision:
         return self._team_member
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "DocRevision":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DocRevision":
 
         team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
         revision_label = et_element.findtext("REVISION-LABEL")

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from .dataobjectproperty import DataObjectProperty
 from .diagnostictroublecode import DiagnosticTroubleCode
-from .exceptions import odxassert
+from .exceptions import EncodeError, odxassert
 from .nameditemlist import NamedItemList
 from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .utils import short_name_as_id

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from copy import copy
 from typing import TYPE_CHECKING, List, Optional
+from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .createsdgs import create_sdgs_from_et
@@ -51,7 +52,8 @@ class EndOfPduField(DopBase):
         self.max_number_of_items = max_number_of_items
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "EndOfPduField":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "EndOfPduField":
         odx_id = OdxLinkId.from_et(et_element, doc_frags)
         odxassert(odx_id is not None)
         short_name = et_element.findtext("SHORT-NAME")
@@ -69,12 +71,12 @@ class EndOfPduField(DopBase):
         if (edsnr_elem := et_element.find("ENV-DATA-DESC-SNREF")) is not None:
             env_data_desc_snref = edsnr_elem.get("SHORT-NAME")
 
-        if et_element.find("MIN-NUMBER-OF-ITEMS") is not None:
-            min_number_of_items = int(et_element.findtext("MIN-NUMBER-OF-ITEMS"))
+        if (min_n_str := et_element.findtext("MIN-NUMBER-OF-ITEMS")) is not None:
+            min_number_of_items = int(min_n_str)
         else:
             min_number_of_items = None
-        if et_element.find("MAX-NUMBER-OF-ITEMS") is not None:
-            max_number_of_items = int(et_element.findtext("MAX-NUMBER-OF-ITEMS"))
+        if (max_n_str := et_element.findtext("MAX-NUMBER-OF-ITEMS")) is not None:
+            max_number_of_items = int(max_n_str)
         else:
             max_number_of_items = None
 

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import List
+from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .createsdgs import create_sdgs_from_et
@@ -22,7 +23,8 @@ class EnvironmentData(BasicStructure):
         self.dtc_values = dtc_values
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "EnvironmentData":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "EnvironmentData":
         """Reads Environment Data from Diag Layer."""
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = et_element.findtext("SHORT-NAME")
@@ -37,7 +39,8 @@ class EnvironmentData(BasicStructure):
         byte_size_text = et_element.findtext("BYTE-SIZE")
         byte_size = None if byte_size_text is None else int(byte_size_text)
         dtc_values = [
-            int(dtcv_elem.text) for dtcv_elem in et_element.iterfind("DTC-VALUES/DTC-VALUE")
+            int(odxrequire(dtcv_elem.text))
+            for dtcv_elem in et_element.iterfind("DTC-VALUES/DTC-VALUE")
         ]
 
         return EnvironmentData(

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .createsdgs import create_sdgs_from_et
 from .decodestate import DecodeState
@@ -41,7 +41,7 @@ class EnvironmentDataDescription(DopBase):
         self.param_snpathref = param_snpathref
 
     @staticmethod
-    def from_et(et_element: Element,
+    def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "EnvironmentDataDescription":
         """Reads Environment Data Description from Diag Layer."""
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -23,7 +23,8 @@ class FunctionalClass:
     description: Optional[str]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "FunctionalClass":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "FunctionalClass":
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
 

--- a/odxtools/inputparam.py
+++ b/odxtools/inputparam.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .dopbase import DopBase
 from .exceptions import odxrequire
@@ -23,7 +23,7 @@ class InputParam:
     physical_default_value: Optional[str]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "InputParam":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "InputParam":
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -141,7 +141,7 @@ class IsoTpStateMachine:
                     return
 
                 if m := self.can_normal_frame_re.match(cur_line.strip()):
-                    frame_interface = m.group(1)
+                    #frame_interface = m.group(1)
                     frame_id = int(m.group(2), 16)
 
                     frame_data_formatted = m.group(3).strip()
@@ -152,7 +152,7 @@ class IsoTpStateMachine:
                         yield tmp
 
                 elif m := self.can_log_frame_re.match(cur_line.strip()):
-                    frame_interface = m.group(2)
+                    #frame_interface = m.group(2)
                     frame_id = int(m.group(2), 16)
 
                     frame_data_formatted = m.group(3).strip()
@@ -253,7 +253,7 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
 
     def on_single_frame(self, telegram_idx, frame_payload):
         # send ACK
-        rx_id = self.can_rx_id(telegram_idx)
+        #rx_id = self.can_rx_id(telegram_idx)
         tx_id = self.can_tx_id(telegram_idx)
         block_size = 0xFF
         min_separation_time = 0  # ms
@@ -272,7 +272,7 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
 
     def on_first_frame(self, telegram_idx, frame_payload):
         # send ACK
-        rx_id = self.can_rx_id(telegram_idx)
+        #rx_id = self.can_rx_id(telegram_idx)
         tx_id = self.can_tx_id(telegram_idx)
         block_size = 0xFF  # default value, can be overwritten later
         min_separation_time = 0  # ms
@@ -298,7 +298,7 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
         # send new ACK if necessary
         block_size = self._block_size[telegram_idx]
         if self._frames_received[telegram_idx] >= block_size:
-            rx_id = self.can_rx_id(telegram_idx)
+            #rx_id = self.can_rx_id(telegram_idx)
             tx_id = self.can_tx_id(telegram_idx)
             min_separation_time = 0  # ms
             fc_payload = bitstruct.pack(

--- a/odxtools/modification.py
+++ b/odxtools/modification.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 
@@ -15,7 +15,7 @@ class Modification:
     reason: Optional[str]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "Modification":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Modification":
         change = et_element.findtext("CHANGE")
         reason = et_element.findtext("REASON")
 

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .createsdgs import create_sdgs_from_et
 from .decodestate import DecodeState
@@ -31,7 +31,7 @@ class Multiplexer(DopBase):
     cases: List[MultiplexerCase]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "Multiplexer":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Multiplexer":
         """Reads a Multiplexer from Diag Layer."""
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .exceptions import odxrequire
@@ -25,7 +25,8 @@ class MultiplexerCase:
         self._structure: Optional[BasicStructure] = None
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "MultiplexerCase":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "MultiplexerCase":
         """Reads a Case for a Multiplexer."""
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")

--- a/odxtools/multiplexerdefaultcase.py
+++ b/odxtools/multiplexerdefaultcase.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .exceptions import odxrequire
@@ -23,7 +23,8 @@ class MultiplexerDefaultCase:
         self._structure: Optional[BasicStructure] = None
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "MultiplexerDefaultCase":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "MultiplexerDefaultCase":
         """Reads a Default Case for a Multiplexer."""
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")

--- a/odxtools/multiplexerswitchkey.py
+++ b/odxtools/multiplexerswitchkey.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .dataobjectproperty import DataObjectProperty
 from .exceptions import odxrequire
@@ -24,7 +24,8 @@ class MultiplexerSwitchKey:
         self._dop: DataObjectProperty = None  # type: ignore
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "MultiplexerSwitchKey":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "MultiplexerSwitchKey":
         """Reads a Switch Key for a Multiplexer."""
         byte_position = int(odxrequire(et_element.findtext("BYTE-POSITION", "0")))
         bit_position_str = et_element.findtext("BIT-POSITION")

--- a/odxtools/negoutputparam.py
+++ b/odxtools/negoutputparam.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .dopbase import DopBase
 from .exceptions import odxrequire
@@ -23,7 +23,8 @@ class NegOutputParam:
         self._dop: Optional[DopBase] = None
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "NegOutputParam":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "NegOutputParam":
 
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -2,7 +2,7 @@
 import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type, TypeVar, overload
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import OdxWarning, odxassert
 
@@ -63,7 +63,8 @@ class OdxLinkId:
         return f"OdxLinkId('{self.local_id}')"
 
     @staticmethod
-    def from_et(et: Element, doc_fragments: List[OdxDocFragment]) -> Optional["OdxLinkId"]:
+    def from_et(et: ElementTree.Element,
+                doc_fragments: List[OdxDocFragment]) -> Optional["OdxLinkId"]:
         """Construct an OdxLinkId for a given XML node (ElementTree object).
 
         Returns None if the given XML node does not exhibit an ID.
@@ -98,11 +99,11 @@ class OdxLinkRef:
 
     @overload
     @staticmethod
-    def from_et(et: Element, source_doc_frags: List[OdxDocFragment]) -> "OdxLinkRef":
+    def from_et(et: ElementTree.Element, source_doc_frags: List[OdxDocFragment]) -> "OdxLinkRef":
         ...
 
     @staticmethod
-    def from_et(et: Optional[Element],
+    def from_et(et: Optional[ElementTree.Element],
                 source_doc_frags: List[OdxDocFragment]) -> Optional["OdxLinkRef"]:
         """Construct an OdxLinkRef for a given XML node (ElementTree object).
 

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .dopbase import DopBase
 from .exceptions import odxrequire
@@ -26,7 +26,7 @@ class OutputParam:
         self._dop: Optional[DopBase] = None
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "OutputParam":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "OutputParam":
 
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from copy import copy
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict
 
 from ..decodestate import DecodeState
 from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, odxraise
 from ..odxlink import OdxLinkDatabase, OdxLinkId
-from ..odxtypes import DataType
+from ..odxtypes import AtomicOdxType, DataType
 from .parameter import Parameter
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 class CodedConstParameter(Parameter):
 
-    def __init__(self, *, diag_coded_type: DiagCodedType, coded_value: Union[int, bytes], **kwargs):
+    def __init__(self, *, diag_coded_type: DiagCodedType, coded_value: AtomicOdxType, **kwargs):
         super().__init__(parameter_type="CODED-CONST", **kwargs)
 
         self.diag_coded_type = diag_coded_type

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -1,14 +1,19 @@
 # SPDX-License-Identifier: MIT
+from typing import List
+from xml.etree import ElementTree
+
 from ..createanydiagcodedtype import create_any_diag_coded_type_from_et
 from ..createsdgs import create_sdgs_from_et
+from ..exceptions import odxrequire
 from ..globals import xsi
-from ..odxlink import OdxLinkId, OdxLinkRef
+from ..odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
 from ..utils import create_description_from_et
 from .codedconstparameter import CodedConstParameter
 from .dynamicparameter import DynamicParameter
 from .lengthkeyparameter import LengthKeyParameter
 from .matchingrequestparameter import MatchingRequestParameter
 from .nrcconstparameter import NrcConstParameter
+from .parameter import Parameter
 from .physicalconstantparameter import PhysicalConstantParameter
 from .reservedparameter import ReservedParameter
 from .systemparameter import SystemParameter
@@ -18,7 +23,9 @@ from .tablestructparameter import TableStructParameter
 from .valueparameter import ValueParameter
 
 
-def create_any_parameter_from_et(et_element, doc_frags):
+def create_any_parameter_from_et(et_element: ElementTree.Element,
+                                 doc_frags: List[OdxDocFragment]) \
+                                 -> Parameter:
     short_name = et_element.findtext("SHORT-NAME")
     long_name = et_element.findtext("LONG-NAME")
     description = create_description_from_et(et_element.find("DESC"))
@@ -36,9 +43,9 @@ def create_any_parameter_from_et(et_element, doc_frags):
     # Which attributes are set depends on the type of the parameter.
     if parameter_type in ["VALUE", "PHYS-CONST", "SYSTEM", "LENGTH-KEY"]:
         dop_ref = OdxLinkRef.from_et(et_element.find("DOP-REF"), doc_frags)
-        dop_snref = (
-            et_element.find("DOP-SNREF").get("SHORT-NAME")
-            if et_element.find("DOP-SNREF") is not None else None)
+        dop_snref = None
+        if (dop_snref_elem := et_element.find("DOP-SNREF")) is not None:
+            dop_snref = odxrequire(dop_snref_elem.get("SHORT-NAME"))
 
         if dop_ref is None and dop_snref is None:
             raise ValueError(
@@ -64,7 +71,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
         )
 
     elif parameter_type == "PHYS-CONST":
-        physical_constant_value = et_element.findtext("PHYS-CONSTANT-VALUE")
+        physical_constant_value = odxrequire(et_element.findtext("PHYS-CONSTANT-VALUE"))
 
         return PhysicalConstantParameter(
             short_name=short_name,
@@ -80,9 +87,10 @@ def create_any_parameter_from_et(et_element, doc_frags):
         )
 
     elif parameter_type == "CODED-CONST":
-        diag_coded_type = create_any_diag_coded_type_from_et(
-            et_element.find("DIAG-CODED-TYPE"), doc_frags)
-        coded_value = diag_coded_type.base_data_type.from_string(et_element.findtext("CODED-VALUE"))
+        dct_elem = odxrequire(et_element.find("DIAG-CODED-TYPE"))
+        diag_coded_type = create_any_diag_coded_type_from_et(dct_elem, doc_frags)
+        coded_value = diag_coded_type.base_data_type.from_string(
+            odxrequire(et_element.findtext("CODED-VALUE")))
 
         return CodedConstParameter(
             short_name=short_name,
@@ -98,9 +106,9 @@ def create_any_parameter_from_et(et_element, doc_frags):
 
     elif parameter_type == "NRC-CONST":
         diag_coded_type = create_any_diag_coded_type_from_et(
-            et_element.find("DIAG-CODED-TYPE"), doc_frags)
+            odxrequire(et_element.find("DIAG-CODED-TYPE")), doc_frags)
         coded_values = [
-            diag_coded_type.base_data_type.from_string(val.text)
+            diag_coded_type.base_data_type.from_string(odxrequire(val.text))
             for val in et_element.iterfind("CODED-VALUES/CODED-VALUE")
         ]
 
@@ -117,7 +125,7 @@ def create_any_parameter_from_et(et_element, doc_frags):
         )
 
     elif parameter_type == "RESERVED":
-        bit_length = int(et_element.findtext("BIT-LENGTH"))
+        bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
 
         return ReservedParameter(
             bit_length=bit_length,
@@ -131,8 +139,8 @@ def create_any_parameter_from_et(et_element, doc_frags):
         )
 
     elif parameter_type == "MATCHING-REQUEST-PARAM":
-        byte_length = int(et_element.findtext("BYTE-LENGTH"))
-        request_byte_pos = int(et_element.findtext("REQUEST-BYTE-POS"))
+        byte_length = int(odxrequire(et_element.findtext("BYTE-LENGTH")))
+        request_byte_pos = int(odxrequire(et_element.findtext("REQUEST-BYTE-POS")))
 
         return MatchingRequestParameter(
             short_name=short_name,
@@ -192,9 +200,10 @@ def create_any_parameter_from_et(et_element, doc_frags):
 
     elif parameter_type == "TABLE-STRUCT":
         key_ref = OdxLinkRef.from_et(et_element.find("TABLE-KEY-REF"), doc_frags)
-        key_snref = (
-            et_element.find("TABLE-KEY-SNREF").get("SHORT-NAME")
-            if et_element.find("TABLE-KEY-SNREF") is not None else None)
+        if (key_snref_elem := et_element.find("TABLE-KEY-SNREF")) is not None:
+            key_snref = odxrequire(key_snref_elem.get("SHORT-NAME"))
+        else:
+            key_snref = None
 
         return TableStructParameter(
             short_name=short_name,
@@ -212,20 +221,23 @@ def create_any_parameter_from_et(et_element, doc_frags):
 
         parameter_id = OdxLinkId.from_et(et_element, doc_frags)
         table_ref = OdxLinkRef.from_et(et_element.find("TABLE-REF"), doc_frags)
-        table_snref = (
-            et_element.find("TABLE-SNREF").get("SHORT-NAME")
-            if et_element.find("TABLE-SNREF") is not None else None)
-        row_snref = (
-            et_element.find("TABLE-ROW-SNREF").get("SHORT-NAME")
-            if et_element.find("TABLE-ROW-SNREF") is not None else None)
-        row_ref = OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), doc_frags)
+        if (table_snref_elem := et_element.find("TABLE-SNREF")) is not None:
+            table_snref = odxrequire(table_snref_elem.get("SHORT-NAME"))
+        else:
+            table_snref = None
+
+        table_row_ref = OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), doc_frags)
+        if (table_row_snref_elem := et_element.find("TABLE-ROW-SNREF")) is not None:
+            table_row_snref = odxrequire(table_row_snref_elem.get("SHORT-NAME"))
+        else:
+            table_row_snref = None
 
         return TableKeyParameter(
             short_name=short_name,
             table_ref=table_ref,
             table_snref=table_snref,
-            table_row_snref=row_snref,
-            table_row_ref=row_ref,
+            table_row_snref=table_row_snref,
+            table_row_ref=table_row_ref,
             odx_id=parameter_id,
             long_name=long_name,
             byte_position=byte_position,
@@ -236,8 +248,8 @@ def create_any_parameter_from_et(et_element, doc_frags):
         )
 
     elif parameter_type == "TABLE-ENTRY":
-        target = et_element.findtext("TARGET")
-        table_row_ref = OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), doc_frags)
+        target = odxrequire(et_element.findtext("TARGET"))
+        table_row_ref = odxrequire(OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), doc_frags))
 
         return TableEntryParameter(
             short_name=short_name,

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -8,7 +8,7 @@ from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, EncodeError, odxassert
 from ..odxlink import OdxLinkDatabase, OdxLinkId
-from ..odxtypes import DataType
+from ..odxtypes import AtomicOdxType, DataType
 from .parameter import Parameter
 
 if TYPE_CHECKING:
@@ -25,7 +25,8 @@ class NrcConstParameter(Parameter):
     See ASAM MCD-2 D (ODX), p. 77-79.
     """
 
-    def __init__(self, *, diag_coded_type: DiagCodedType, coded_values: List[int], **kwargs):
+    def __init__(self, *, diag_coded_type: DiagCodedType, coded_values: List[AtomicOdxType],
+                 **kwargs):
         super().__init__(parameter_type="NRC-CONST", **kwargs)
 
         self.diag_coded_type = diag_coded_type

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -100,8 +100,6 @@ class TableKeyParameter(Parameter):
                                   f"a KEY-DOP, but is used in TABLE-KEY parameter "
                                   f"'{self.short_name}'")
 
-            byte_pos = len(encode_state.coded_message
-                          ) if self.byte_position is not None else self.byte_position
             byte_len = (key_dop.bit_length + 7) // 8
             if self.bit_position is not None and self.bit_position > 0:
                 byte_len += 1
@@ -126,8 +124,6 @@ class TableKeyParameter(Parameter):
         return key_dop.convert_physical_to_bytes(tr.key, encode_state, bit_position=bit_position)
 
     def encode_into_pdu(self, encode_state: EncodeState) -> bytes:
-        tr_short_name = encode_state.parameter_values.get(self.short_name)
-
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -22,8 +22,7 @@ class TableStructParameter(Parameter):
         self.table_key_ref = table_key_ref
         self.table_key_snref = table_key_snref
         if self.table_key_ref is None and self.table_key_snref is None:
-            raise OdxError("Either table_key_ref or table_key_snref "
-                           "must be defined.")
+            odxraise("Either table_key_ref or table_key_snref must be defined.")
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return super()._build_odxlinks()

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -24,7 +24,7 @@ class ParentRef:
         return self._layer
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
 
         layer_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
 

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -57,10 +58,11 @@ class PhysicalDimension:
     luminous_intensity_exp: int
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "PhysicalDimension":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "PhysicalDimension":
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         oid = et_element.get("OID")
-        short_name = et_element.findtext("SHORT-NAME")
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
 

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from enum import Enum
+from enum import IntEnum
 from typing import List, Optional
 from xml.etree import ElementTree
 
@@ -9,11 +9,11 @@ from .odxlink import OdxDocFragment
 from .odxtypes import DataType
 
 
-class Radix(Enum):
-    HEX = "HEX"
-    DEC = "DEC"
-    BIN = "BIN"
-    OCT = "OCT"
+class Radix(IntEnum):
+    HEX = 16
+    DEC = 10
+    BIN = 2
+    OCT = 8
 
 
 @dataclass
@@ -67,7 +67,7 @@ class PhysicalType:
         if display_radix_str is not None:
             if display_radix_str not in Radix.__members__:
                 odxraise(f"Encountered unknown display radix '{display_radix_str}'")
-            display_radix = Radix(display_radix_str)
+            display_radix = Radix.__members__[display_radix_str]
         else:
             display_radix = None
 

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -34,9 +34,10 @@ class ProgCode:
         encryption = et_element.findtext("ENCRYPTION")
 
         syntax_str = odxrequire(et_element.findtext("SYNTAX"))
-        if syntax_str not in ProgCodeSyntax.__members__:
+        try:
+            syntax = ProgCodeSyntax(syntax_str)
+        except ValueError:
             odxraise(f"Encountered unknown program code syntax '{syntax_str}'")
-        syntax = ProgCodeSyntax(syntax_str)
 
         revision = odxrequire(et_element.findtext("REVISION"))
         entrypoint = et_element.findtext("ENTRYPOINT")

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -28,7 +28,7 @@ class ProgCode:
     library_refs: List[OdxLinkRef]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "ProgCode":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ProgCode":
         code_file = odxrequire(et_element.findtext("CODE-FILE"))
 
         encryption = et_element.findtext("ENCRYPTION")

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
@@ -37,6 +37,7 @@ class ProgCode:
         try:
             syntax = ProgCodeSyntax(syntax_str)
         except ValueError:
+            syntax = cast(ProgCodeSyntax, None)
             odxraise(f"Encountered unknown program code syntax '{syntax_str}'")
 
         revision = odxrequire(et_element.findtext("REVISION"))

--- a/odxtools/relateddoc.py
+++ b/odxtools/relateddoc.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .odxlink import OdxLinkDatabase, OdxLinkId
 from .utils import create_description_from_et
@@ -17,7 +17,7 @@ class RelatedDoc:
     xdoc: Optional[XDoc]
 
     @staticmethod
-    def from_et(et_element: Element) -> "RelatedDoc":
+    def from_et(et_element: ElementTree.Element) -> "RelatedDoc":
         description = create_description_from_et(et_element.find("DESC"))
 
         xdoc: Optional[XDoc] = None

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -146,9 +146,10 @@ class SingleEcuJob:
 
         diag_class: Optional[DiagClassType] = None
         if (diag_class_str := et_element.get("DIAGNOSTIC-CLASS")) is not None:
-            if diag_class_str not in DiagClassType.__members__:
+            try:
+                diag_class = DiagClassType(diag_class_str)
+            except ValueError:
                 odxraise(f"Encountered unknown diagnostic class type '{diag_class_str}'")
-            diag_class = DiagClassType(diag_class_str)
 
         return SingleEcuJob(
             odx_id=odx_id,

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .audience import Audience
@@ -99,7 +99,7 @@ class SingleEcuJob:
             self.neg_output_params = NamedItemList(short_name_as_id)
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "SingleEcuJob":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "SingleEcuJob":
 
         logger.info(f"Parsing service based on ET DiagService element: {et_element}")
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -144,11 +144,11 @@ class SingleEcuJob:
         is_executable_raw = odxstr_to_bool(et_element.get("IS-MANDATORY"))
         is_final_raw = odxstr_to_bool(et_element.get("IS-FINAL"))
 
-        diag_class_type: Optional[DiagClassType] = None
-        if (diag_class_type_str := et_element.get("DIAGNOSTIC-CLASS")) is not None:
-            if diag_class_type_str not in DiagClassType.__members__:
-                odxraise(f"Encountered unknown diagnostic class type '{diag_class_type_str}'")
-            diag_class_type = DiagClassType(diag_class_type_str)
+        diag_class: Optional[DiagClassType] = None
+        if (diag_class_str := et_element.get("DIAGNOSTIC-CLASS")) is not None:
+            if diag_class_str not in DiagClassType.__members__:
+                odxraise(f"Encountered unknown diagnostic class type '{diag_class_str}'")
+            diag_class = DiagClassType(diag_class_str)
 
         return SingleEcuJob(
             odx_id=odx_id,
@@ -161,7 +161,7 @@ class SingleEcuJob:
             semantic=semantic,
             audience=audience,
             functional_class_refs=functional_class_refs,
-            diagnostic_class=None,
+            diagnostic_class=diag_class,
             input_params=input_params,
             output_params=output_params,
             neg_output_params=neg_output_params,

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -149,6 +149,7 @@ class SingleEcuJob:
             try:
                 diag_class = DiagClassType(diag_class_str)
             except ValueError:
+                diag_class = cast(DiagClassType, None)
                 odxraise(f"Encountered unknown diagnostic class type '{diag_class_str}'")
 
         return SingleEcuJob(

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -80,16 +80,3 @@ class SpecialDataGroup:
 
         for val in self.values:
             val._resolve_snrefs(diag_layer)
-
-
-def create_sdgs_from_et(et_element: Optional[ElementTree.Element],
-                        doc_frags: List[OdxDocFragment]) -> List[SpecialDataGroup]:
-
-    if not et_element:
-        return []
-
-    result = []
-    for sdg_elem in et_element.iterfind("SDG"):
-        result.append(SpecialDataGroup.from_et(sdg_elem, doc_frags))
-
-    return result

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -23,7 +23,7 @@ class State:
     description: Optional[str]
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "State":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "State":
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")

--- a/odxtools/statechart.py
+++ b/odxtools/statechart.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
@@ -34,7 +34,7 @@ class StateChart:
         return self._start_state
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "StateChart":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "StateChart":
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -35,7 +35,8 @@ class StateTransition:
         return self._target_state
 
     @staticmethod
-    def from_et(et_element: Element, doc_frags: List[OdxDocFragment]) -> "StateTransition":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "StateTransition":
 
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .createsdgs import create_sdgs_from_et
@@ -34,7 +35,7 @@ class Table:
     sdgs: List[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "Table":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Table":
         """Reads a TABLE."""
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         short_name: str = odxrequire(et_element.findtext("SHORT-NAME"))

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .createsdgs import create_sdgs_from_et
@@ -22,7 +23,7 @@ class TableRow:
 
     odx_id: OdxLinkId
     short_name: str
-    long_name: str
+    long_name: Optional[str]
     table_ref: OdxLinkRef
     key_raw: str
     structure_ref: Optional[OdxLinkRef]
@@ -49,7 +50,7 @@ class TableRow:
         )
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment], *,
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
                 table_ref: OdxLinkRef) -> "TableRow":
         """Reads a TABLE-ROW."""
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
@@ -57,7 +58,7 @@ class TableRow:
         long_name = et_element.findtext("LONG-NAME")
         semantic = et_element.get("SEMANTIC")
         description = create_description_from_et(et_element.find("DESC"))
-        key_raw = et_element.findtext("KEY")
+        key_raw = odxrequire(et_element.findtext("KEY"))
         structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
         structure_snref: Optional[str] = None
         if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -32,7 +32,7 @@
 
 {%- macro printPhysicalType(physical_type) %}
 {%- if physical_type.display_radix is not none %}
-<PHYSICAL-TYPE BASE-DATA-TYPE="{{physical_type.base_data_type.value}}" DISPLAY-RADIX="{{physical_type.display_radix.value}}" />
+<PHYSICAL-TYPE BASE-DATA-TYPE="{{physical_type.base_data_type.value}}" DISPLAY-RADIX="{{physical_type.display_radix.name}}" />
 {%- elif physical_type.precision is not none   %}
 <PHYSICAL-TYPE BASE-DATA-TYPE="{{physical_type.base_data_type.value}}">
  <PRECISION>{{physical_type.precision}}</PRECISION>

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -67,13 +68,13 @@ class Unit:
         self._physical_dimension = None
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "Unit":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Unit":
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
         oid = et_element.get("OID")
-        short_name = et_element.findtext("SHORT-NAME")
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
-        display_name = et_element.findtext("DISPLAY-NAME")
+        display_name = odxrequire(et_element.findtext("DISPLAY-NAME"))
 
         def read_optional_float(element, name):
             if element.findtext(name):

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList
@@ -36,9 +37,9 @@ class UnitGroup:
         self._units = NamedItemList[Unit](short_name_as_id)
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) -> "UnitGroup":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "UnitGroup":
         oid = et_element.get("OID")
-        short_name = et_element.findtext("SHORT-NAME")
+        short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
         category_str = et_element.findtext("CATEGORY")

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -43,9 +43,10 @@ class UnitGroup:
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
         category_str = et_element.findtext("CATEGORY")
-        if category_str not in UnitGroupCategory.__members__:
+        try:
+            category = UnitGroupCategory(category_str)
+        except ValueError:
             odxraise(f"Encountered unknown unit group category '{category_str}'")
-        category = UnitGroupCategory(category_str)
 
         unit_refs: List[OdxLinkRef] = [
             odxrequire(OdxLinkRef.from_et(el, doc_frags))

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
@@ -42,10 +42,11 @@ class UnitGroup:
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))
-        category_str = et_element.findtext("CATEGORY")
+        category_str = odxrequire(et_element.findtext("CATEGORY"))
         try:
             category = UnitGroupCategory(category_str)
         except ValueError:
+            category = cast(UnitGroupCategory, None)
             odxraise(f"Encountered unknown unit group category '{category_str}'")
 
         unit_refs: List[OdxLinkRef] = [

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Union
+from xml.etree import ElementTree
 
 from .createsdgs import create_sdgs_from_et
 from .nameditemlist import NamedItemList
@@ -39,7 +40,7 @@ class UnitSpec:
         self.physical_dimensions = NamedItemList(short_name_as_id, self.physical_dimensions)
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]):
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]):
 
         unit_groups = [
             UnitGroup.from_et(el, doc_frags) for el in et_element.iterfind("UNIT-GROUPS/UNIT-GROUP")

--- a/odxtools/xdoc.py
+++ b/odxtools/xdoc.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional
-from xml.etree.ElementTree import Element
+from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxLinkDatabase, OdxLinkId
@@ -24,7 +24,7 @@ class XDoc:
     position: Optional[str]
 
     @staticmethod
-    def from_et(et_element: Element) -> "XDoc":
+    def from_et(et_element: ElementTree.Element) -> "XDoc":
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         long_name = et_element.findtext("LONG-NAME")
         description = create_description_from_et(et_element.find("DESC"))

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -386,7 +386,6 @@ class TestParamLengthInfoType(unittest.TestCase):
             byte_position=1,
             bit_position=None,
         )
-        length_key_ref = OdxLinkRef.from_id(length_key_id)
         dct = ParamLengthInfoType(
             base_data_type="A_UINT32",
             base_type_encoding=None,

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -163,7 +163,7 @@ class TestEncodeRequest(unittest.TestCase):
         param1._resolve_odxlinks(odxlinks)
 
         # Missing mandatory parameter.
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             req.encode()
 
         self.assertEqual(


### PR DESCRIPTION
Also, remove the spurious duplicate `create_*_from_et()` functions which were forgotten to be deleted from the non-`create*.py` files during the recent restructuring.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)