### PR TITLE
multiplexer cases: fix internalization of the structure references

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1210,6 +1210,7 @@ somersault_muxs = {
                 long_name="Default Case",
                 description=None,
                 structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
+                structure_snref=None,
             ),
             cases=[
                 MultiplexerCase(
@@ -1219,6 +1220,7 @@ somersault_muxs = {
                     lower_limit="1",
                     upper_limit="3",
                     structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
+                    structure_snref=None,
                 ),
                 MultiplexerCase(
                     short_name="backward_flip",
@@ -1227,6 +1229,7 @@ somersault_muxs = {
                     lower_limit="1",
                     upper_limit="3",
                     structure_ref=OdxLinkRef.from_id(somersault_dops["num_flips"].odx_id),
+                    structure_snref=None,
                 ),
             ],
         )

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -17,30 +17,46 @@ if TYPE_CHECKING:
 class MultiplexerCase(NamedElement):
     """This class represents a Case which represents multiple options in a Multiplexer."""
 
-    structure_ref: OdxLinkRef
+    structure_ref: Optional[OdxLinkRef]
+    structure_snref: Optional[str]
     lower_limit: str
     upper_limit: str
 
     def __post_init__(self) -> None:
-        self._structure: Optional[BasicStructure] = None
+        self._structure: BasicStructure
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "MultiplexerCase":
         """Reads a Case for a Multiplexer."""
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
-        structure_ref = odxrequire(OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags))
+        structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
+        structure_snref = None
+        if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:
+            structure_snref = odxrequire(structure_snref_elem.get("SHORT-NAME"))
+
         lower_limit = odxrequire(et_element.findtext("LOWER-LIMIT"))
         upper_limit = odxrequire(et_element.findtext("UPPER-LIMIT"))
 
         return MultiplexerCase(
-            structure_ref=structure_ref, lower_limit=lower_limit, upper_limit=upper_limit, **kwargs)
+            structure_ref=structure_ref,
+            structure_snref=structure_snref,
+            lower_limit=lower_limit,
+            upper_limit=upper_limit,
+            **kwargs)
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        self._structure = odxlinks.resolve(self.structure_ref)
+        if self.structure_ref:
+            self._structure = odxlinks.resolve(self.structure_ref)
 
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
-        pass
+        if self.structure_snref:
+            ddds = diag_layer.diag_data_dictionary_spec
+            self._structure = odxrequire(ddds.structures.get(self.structure_snref))
+
+    @property
+    def structure(self) -> BasicStructure:
+        return self._structure

--- a/odxtools/multiplexerdefaultcase.py
+++ b/odxtools/multiplexerdefaultcase.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .element import NamedElement
+from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .utils import dataclass_fields_asdict
 
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 class MultiplexerDefaultCase(NamedElement):
     """This class represents a Default Case, which is selected when there are no cases defined in the Multiplexer."""
     structure_ref: Optional[OdxLinkRef]
+    structure_snref: Optional[str]
 
     def __post_init__(self) -> None:
         self._structure: Optional[BasicStructure] = None
@@ -27,8 +29,12 @@ class MultiplexerDefaultCase(NamedElement):
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
+        structure_snref = None
+        if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:
+            structure_snref = odxrequire(structure_snref_elem.get("SHORT-NAME"))
 
-        return MultiplexerDefaultCase(structure_ref=structure_ref, **kwargs)
+        return MultiplexerDefaultCase(
+            structure_ref=structure_ref, structure_snref=structure_snref, **kwargs)
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return {}
@@ -38,4 +44,6 @@ class MultiplexerDefaultCase(NamedElement):
             self._structure = odxlinks.resolve(self.structure_ref)
 
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
-        pass
+        if self.structure_snref:
+            ddds = diag_layer.diag_data_dictionary_spec
+            self._structure = odxrequire(ddds.structures.get(self.structure_snref))

--- a/odxtools/templates/macros/printMux.xml.jinja2
+++ b/odxtools/templates/macros/printMux.xml.jinja2
@@ -22,6 +22,9 @@
     {%- if mux.default_case.structure_ref is not none %}
     <STRUCTURE-REF ID-REF="{{mux.default_case.structure_ref.ref_id}}"/>
     {%- endif %}
+    {%- if mux.default_case.structure_snref is not none %}
+    <STRUCTURE-SNREF SHORT_NAME="{{mux.default_case.structure_snref}}"/>
+    {%- endif %}
   </DEFAULT-CASE>
   {%- endif %}
   {%- if mux.cases %}
@@ -30,7 +33,12 @@
     <CASE>
       <SHORT-NAME>{{case.short_name}}</SHORT-NAME>
       <LONG-NAME>{{case.long_name}}</LONG-NAME>
+      {%- if case.structure_ref is not none %}
       <STRUCTURE-REF ID-REF="{{case.structure_ref.ref_id}}"/>
+      {%- endif %}
+      {%- if case.structure_snref is not none %}
+      <STRUCTURE-SNREF SHORT_NAME="{{case.structure_snref}}"/>
+      {%- endif %}
       <LOWER-LIMIT>{{case.lower_limit}}</LOWER-LIMIT>
       <UPPER-LIMIT>{{case.upper_limit}}</UPPER-LIMIT>
     </CASE>

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -237,6 +237,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                 long_name="Default Case",
                 description=None,
                 structure_ref="structure_ref",
+                structure_snref=None,
             ),
             cases=[
                 MultiplexerCase(
@@ -246,6 +247,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     lower_limit="1",
                     upper_limit="3",
                     structure_ref="structure_ref",
+                    structure_snref=None,
                 ),
                 MultiplexerCase(
                     short_name="backward_flip",
@@ -254,6 +256,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     lower_limit="1",
                     upper_limit="3",
                     structure_ref="structure_ref",
+                    structure_snref=None,
                 ),
             ],
         )


### PR DESCRIPTION
it turns out that these references are (a) optional and (b) can be done via SNREF...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)