### PR TITLE
Add type annotations, part 1

### DIFF
--- a/examples/isotp_send.py
+++ b/examples/isotp_send.py
@@ -25,7 +25,7 @@ tx_id = int(sys.argv[3], 0)
 payload = sys.argv[4].encode()
 
 
-def isotp_error_handler(error):
+def isotp_error_handler(error: str) -> None:
     print(f"An isotp error occoured: {error}")
 
 

--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -4,8 +4,7 @@ import logging
 import sys
 from typing import Dict, List, Union
 
-import PyInquirer
-import PyInquirer.prompt as PI_promt
+import PyInquirer.prompt as PI_prompt
 
 from ..database import Database
 from ..diaglayer import DiagLayer
@@ -80,7 +79,7 @@ def prompt_single_parameter_value(parameter):
             "message": f"Value for parameter '{parameter.short_name}'",
             "choices": parameter.get_valid_physical_values(),
         }]
-    answer = PI_promt.prompt(param_prompt)
+    answer = PI_prompt.prompt(param_prompt)
     if answer.get(parameter.short_name) == "" and parameter.is_optional:
         return None
     elif parameter.physical_type.base_data_type is not None:
@@ -117,7 +116,7 @@ def encode_message_interactively(sub_service, ask_user_confirmation=False):
                 "message": f"Do you want to encode a message? [y/n]",
                 "choices": ["yes", "no"],
             }]
-            answer = PI_promt.prompt(encode_message_prompt)
+            answer = PI_prompt.prompt(encode_message_prompt)
             if answer.get("yes_no_prompt") == "no":
                 return
 
@@ -132,7 +131,7 @@ def encode_message_interactively(sub_service, ask_user_confirmation=False):
                 "filter":
                     lambda input: _convert_string_to_bytes(input),
             }]
-            answer = PI_promt.prompt(answered_request_prompt)
+            answer = PI_prompt.prompt(answered_request_prompt)
             answered_request = answer.get("request")
             print(f"Input interpretation as list: {list(answered_request)}")
 
@@ -244,7 +243,7 @@ def browse(odxdb: Database):
             "message": "Select a Variant.",
             "choices": list(dl_names) + ["[exit]"],
         }]
-        answer = PI_promt.prompt(selection)
+        answer = PI_prompt.prompt(selection)
         if answer.get("variant") == "[exit]":
             return
 
@@ -280,7 +279,7 @@ def browse(odxdb: Database):
                     f"The variant {variant.short_name} offers the following services. Select one!",
                 "choices": [s.short_name for s in services] + ["[back]"],
             }]
-            answer = PI_promt.prompt(selection)
+            answer = PI_prompt.prompt(selection)
             if answer.get("service") == "[back]":
                 break
 
@@ -314,7 +313,7 @@ def browse(odxdb: Database):
                     "short": f"Negative response: {nr.short_name}",
                 } for nr in service.negative_responses] + ["[back]"],  # type: ignore
             }]
-            answer = PI_promt.prompt(selection)
+            answer = PI_prompt.prompt(selection)
             if answer.get("message_type") == "[back]":
                 continue
 

--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import sys
-from typing import List
 
 
 class DummyTool:

--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import sys
+from typing import List
 
 
 class DummyTool:
