### PR TITLE
rework .is_required and .is_optional methods of parameters

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -77,7 +77,7 @@ class BasicStructure(DopBase):
     def required_parameters(self) -> List[Parameter]:
         """Return the list of parameters which are required for
         encoding the structure."""
-        return [p for p in self.parameters if p.is_required()]
+        return [p for p in self.parameters if p.is_required]
 
     @property
     def free_parameters(self) -> List[Union[Parameter, "EndOfPduField"]]:  # type: ignore
@@ -96,7 +96,7 @@ class BasicStructure(DopBase):
             if isinstance(param, EndOfPduField):
                 result.append(param)
                 continue
-            elif not param.is_required():
+            elif not param.is_required:
                 continue
             # The user cannot specify MatchingRequestParameters freely!
             elif isinstance(param, MatchingRequestParameter):

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -47,10 +47,12 @@ class CodedConstParameter(Parameter):
     def internal_data_type(self) -> DataType:
         return self.diag_coded_type.base_data_type
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         return False
 
-    def is_optional(self):
+    @property
+    def is_settable(self) -> bool:
         return False
 
     def get_coded_value(self):

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -11,11 +11,13 @@ class DynamicParameter(Parameter):
     def parameter_type(self) -> ParameterType:
         return "DYNAMIC"
 
-    def is_required(self):
-        raise NotImplementedError("DynamicParameter.is_required is not implemented yet.")
+    @property
+    def is_required(self) -> bool:
+        raise NotImplementedError(".is_required for a DynamicParameter")
 
-    def is_optional(self):
-        raise NotImplementedError("DynamicParameter.is_optional is not implemented yet.")
+    @property
+    def is_settable(self) -> bool:
+        raise NotImplementedError(".is_settable for a DynamicParameter")
 
     def get_coded_value(self):
         raise NotImplementedError("Encoding a DynamicParameter is not implemented yet.")

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -43,10 +43,15 @@ class LengthKeyParameter(ParameterWithDOP):
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         super()._resolve_snrefs(diag_layer)
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         return False
 
-    def is_optional(self):
+    @property
+    def is_settable(self) -> bool:
+        # length keys can be explicitly set, but they do not need to
+        # be because they can be implicitly determined by the length
+        # of the corresponding field
         return True
 
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -20,10 +20,12 @@ class MatchingRequestParameter(Parameter):
     def bit_length(self):
         return 8 * self.byte_length
 
-    def is_required(self):
-        return True
+    @property
+    def is_required(self) -> bool:
+        return False
 
-    def is_optional(self):
+    @property
+    def is_settable(self) -> bool:
         return False
 
     def get_coded_value(self, request_value=None):

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -55,10 +55,12 @@ class NrcConstParameter(Parameter):
     def internal_data_type(self) -> DataType:
         return self.diag_coded_type.base_data_type
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         return False
 
-    def is_optional(self):
+    @property
+    def is_settable(self) -> bool:
         return False
 
     def get_coded_value(self):

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -62,13 +62,28 @@ class Parameter(NamedElement, abc.ABC):
     def bit_length(self) -> Optional[int]:
         return None
 
-    @abc.abstractmethod
-    def is_required(self):
-        pass
+    @property
+    def is_required(self) -> bool:
+        """True if the parameter must be explicitly specified when
+        encoding a message.
 
-    @abc.abstractmethod
-    def is_optional(self):
-        pass
+        Required parameters are always settable, and parameters which
+        have a default value are settable but not required to be
+        specified.
+
+        """
+        raise NotImplemented
+
+    @property
+    def is_settable(self) -> bool:
+        """True if the parameter can be specified when encoding a
+        message.
+
+        Required parameters are always settable, and parameters which
+        have a default value are settable but not required to be
+        specified.
+        """
+        raise NotImplemented
 
     @abc.abstractmethod
     def get_coded_value(self):

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -72,7 +72,7 @@ class Parameter(NamedElement, abc.ABC):
         specified.
 
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def is_settable(self) -> bool:
@@ -83,7 +83,7 @@ class Parameter(NamedElement, abc.ABC):
         have a default value are settable but not required to be
         specified.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_coded_value(self):

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -44,10 +44,12 @@ class PhysicalConstantParameter(ParameterWithDOP):
     def physical_constant_value(self) -> ParameterValue:
         return self._physical_constant_value
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         return False
 
