### PR TITLE
Make the compumethods dataclasses

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -424,9 +424,24 @@ somersault_compumethods: Dict[str, CompuMethod] = {
     "boolean":
         TexttableCompuMethod(
             internal_type=DataType.A_UINT32,
+            physical_type=DataType.A_UNICODE2STRING,
             internal_to_phys=[
-                CompuScale(compu_const="false", lower_limit=Limit(0), upper_limit=Limit(0)),
-                CompuScale(compu_const="true", lower_limit=Limit(1), upper_limit=Limit(1)),
+                CompuScale(
+                    compu_const="false",
+                    lower_limit=Limit(0),
+                    upper_limit=Limit(0),
+                    short_label=None,
+                    description=None,
+                    compu_inverse_value=None,
+                    compu_rational_coeffs=None),
+                CompuScale(
+                    compu_const="true",
+                    lower_limit=Limit(1),
+                    upper_limit=Limit(1),
+                    short_label=None,
+                    description=None,
+                    compu_inverse_value=None,
+                    compu_rational_coeffs=None),
             ],
         ),
 }

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -1,16 +1,28 @@
 # SPDX-License-Identifier: MIT
-from typing import Union
+import abc
+from dataclasses import dataclass
+from typing import Literal, Union
 
 from ..odxtypes import DataType
 
+CompuMethodCategory = Literal[
+    "IDENTICAL",
+    "LINEAR",
+    "SCALE-LINEAR",
+    "TAB-INTP",
+    "TEXTTABLE",
+]
 
-class CompuMethod:
 
-    def __init__(self, *, internal_type: Union[DataType, str], physical_type: Union[DataType, str],
-                 category: str):
-        self.internal_type = DataType(internal_type)
-        self.physical_type = DataType(physical_type)
-        self.category = category
+@dataclass
+class CompuMethod(abc.ABC):
+    internal_type: DataType
+    physical_type: DataType
+
+    @property
+    @abc.abstractmethod
+    def category(self) -> CompuMethodCategory:
+        pass
 
     def convert_physical_to_internal(self, physical_value):
         raise NotImplementedError()
@@ -26,9 +38,3 @@ class CompuMethod:
 
     def get_valid_physical_values(self):
         return None
-
-    def __str__(self) -> str:
-        return f"CompuMethod(category={self.category}"
-
-    def __repr__(self) -> str:
-        return str(self)

--- a/odxtools/compumethods/compurationalcoeffs.py
+++ b/odxtools/compumethods/compurationalcoeffs.py
@@ -1,7 +1,25 @@
 # SPDX-License-Identifier: MIT
-from typing import List, NamedTuple
+from dataclasses import dataclass
+from typing import List
+from xml.etree import ElementTree
+
+from ..exceptions import odxrequire
+from ..odxlink import OdxDocFragment
 
 
-class CompuRationalCoeffs(NamedTuple):
+@dataclass
+class CompuRationalCoeffs:
     numerators: List[float]
     denominators: List[float]
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "CompuRationalCoeffs":
+        numerators = [
+            float(odxrequire(elem.text)) for elem in et_element.iterfind("COMPU-NUMERATOR/V")
+        ]
+        denominators = [
+            float(odxrequire(elem.text)) for elem in et_element.iterfind("COMPU-DENOMINATOR/V")
+        ]
+
+        return CompuRationalCoeffs(numerators=numerators, denominators=denominators)

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: MIT
+from dataclasses import dataclass
 from typing import Union
 
 from ..odxtypes import DataType
-from .compumethod import CompuMethod
+from .compumethod import CompuMethod, CompuMethodCategory
 
 
+@dataclass
 class IdenticalCompuMethod(CompuMethod):
 
-    def __init__(self, *, internal_type: Union[DataType, str], physical_type: Union[DataType, str]):
-        super().__init__(
-            internal_type=internal_type, physical_type=physical_type, category="IDENTICAL")
+    @property
+    def category(self) -> CompuMethodCategory:
+        return "IDENTICAL"
 
     def convert_physical_to_internal(self, physical_value):
         return physical_value

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+from dataclasses import dataclass
 from enum import Enum
 from typing import NamedTuple, Optional, Union
 from xml.etree import ElementTree
@@ -13,12 +14,17 @@ class IntervalType(Enum):
     INFINITE = "INFINITE"
 
 
-class Limit(NamedTuple):
+@dataclass
+class Limit:
     value: Union[str, int, float, bytes]
     interval_type: IntervalType = IntervalType.CLOSED
 
+    def __post_init__(self) -> None:
+        if self.interval_type == IntervalType.INFINITE:
+            self.value = 0
+
     @staticmethod
