### PR TITLE
add a MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+recursive-include doc *
+recursive-include odxtools
+recursive-include odxtools/templates *.jinja2
+recursive-include tests
+recursive-include examples *
+include *.md
+include LICENSE


### PR DESCRIPTION
for whatever reason, the `setuptools` heuristic for automatically determining which files ought to be distributed broke down recently, so that all sub-directories of `odxtools/` were no longer part of the pypi package. Explicitly instructing `setuptools` what to include fixes that...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)