@@ -14,11 +15,11 @@ class DummyTool:
     should bail out.
     """
 
-    def __init__(self, tool_name, error):
+    def __init__(self, tool_name: str, error: Exception):
         self._odxtools_tool_name_ = tool_name
         self._error = error
 
-    def add_subparser(self, subparser_list):
+    def add_subparser(self, subparser_list: argparse._SubParsersAction) -> None:
         subparser_list.add_parser(
             self._odxtools_tool_name_,
             description=f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}",
@@ -26,7 +27,7 @@ class DummyTool:
             formatter_class=argparse.RawTextHelpFormatter,
         )
 
-    def run(self, args: argparse.Namespace):
+    def run(self, args: argparse.Namespace) -> None:
         print(
             f"Error: Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}",
             file=sys.stderr,

--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -19,7 +19,7 @@ class DummyTool:
         self._odxtools_tool_name_ = tool_name
         self._error = error
 
-    def add_subparser(self, subparser_list: argparse._SubParsersAction) -> None:
+    def add_subparser(self, subparser_list: "argparse._SubParsersAction") -> None:
         subparser_list.add_parser(
             self._odxtools_tool_name_,
             description=f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}",

--- a/odxtools/cli/main.py
+++ b/odxtools/cli/main.py
@@ -16,7 +16,7 @@ for tool_name in ["list", "browse", "snoop", "find"]:
         tool_modules.append(DummyTool(tool_name, e))
 
 
-def start_cli():
+def start_cli() -> None:
     argparser = argparse.ArgumentParser(
         description="\n".join([
             "Utilities to interact with automotive diagnostic descriptions based on the ODX standard.",

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional, Union
+from typing import List, Optional
 from xml.etree import ElementTree
 
-from ..exceptions import odxrequire
 from ..odxlink import OdxDocFragment
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import create_description_from_et

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -7,7 +7,6 @@ from ..exceptions import OdxWarning, odxassert, odxraise, odxrequire
 from ..globals import logger
 from ..odxlink import OdxDocFragment
 from ..odxtypes import DataType
-from ..utils import create_description_from_et
 from .compumethod import CompuMethod
 from .compuscale import CompuScale
 from .identicalcompumethod import IdenticalCompuMethod

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Union
 
-from ..odxtypes import DataType
 from .compumethod import CompuMethod, CompuMethodCategory
 
 

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from enum import Enum
-from typing import NamedTuple, Optional, Union
+from typing import Optional, Union
 from xml.etree import ElementTree
 
 from ..exceptions import odxassert, odxraise, odxrequire

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Union
 
 from ..exceptions import odxassert
 from ..odxtypes import DataType

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import List
 
 from ..exceptions import odxassert
-from ..globals import logger
 from .compumethod import CompuMethod, CompuMethodCategory
 from .linearcompumethod import LinearCompuMethod
 

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import List, Tuple, Union
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..globals import logger
 from ..odxtypes import DataType
 from .compumethod import CompuMethod, CompuMethodCategory
 from .limit import IntervalType, Limit

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -23,7 +23,7 @@ class MatchingParameter:
     diag_comm_snref: str
     out_param_if: str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         odxassert(is_short_name(self.diag_comm_snref))
         odxassert(is_short_name_path(self.out_param_if))
 

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -12,10 +12,14 @@ class OdxDocFragment:
     doc_name: str
     doc_type: Optional[str]
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if other is None:
-            # if the other document fragment is not specified, we treat it as a wildcard...
+            # if the other document fragment is not specified, we
+            # treat it as a wildcard...
             return True
+
+        if not isinstance(other, OdxDocFragment):
+            return False
 
         # the ODX spec says that the doctype can be ignored...
         return self.doc_name == other.doc_name
@@ -59,7 +63,7 @@ class OdxLinkId:
         # i.e. the same OdxId object can be put into all of them.
         return self.local_id == other.local_id
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"OdxLinkId('{self.local_id}')"
 
     @staticmethod
@@ -139,7 +143,7 @@ class OdxLinkRef:
         """Construct an OdxLinkRef for a given OdxLinkId."""
         return OdxLinkRef(odxid.local_id, odxid.doc_fragments)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"OdxLinkRef('{self.ref_id}')"
 
     def __contains__(self, odx_id: OdxLinkId) -> bool:

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from xml.etree import ElementTree
 
-from .exceptions import odxraise, odxrequire
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 
 if TYPE_CHECKING:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 
-import sys
 import unittest
 from argparse import Namespace
 


### PR DESCRIPTION
This is the kick-off PR of another long and winding quest; this time the goal is to add comprehensive type annotations to everything so that `mypy --disallow-untyped-defs` passes for odxtools without any complaints. Note that this quest will include many side-tasks; I indent to put them into separate PRs as much as possible, but it is about as certain as death and taxes that I'll occasionally miss a few of these "drive-by fixes"...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)