### PR TITLE
Allow to use contemporary versions of python can

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires_list = [
     "argparse_addons",
     "PyInquirer",
     "jinja2",
-    "python-can < 4.0",
+    "python-can",
     "can-isotp",
     "markdownify",
     "deprecation",


### PR DESCRIPTION
In the odxtools stone age, python-can 4.0 causes some exceptions to be raised. This has long been fixed.

This fixes #174.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)