-    def from_et(et_element: Optional[ElementTree.Element],
+    def from_et(et_element: Optional[ElementTree.Element], *,
                 internal_type: DataType) -> Optional["Limit"]:
 
         if et_element is None:

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: MIT
+from dataclasses import dataclass
 from typing import Optional, Union
 
 from ..exceptions import odxassert
 from ..odxtypes import DataType
-from .compumethod import CompuMethod
+from .compumethod import CompuMethod, CompuMethodCategory
 from .limit import IntervalType, Limit
 
 
+@dataclass
 class LinearCompuMethod(CompuMethod):
     """Represents the decoding function d(y) = (offset + factor * y) / denominator
     where d(y) is the physical value and y is the internal value.
@@ -55,37 +57,20 @@ class LinearCompuMethod(CompuMethod):
     For example, limits given by the bit length are not considered in the compu method.)
     """
 
-    def __init__(
-        self,
-        *,
-        offset: float,
-        factor: float,
-        denominator: float,
-        internal_type: Union[DataType, str],
-        physical_type: Union[DataType, str],
-        internal_lower_limit: Optional[Limit],
-        internal_upper_limit: Optional[Limit],
-    ):
-        super().__init__(
-            internal_type=internal_type, physical_type=physical_type, category="LINEAR")
-        self.offset = offset
-        self.factor = factor
-        self.denominator = denominator
+    offset: float
+    factor: float
+    denominator: float
+    internal_lower_limit: Limit
+    internal_upper_limit: Limit
 
-        self.internal_lower_limit = internal_lower_limit
-        if (internal_lower_limit is None or
-                internal_lower_limit.interval_type == IntervalType.INFINITE):
-            self.internal_lower_limit = Limit(float("-inf"), IntervalType.INFINITE)
-
-        self.internal_upper_limit = internal_upper_limit
-        if (internal_upper_limit is None or
-                internal_upper_limit.interval_type == IntervalType.INFINITE):
-            self.internal_upper_limit = Limit(float("inf"), IntervalType.INFINITE)
-
-        odxassert(self.internal_lower_limit is not None and self.internal_upper_limit is not None)
-        odxassert(denominator > 0 and isinstance(denominator, (int, float)))
+    def __post_init__(self) -> None:
+        odxassert(self.denominator > 0)
 
         self.__compute_physical_limits()
+
+    @property
+    def category(self) -> CompuMethodCategory:
+        return "LINEAR"
 
     @property
     def physical_lower_limit(self):

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -1,22 +1,20 @@
 # SPDX-License-Identifier: MIT
-from typing import Iterable
+from dataclasses import dataclass
+from typing import List
 
 from ..exceptions import odxassert
 from ..globals import logger
-from .compumethod import CompuMethod
+from .compumethod import CompuMethod, CompuMethodCategory
 from .linearcompumethod import LinearCompuMethod
 
 
+@dataclass
 class ScaleLinearCompuMethod(CompuMethod):
+    linear_methods: List[LinearCompuMethod]
 
-    def __init__(self, *, linear_methods: Iterable[LinearCompuMethod]):
-        super().__init__(
-            internal_type=list(linear_methods)[0].internal_type,
-            physical_type=list(linear_methods)[0].physical_type,
-            category="SCALE-LINEAR",
-        )
-        self.linear_methods = list(linear_methods)
-        logger.debug("Created scale linear compu method!")
+    @property
+    def category(self) -> CompuMethodCategory:
+        return "SCALE-LINEAR"
 
     def convert_physical_to_internal(self, physical_value):
         odxassert(

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: MIT
+from dataclasses import dataclass
 from typing import List, Tuple, Union
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
 from ..globals import logger
 from ..odxtypes import DataType
-from .compumethod import CompuMethod
+from .compumethod import CompuMethod, CompuMethodCategory
 from .limit import IntervalType, Limit
 
 
+@dataclass
 class TabIntpCompuMethod(CompuMethod):
     """
     A compu method of type Tab Interpolated is used for linear interpolation.
@@ -64,25 +66,18 @@ class TabIntpCompuMethod(CompuMethod):
 
     """
 
-    def __init__(
-        self,
-        *,
-        internal_type: Union[DataType, str],
-        physical_type: Union[DataType, str],
-        internal_points: List[Union[float, int]],
-        physical_points: List[Union[float, int]],
-    ):
-        super().__init__(
-            internal_type=internal_type, physical_type=physical_type, category="TAB-INTP")
+    internal_points: List[Union[float, int]]
+    physical_points: List[Union[float, int]]
 
-        self.internal_points = internal_points
-        self.physical_points = physical_points
+    def __post_init__(self) -> None:
+        self._physical_lower_limit = Limit(min(self.physical_points), IntervalType.CLOSED)
+        self._physical_upper_limit = Limit(max(self.physical_points), IntervalType.CLOSED)
 
-        self._physical_lower_limit = Limit(min(physical_points), IntervalType.CLOSED)
-        self._physical_upper_limit = Limit(max(physical_points), IntervalType.CLOSED)
-
-        logger.debug("Created compu method of type tab interpolated !")
         self._assert_validity()
+
+    @property
+    def category(self) -> CompuMethodCategory:
+        return "TAB-INTP"
 
     @property
     def physical_lower_limit(self) -> Limit:

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -1,26 +1,29 @@
 # SPDX-License-Identifier: MIT
+from dataclasses import dataclass
 from typing import List
 
 from ..exceptions import DecodeError, odxassert
 from ..odxtypes import DataType
-from .compumethod import CompuMethod
+from .compumethod import CompuMethod, CompuMethodCategory
 from .compuscale import CompuScale
 
 
+@dataclass
 class TexttableCompuMethod(CompuMethod):
 
-    def __init__(self, *, internal_to_phys: List[CompuScale], internal_type):
-        super().__init__(
-            internal_type=internal_type,
-            physical_type=DataType.A_UNICODE2STRING,
-            category="TEXTTABLE",
-        )
-        self.internal_to_phys = internal_to_phys
+    internal_to_phys: List[CompuScale]
 
+    def __post_init__(self) -> None:
+        odxassert(self.physical_type == DataType.A_UNICODE2STRING,
+                  "TEXTTABLE must have A_UNICODE2STRING as its physical datatype.")
         odxassert(
             all(scale.lower_limit is not None or scale.upper_limit is not None
                 for scale in self.internal_to_phys),
             "Text table compu method doesn't have expected format!")
+
+    @property
+    def category(self) -> CompuMethodCategory:
+        return "TEXTTABLE"
 
     def convert_physical_to_internal(self, physical_value):
         scale = next(

--- a/odxtools/parameterinfo.py
+++ b/odxtools/parameterinfo.py
@@ -58,7 +58,7 @@ def parameter_info(param_list: Iterable[Union[Parameter, EndOfPduField]]) -> str
         if isinstance(cm, TexttableCompuMethod):
             result += f": enum; choices:\n"
             for scale in cm.internal_to_phys:
-                result += f"  '{scale.compu_const}'\n"
+                result += f"  '{str(scale.compu_const)}'\n"
 
         elif isinstance(cm, IdenticalCompuMethod):
             bdt = dop.physical_type.base_data_type

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -46,8 +46,8 @@ class TestLinearCompuMethod(unittest.TestCase):
             denominator=3600,
             internal_type=DataType.A_INT32,
             physical_type=DataType.A_INT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
 
         self.linear_compumethod_odx = f"""
@@ -107,8 +107,8 @@ class TestLinearCompuMethod(unittest.TestCase):
             denominator=3600,
             internal_type=DataType.A_INT32,
             physical_type=DataType.A_INT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
         self.assertEqual(compu_method.convert_physical_to_internal(2), 7200)
 
@@ -121,8 +121,8 @@ class TestLinearCompuMethod(unittest.TestCase):
             denominator=1,
             internal_type=DataType.A_INT32,
             physical_type=DataType.A_INT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
 
         self.assertEqual(compu_method.convert_internal_to_physical(4), 13)
@@ -140,8 +140,8 @@ class TestLinearCompuMethod(unittest.TestCase):
             denominator=1,
             internal_type=DataType.A_INT32,
             physical_type=DataType.A_FLOAT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
         self.assertTrue(compu_method.is_valid_internal_value(123))
         self.assertFalse(compu_method.is_valid_internal_value("123"))
@@ -158,8 +158,8 @@ class TestLinearCompuMethod(unittest.TestCase):
             denominator=1,
             internal_type=DataType.A_FLOAT32,
             physical_type=DataType.A_INT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
         self.assertTrue(compu_method.is_valid_internal_value(1.2345))
         self.assertTrue(compu_method.is_valid_internal_value(123))
@@ -176,8 +176,8 @@ class TestLinearCompuMethod(unittest.TestCase):
             denominator=1,
             internal_type=DataType.A_ASCIISTRING,
             physical_type=DataType.A_UNICODE2STRING,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
         self.assertTrue(compu_method.is_valid_internal_value("123"))
         self.assertFalse(compu_method.is_valid_internal_value(123))

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -2,6 +2,7 @@
 import unittest
 
 from odxtools.compumethods.identicalcompumethod import IdenticalCompuMethod
+from odxtools.compumethods.limit import IntervalType, Limit
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
@@ -837,8 +838,8 @@ class TestDecoding(unittest.TestCase):
             denominator=1,
             internal_type=DataType.A_INT32,
             physical_type=DataType.A_INT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
         diag_coded_type = StandardLengthType(
             base_data_type=DataType.A_UINT32,
@@ -1404,8 +1405,8 @@ class TestDecodingAndEncoding(unittest.TestCase):
                 denominator=1,
                 internal_type=DataType.A_UINT32,
                 physical_type=DataType.A_INT32,
-                internal_lower_limit=None,
-                internal_upper_limit=None,
+                internal_lower_limit=Limit(0, IntervalType.INFINITE),
+                internal_upper_limit=Limit(0, IntervalType.INFINITE),
             ),
             unit_ref=None,
             sdgs=[],

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 
 import odxtools.uds as uds
 from odxtools.compumethods.identicalcompumethod import IdenticalCompuMethod
+from odxtools.compumethods.limit import IntervalType, Limit
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.createanydiagcodedtype import create_any_diag_coded_type_from_et
 from odxtools.dataobjectproperty import DataObjectProperty
@@ -436,8 +437,8 @@ class TestParamLengthInfoType(unittest.TestCase):
                     denominator=1,
                     internal_type=DataType.A_UINT32,
                     physical_type=DataType.A_UINT32,
-                    internal_lower_limit=None,
-                    internal_upper_limit=None,
+                    internal_lower_limit=Limit(0, IntervalType.INFINITE),
+                    internal_upper_limit=Limit(0, IntervalType.INFINITE),
                 ),
         }
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 import unittest
 
+from odxtools.compumethods.limit import IntervalType, Limit
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.exceptions import EncodeError
@@ -122,8 +123,8 @@ class TestEncodeRequest(unittest.TestCase):
             denominator=1,
             internal_type=DataType.A_UINT32,
             physical_type=DataType.A_UINT32,
-            internal_lower_limit=None,
-            internal_upper_limit=None,
+            internal_lower_limit=Limit(0, IntervalType.INFINITE),
+            internal_upper_limit=Limit(0, IntervalType.INFINITE),
         )
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.id", doc_frags),

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -11,7 +11,7 @@ import odxtools
 from odxtools.additionalaudience import AdditionalAudience
 from odxtools.audience import Audience
 from odxtools.compumethods.compuscale import CompuScale
-from odxtools.compumethods.limit import Limit
+from odxtools.compumethods.limit import IntervalType, Limit
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.compumethods.texttablecompumethod import TexttableCompuMethod
 from odxtools.dataobjectproperty import DataObjectProperty
@@ -85,9 +85,24 @@ class TestSingleEcuJob(unittest.TestCase):
                 physical_type=PhysicalType(
                     DataType.A_UNICODE2STRING, display_radix=None, precision=None),
                 compu_method=TexttableCompuMethod(
+                    physical_type=DataType.A_UNICODE2STRING,
                     internal_to_phys=[
-                        CompuScale("yes", lower_limit=Limit(0), compu_const="Yes!"),
-                        CompuScale("no", lower_limit=Limit(1), compu_const="No!"),
+                        CompuScale(
+                            "yes",
+                            lower_limit=Limit(0),
+                            compu_const="Yes!",
+                            description=None,
+                            compu_inverse_value=None,
+                            upper_limit=None,
+                            compu_rational_coeffs=None),
+                        CompuScale(
+                            "no",
+                            lower_limit=Limit(1),
+                            compu_const="No!",
+                            description=None,
+                            compu_inverse_value=None,
+                            upper_limit=None,
+                            compu_rational_coeffs=None),
                     ],
                     internal_type=DataType.A_UINT32,
                 ),
@@ -116,8 +131,8 @@ class TestSingleEcuJob(unittest.TestCase):
                     denominator=1,
                     internal_type=DataType.A_UINT32,
                     physical_type=DataType.A_UINT32,
-                    internal_lower_limit=None,
-                    internal_upper_limit=None,
+                    internal_lower_limit=Limit(0, IntervalType.INFINITE),
+                    internal_upper_limit=Limit(0, IntervalType.INFINITE),
                 ),
                 unit_ref=None,
                 sdgs=[],
@@ -144,8 +159,8 @@ class TestSingleEcuJob(unittest.TestCase):
                     denominator=1,
                     internal_type=DataType.A_UINT32,
                     physical_type=DataType.A_UINT32,
-                    internal_lower_limit=None,
-                    internal_upper_limit=None,
+                    internal_lower_limit=Limit(0, IntervalType.INFINITE),
+                    internal_upper_limit=Limit(0, IntervalType.INFINITE),
                 ),
                 unit_ref=None,
                 sdgs=[],


### PR DESCRIPTION
The next part of the quest for the database containing mostly dataclasses. This PR also contains a few drive-by fixes, in particular that we now have a proper class for COMPU-RATIONAL-COEFFS, the CompuScale and Limit classes no longer uses default values, and that CompuScale has a `.from_et()` method.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)