-    def is_optional(self):
+    @property
+    def is_settable(self) -> bool:
         return False
 
     def get_coded_value(self):

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -15,10 +15,12 @@ class ReservedParameter(Parameter):
     def parameter_type(self) -> ParameterType:
         return "RESERVED"
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         return False
 
-    def is_optional(self):
+    @property
+    def is_settable(self) -> bool:
         return False
 
     @property

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -13,11 +13,13 @@ class SystemParameter(ParameterWithDOP):
     def parameter_type(self) -> ParameterType:
         return "SYSTEM"
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         raise NotImplementedError("SystemParameter.is_required is not implemented yet.")
 
-    def is_optional(self):
-        raise NotImplementedError("SystemParameter.is_optional is not implemented yet.")
+    @property
+    def is_settable(self) -> bool:
+        raise NotImplementedError("SystemParameter.is_settable is not implemented yet.")
 
     def get_coded_value(self):
         raise NotImplementedError("Encoding a SystemParameter is not implemented yet.")

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -14,11 +14,13 @@ class TableEntryParameter(Parameter):
     def parameter_type(self) -> ParameterType:
         return "TABLE-ENTRY"
 
-    def is_required(self):
+    @property
+    def is_required(self) -> bool:
         raise NotImplementedError("TableKeyParameter.is_required is not implemented yet.")
 
-    def is_optional(self):
-        raise NotImplementedError("TableKeyParameter.is_optional is not implemented yet.")
+    @property
+    def is_settable(self) -> bool:
+        raise NotImplementedError("TableKeyParameter.is_settable is not implemented yet.")
 
     def get_coded_value(self):
         raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -84,11 +84,15 @@ class TableKeyParameter(Parameter):
     def table_row(self) -> Optional["TableRow"]:
         return self._table_row
 
-    def is_required(self):
-        return self._table_row is None
+    @property
+    def is_required(self) -> bool:
+        # TABLE-KEY parameters can be implicitly determined from the
+        # corresponding TABLE-STRUCT
+        return False
 
-    def is_optional(self):
-        return not self.is_required()
+    @property
+    def is_settable(self) -> bool:
+        return True
 
     def get_coded_value(self, physical_value=None) -> Any:
         key_dop = self.table.key_dop

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -50,11 +50,13 @@ class TableStructParameter(Parameter):
     def table_key(self) -> TableKeyParameter:
         return self._table_key
 
+    @property
     def is_required(self):
         return True
 
-    def is_optional(self):
-        return False
+    @property
+    def is_settable(self):
+        return True
 
     def get_coded_value(self, physical_value=None):
         raise EncodeError("TableStructParameters cannot be converted to "

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -47,11 +47,13 @@ class ValueParameter(ParameterWithDOP):
     def physical_default_value(self) -> Optional[AtomicOdxType]:
         return self._physical_default_value
 
+    @property
     def is_required(self) -> bool:
-        return self.physical_default_value is None
+        return self._physical_default_value is None
 
-    def is_optional(self) -> bool:
-        return not self.is_required()
+    @property
+    def is_settable(self) -> bool:
+        return True
 
     def get_coded_value(self, physical_value: Optional[AtomicOdxType] = None):
         if physical_value is not None:

--- a/tests/test_somersault.py
+++ b/tests/test_somersault.py
@@ -144,7 +144,7 @@ class TestDatabase(unittest.TestCase):
 
         pr = service.positive_responses.grudging_forward
         self.assertEqual([x.short_name for x in pr.parameters], ["sid", "num_flips_done"])
-        self.assertEqual([x.short_name for x in pr.required_parameters], ["num_flips_done"])
+        self.assertEqual([x.short_name for x in pr.required_parameters], [])
         self.assertEqual(pr.bit_length, 16)
 
         nr = service.negative_responses.flips_not_done


### PR DESCRIPTION
`Parameter.is_optional()` and `Parameter.is_required()` were quite confusing as it can be assumed that one is just the negation of the other. We thus rename `.is_optional` to `.is_settable` to more clearly express that this indicates that a parameter is user-definable. (In the process, a few instances in the `browse` tool where this seems to have been mixed up are fixed.) While at it, make these functions properties so that they do not need to be called anymore...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)