### PR TITLE
Don't assert about short names starting with digits

### DIFF
--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -4,7 +4,7 @@ from keyword import iskeyword
 from typing import (Callable, Collection, Generic, Iterable, List, Optional, Protocol, Tuple,
                     TypeVar, Union, cast, overload, runtime_checkable)
 
-from .exceptions import odxassert, odxraise
+from .exceptions import odxraise
 
 
 @runtime_checkable

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -168,7 +168,7 @@ def short_name_as_key(obj: OdxNamed) -> str:
 
     Although short names are almost identical to python identifiers,
     their first character is allowed to be a number. This method
-    prepends an underscore to such such shortnames.
+    prepends an underscore to such shortnames.
     """
     if not isinstance(obj, OdxNamed):
         odxraise()
@@ -176,20 +176,11 @@ def short_name_as_key(obj: OdxNamed) -> str:
     if not isinstance(sn, str):
         odxraise()
 
-    odxassert(
-        sn.isidentifier(),
-        message=("For NamedItemList objects to work properly, "
-                 "all item names must be valid python identifiers."
-                 f"Encountered name '{sn}' which is not an identifier!"),
-    )
-
-    if sn[0].isdigit():
+    # make sure that the name of the item in question:
+    # * is not a python keyword (this would lead to syntax errors)
+    # * does not starts with a digit
+    if sn[0].isdigit() or iskeyword(sn):
         return f"_{sn}"
-
-    # make sure that the name of the item in question is not a
-    # python keyword (this would lead to syntax errors)
-    if iskeyword(sn):
-        return f"{sn}_"
 
     return sn
 

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -123,8 +123,8 @@ class TestNamedItemList(unittest.TestCase):
         # add a keyword identifier
         foo.append(X("as", 3))
         self.assertEqual(foo[3], X("as", 3))
-        self.assertEqual(foo["as_"], X("as", 3))
-        self.assertEqual(foo.as_, X("as", 3))  # type: ignore[attr-defined]
+        self.assertEqual(foo["_as"], X("as", 3))
+        self.assertEqual(foo._as, X("as", 3))  # type: ignore[attr-defined]
 
         # add an object which's name conflicts with a method of the class
         foo.append(X("sort", 4))
@@ -147,7 +147,7 @@ class TestNamedItemList(unittest.TestCase):
         self.assertEqual(i, len(foo) - 1)
 
         # make sure that the keys(), values() and items() exist
-        self.assertEqual(set(foo.keys()), {"hello", "world", "hello_2", "as_", "sort_2"})
+        self.assertEqual(set(foo.keys()), {"hello", "world", "hello_2", "_as", "sort_2"})
         self.assertEqual(len(foo.items()), len(foo))
         self.assertEqual(len(foo.values()), len(foo))
 


### PR DESCRIPTION
OEM files are using short names that start with digit

The generates hundreds of errors/warnings for something that is not against ODX standard

The standard allows for short names to start with digits, so making an assert for it don't make much sense

Users who need to access an item that is a keyword or start with digit will get a syntax error anyway and their code won't run, so the extra assert is pointless.