### PR TITLE
remove the `ProgCodeSyntax` enum class

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -51,7 +51,7 @@ from odxtools.parameters.valueparameter import ValueParameter
 from odxtools.parentref import ParentRef
 from odxtools.physicaldimension import PhysicalDimension
 from odxtools.physicaltype import PhysicalType
-from odxtools.progcode import ProgCode, ProgCodeSyntax
+from odxtools.progcode import ProgCode
 from odxtools.relateddoc import RelatedDoc
 from odxtools.request import Request
 from odxtools.response import Response
@@ -1787,7 +1787,7 @@ somersault_single_ecu_jobs = {
                 ProgCode(
                     code_file="jobs.jar",
                     encryption=None,
-                    syntax=ProgCodeSyntax.JAR,
+                    syntax="JAR",
                     entrypoint="com.supervisor.jobs.CompulsoryProgram",
                     revision="1.23.4",
                     library_refs=[],

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -36,7 +36,7 @@ class TexttableCompuMethod(CompuMethod):
         return scales
 
     def convert_physical_to_internal(self, physical_value):
-        scale: CompuScale = next(
+        scale = next(
             filter(lambda scale: scale.compu_const == physical_value, self._get_scales()), None)
         if scale is not None:
             res = (

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -36,7 +36,7 @@ class TexttableCompuMethod(CompuMethod):
         return scales
 
     def convert_physical_to_internal(self, physical_value):
-        scale = next(
+        scale: CompuScale = next(
             filter(lambda scale: scale.compu_const == physical_value, self._get_scales()), None)
         if scale is not None:
             res = (

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -11,17 +11,11 @@ if TYPE_CHECKING:
     from .diaglayer import DiagLayer
 
 
-class ProgCodeSyntax(Enum):
-    JAVA = "JAVA"
-    CLASS = "CLASS"
-    JAR = "JAR"
-
-
 @dataclass
 class ProgCode:
     """A reference to code that is executed by a single ECU job"""
     code_file: str
-    syntax: ProgCodeSyntax
+    syntax: str
     revision: str
     encryption: Optional[str]
     entrypoint: Optional[str]
@@ -32,14 +26,7 @@ class ProgCode:
         code_file = odxrequire(et_element.findtext("CODE-FILE"))
 
         encryption = et_element.findtext("ENCRYPTION")
-
-        syntax_str = odxrequire(et_element.findtext("SYNTAX"))
-        try:
-            syntax = ProgCodeSyntax(syntax_str)
-        except ValueError:
-            syntax = cast(ProgCodeSyntax, None)
-            odxraise(f"Encountered unknown program code syntax '{syntax_str}'")
-
+        syntax = odxrequire(et_element.findtext("SYNTAX"))
         revision = odxrequire(et_element.findtext("REVISION"))
         entrypoint = et_element.findtext("ENTRYPOINT")
 

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -63,7 +63,7 @@
 {%- if prog.encryption %}
  <ENCRYPTION>{{prog.encryption}}</ENCRYPTION>
 {%- endif %}
- <SYNTAX>{{prog.syntax.value}}</SYNTAX>
+ <SYNTAX>{{prog.syntax}}</SYNTAX>
  <REVISION>{{prog.revision}}</REVISION>
 {%- if prog.entrypoint %}
  <ENTRYPOINT>{{prog.entrypoint}}</ENTRYPOINT>

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -26,7 +26,7 @@ from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLink
 from odxtools.odxtypes import DataType
 from odxtools.outputparam import OutputParam
 from odxtools.physicaltype import PhysicalType
-from odxtools.progcode import ProgCode, ProgCodeSyntax
+from odxtools.progcode import ProgCode
 from odxtools.singleecujob import SingleEcuJob
 from odxtools.standardlengthtype import StandardLengthType
 from odxtools.write_pdx_file import jinja2_odxraise_helper, make_bool_xml_attrib, make_xml_attrib
@@ -221,7 +221,7 @@ class TestSingleEcuJob(unittest.TestCase):
                 ProgCode(
                     code_file="abc.jar",
                     encryption="RSA512",
-                    syntax=ProgCodeSyntax.JAR,
+                    syntax="JAR",
                     revision="0.12.34",
                     entrypoint="CalledClass",
                     library_refs=[OdxLinkRef("my.favourite.lib", doc_frags)],
@@ -251,7 +251,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     <PROG-CODE>
                         <CODE-FILE>{self.singleecujob_object.prog_codes[0].code_file}</CODE-FILE>
                         <ENCRYPTION>{self.singleecujob_object.prog_codes[0].encryption}</ENCRYPTION>
-                        <SYNTAX>{self.singleecujob_object.prog_codes[0].syntax.value}</SYNTAX>
+                        <SYNTAX>{self.singleecujob_object.prog_codes[0].syntax}</SYNTAX>
                         <REVISION>{self.singleecujob_object.prog_codes[0].revision}</REVISION>
                         <ENTRYPOINT>{self.singleecujob_object.prog_codes[0].entrypoint}</ENTRYPOINT>
                         <LIBRARY-REFS>


### PR DESCRIPTION
Instead, make this a string because the SYNTAX subtag of SINGLE-ECU-JOB is specified to be a plain string in the ODX specification. It seems like we wanted to be more strict on our own files and tried to constrain the possible values for this. This was implemented using a string literal (which is like a type-checking only enum, i.e., it does not check if the value specified is valid if can only be determined at runtime). After changing this to an `Enum` class in #172, it got some (incorrect) teeth which bit users that used non-Java single ECU jobs.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)