### PR TITLE
rename `DecodeState.next_byte_position` to `DecodeState.cursor_position`

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -199,21 +199,21 @@ class BasicStructure(DopBase):
         if bit_position != 0:
             raise DecodeError("Structures must be aligned, i.e. bit_position=0, but "
                               f"{self.short_name} was passed the bit position {bit_position}")
-        byte_code = decode_state.coded_message[decode_state.next_byte_position:]
+        byte_code = decode_state.coded_message[decode_state.cursor_position:]
         inner_decode_state = DecodeState(
-            coded_message=byte_code, parameter_values={}, next_byte_position=0)
+            coded_message=byte_code, parameter_values={}, cursor_position=0)
 
         for parameter in self.parameters:
-            value, next_byte_position = parameter.decode_from_pdu(inner_decode_state)
+            value, cursor_position = parameter.decode_from_pdu(inner_decode_state)
 
             inner_decode_state.parameter_values[parameter.short_name] = value
             inner_decode_state = DecodeState(
                 coded_message=byte_code,
                 parameter_values=inner_decode_state.parameter_values,
-                next_byte_position=max(inner_decode_state.next_byte_position, next_byte_position),
+                cursor_position=max(inner_decode_state.cursor_position, cursor_position),
             )
 
-        return inner_decode_state.parameter_values, decode_state.next_byte_position + inner_decode_state.next_byte_position
+        return inner_decode_state.parameter_values, decode_state.cursor_position + inner_decode_state.cursor_position
 
     def encode(self, coded_request: Optional[bytes] = None, **params) -> bytes:
         """
@@ -232,12 +232,12 @@ class BasicStructure(DopBase):
 
     def decode(self, message: bytes) -> ParameterValueDict:
         # dummy decode state to be passed to convert_bytes_to_physical
-        decode_state = DecodeState(parameter_values={}, coded_message=message, next_byte_position=0)
-        param_values, next_byte_position = self.convert_bytes_to_physical(decode_state)
-        if len(message) != next_byte_position:
+        decode_state = DecodeState(parameter_values={}, coded_message=message, cursor_position=0)
+        param_values, cursor_position = self.convert_bytes_to_physical(decode_state)
+        if len(message) != cursor_position:
             warnings.warn(
                 f"The message {message.hex()} is longer than could be parsed."
-                f" Expected {next_byte_position} but got {len(message)}.",
+                f" Expected {cursor_position} but got {len(message)}.",
                 DecodeError,
                 stacklevel=1,
             )

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -164,11 +164,11 @@ class DataObjectProperty(DopBase):
         """
         odxassert(0 <= bit_position and bit_position < 8)
 
-        internal, next_byte_position = self.diag_coded_type.convert_bytes_to_internal(
+        internal, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
             decode_state, bit_position=bit_position)
 
         if self.compu_method.is_valid_internal_value(internal):
-            return self.compu_method.convert_internal_to_physical(internal), next_byte_position
+            return self.compu_method.convert_internal_to_physical(internal), cursor_position
         else:
             # TODO: How to prevent this?
             raise DecodeError(

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -15,4 +15,4 @@ class DecodeState:
     parameter_values: ParameterValueDict
 
     #: Position of the next parameter if its position is not specified in ODX
-    next_byte_position: int
+    cursor_position: int

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -81,8 +81,8 @@ class DiagCodedType(abc.ABC):
         byte_length = (bit_length + bit_position + 7) // 8
         if byte_position + byte_length > len(coded_message):
             raise DecodeError(f"Expected a longer message.")
-        next_byte_position = byte_position + byte_length
-        extracted_bytes = coded_message[byte_position:next_byte_position]
+        cursor_position = byte_position + byte_length
+        extracted_bytes = coded_message[byte_position:cursor_position]
 
         # Apply byteorder
         if not is_highlow_byte_order and base_data_type not in [
@@ -120,7 +120,7 @@ class DiagCodedType(abc.ABC):
             else:
                 internal_value = internal_value.decode("utf-16-le")
 
-        return internal_value, next_byte_position
+        return internal_value, cursor_position
 
     def _to_bytes(
         self,

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -29,7 +29,7 @@ class DtcDop(DataObjectProperty):
         return self._linked_dtc_dops
 
     def convert_bytes_to_physical(self, decode_state, bit_position: int = 0):
-        trouble_code, next_byte = super().convert_bytes_to_physical(
+        trouble_code, cursor_position = super().convert_bytes_to_physical(
             decode_state, bit_position=bit_position)
 
         dtcs = [x for x in self.dtcs if x.trouble_code == trouble_code]
@@ -38,7 +38,7 @@ class DtcDop(DataObjectProperty):
 
         if len(dtcs) == 1:
             # we found exactly one described DTC
-            return dtcs[0], next_byte
+            return dtcs[0], cursor_position
 
         # the DTC was not specified. This probably means that the
         # diagnostic description file is incomplete. We do not bail
@@ -57,7 +57,7 @@ class DtcDop(DataObjectProperty):
             sdgs=[],
         )
 
-        return dtc, next_byte
+        return dtc, cursor_position
 
     def convert_physical_to_bytes(self, physical_value, encode_state, bit_position):
         if isinstance(physical_value, DiagnosticTroubleCode):

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -64,19 +64,19 @@ class EndOfPduField(Field):
 
     def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
         decode_state = copy(decode_state)
-        next_byte_position = decode_state.next_byte_position
+        cursor_position = decode_state.cursor_position
         byte_code = decode_state.coded_message
 
         value = []
-        while len(byte_code) > next_byte_position:
+        while len(byte_code) > cursor_position:
             # ATTENTION: the ODX specification is very misleading
             # here: it says that the item is repeated until the end of
             # the PDU, but it means that DOP of the items that are
             # repeated are identical, not their values
-            new_value, next_byte_position = self.structure.convert_bytes_to_physical(
+            new_value, cursor_position = self.structure.convert_bytes_to_physical(
                 decode_state, bit_position=bit_position)
             # Update next byte_position
-            decode_state.next_byte_position = next_byte_position
+            decode_state.cursor_position = cursor_position
             value.append(new_value)
 
-        return value, next_byte_position
+        return value, cursor_position

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -59,7 +59,7 @@ class LeadingLengthInfoType(DiagCodedType):
         # Extract length of the parameter value
         byte_length, byte_position = self._extract_internal(
             coded_message=coded_message,
-            byte_position=decode_state.next_byte_position,
+            byte_position=decode_state.cursor_position,
             bit_position=bit_position,
             bit_length=self.bit_length,
             base_data_type=DataType.A_UINT32,  # length is an integer
@@ -72,7 +72,7 @@ class LeadingLengthInfoType(DiagCodedType):
         # Extract actual value
         # TODO: The returned value is None if the byte_length is 0. Maybe change it
         #       to some default value like an empty bytearray() or 0?
-        value, next_byte_position = self._extract_internal(
+        value, cursor_position = self._extract_internal(
             coded_message=coded_message,
             byte_position=byte_position,
             bit_position=0,
@@ -81,4 +81,4 @@ class LeadingLengthInfoType(DiagCodedType):
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
 
-        return value, next_byte_position
+        return value, cursor_position

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -109,11 +109,11 @@ class Multiplexer(DopBase):
                               f"{self.short_name} was passed the bit position {bit_position}")
         key_value, key_next_byte = self.switch_key.convert_bytes_to_physical(decode_state)
 
-        byte_code = decode_state.coded_message[decode_state.next_byte_position:]
+        byte_code = decode_state.coded_message[decode_state.cursor_position:]
         case_decode_state = DecodeState(
             coded_message=byte_code[self.byte_position:],
             parameter_values={},
-            next_byte_position=0,
+            cursor_position=0,
         )
         case_found = False
         case_next_byte = 0
@@ -138,7 +138,7 @@ class Multiplexer(DopBase):
                 f"Failed to find a matching case in {self.short_name} for value {key_value}")
 
         mux_value = OrderedDict({case.short_name: case_value})
-        mux_next_byte = decode_state.next_byte_position + max(
+        mux_next_byte = decode_state.cursor_position + max(
             key_next_byte + self.switch_key.byte_position, case_next_byte + self.byte_position)
         return mux_value, mux_next_byte
 

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -69,13 +69,13 @@ class CodedConstParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         decode_state = copy(decode_state)
-        if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             # Update byte position
-            decode_state.next_byte_position = self.byte_position
+            decode_state.cursor_position = self.byte_position
 
         # Extract coded values
         bit_position_int = self.bit_position if self.bit_position is not None else 0
-        coded_val, next_byte_position = self.diag_coded_type.convert_bytes_to_internal(
+        coded_val, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
             decode_state, bit_position=bit_position_int)
 
         # Check if the coded value in the message is correct.
@@ -84,13 +84,13 @@ class CodedConstParameter(Parameter):
                 f"Coded constant parameter does not match! "
                 f"The parameter {self.short_name} expected coded "
                 f"value {str(self._coded_value_str)} but got {str(coded_val)} "
-                f"at byte position {decode_state.next_byte_position} "
+                f"at byte position {decode_state.cursor_position} "
                 f"in coded message {decode_state.coded_message.hex()}.",
                 DecodeError,
                 stacklevel=1,
             )
 
-        return coded_val, next_byte_position
+        return coded_val, cursor_position
 
     def _as_dict(self):
         d = super()._as_dict()

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -41,8 +41,7 @@ class MatchingRequestParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         byte_position = (
-            self.byte_position
-            if self.byte_position is not None else decode_state.next_byte_position)
+            self.byte_position if self.byte_position is not None else decode_state.cursor_position)
         bit_position = self.bit_position if self.bit_position is not None else 0
         byte_length = (self.bit_length + bit_position + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:byte_position + byte_length]

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -84,13 +84,13 @@ class NrcConstParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         decode_state = copy(decode_state)
-        if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             # Update byte position
-            decode_state.next_byte_position = self.byte_position
+            decode_state.cursor_position = self.byte_position
 
         # Extract coded values
         bit_position_int = self.bit_position if self.bit_position is not None else 0
-        coded_value, next_byte_position = self.diag_coded_type.convert_bytes_to_internal(
+        coded_value, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
             decode_state, bit_position=bit_position_int)
 
         # Check if the coded value in the message is correct.
@@ -99,13 +99,13 @@ class NrcConstParameter(Parameter):
                 f"Coded constant parameter does not match! "
                 f"The parameter {self.short_name} expected a coded "
                 f"value in {str(self.coded_values)} but got {str(coded_value)} "
-                f"at byte position {decode_state.next_byte_position} "
+                f"at byte position {decode_state.cursor_position} "
                 f"in coded message {decode_state.coded_message.hex()}.",
                 DecodeError,
                 stacklevel=1,
             )
 
-        return coded_value, next_byte_position
+        return coded_value, cursor_position
 
     def _as_dict(self):
         d = super()._as_dict()

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -86,15 +86,15 @@ class ParameterWithDOP(Parameter):
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
         dop = odxrequire(self.dop, "Reference to DOP is not resolved")
         decode_state = copy(decode_state)
-        if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
-            decode_state.next_byte_position = self.byte_position
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
+            decode_state.cursor_position = self.byte_position
 
         # Use DOP to decode
         bit_position_int = self.bit_position if self.bit_position is not None else 0
-        phys_val, next_byte_position = dop.convert_bytes_to_physical(
+        phys_val, cursor_position = dop.convert_bytes_to_physical(
             decode_state, bit_position=bit_position_int)
 
-        return phys_val, next_byte_position
+        return phys_val, cursor_position
 
     def _as_dict(self):
         d = super()._as_dict()

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -69,16 +69,16 @@ class PhysicalConstantParameter(ParameterWithDOP):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         # Decode value
-        phys_val, next_byte_position = super().decode_from_pdu(decode_state)
+        phys_val, cursor_position = super().decode_from_pdu(decode_state)
 
         # Check if decoded value matches expected value
         if phys_val != self.physical_constant_value:
             warnings.warn(
                 f"Physical constant parameter does not match! "
                 f"The parameter {self.short_name} expected physical value {self.physical_constant_value!r} but got {phys_val!r} "
-                f"at byte position {next_byte_position} "
+                f"at byte position {cursor_position} "
                 f"in coded message {decode_state.coded_message.hex()}.",
                 DecodeError,
                 stacklevel=1,
             )
-        return phys_val, next_byte_position
+        return phys_val, cursor_position

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -41,12 +41,11 @@ class ReservedParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState):
         byte_position = (
-            self.byte_position
-            if self.byte_position is not None else decode_state.next_byte_position)
+            self.byte_position if self.byte_position is not None else decode_state.cursor_position)
         bit_position_int = self.bit_position if self.bit_position is not None else 0
         byte_length = (self.bit_length_raw + bit_position_int + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:byte_position + byte_length]
-        next_byte_position = byte_position + byte_length
+        cursor_position = byte_position + byte_length
 
         # Check that reserved bits are 0
         expected = sum(
@@ -64,4 +63,4 @@ class ReservedParameter(Parameter):
                 stacklevel=1,
             )
 
-        return None, next_byte_position
+        return None, cursor_position

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -143,20 +143,20 @@ class TableKeyParameter(Parameter):
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
-        if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
-            next_byte_position = self.byte_position
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
+            cursor_position = self.byte_position
 
         # update the decode_state's table key
         if self.table_row is not None:
             # the table row to be used is statically specified -> no
             # need to decode anything!
             phys_val = self.table_row.short_name
-            next_byte_position = decode_state.next_byte_position
+            cursor_position = decode_state.cursor_position
         else:
             # Use DOP to decode
             key_dop = odxrequire(self.table.key_dop)
             bit_position_int = self.bit_position if self.bit_position is not None else 0
-            key_dop_val, next_byte_position = key_dop.convert_bytes_to_physical(
+            key_dop_val, cursor_position = key_dop.convert_bytes_to_physical(
                 decode_state, bit_position=bit_position_int)
 
             table_row_candidates = [x for x in self.table.table_rows if x.key == key_dop_val]
@@ -167,4 +167,4 @@ class TableKeyParameter(Parameter):
                     f"Multiple rows exhibiting key '{str(key_dop_val)}' found in table")
             phys_val = table_row_candidates[0].short_name
 
-        return phys_val, next_byte_position
+        return phys_val, cursor_position

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -134,10 +134,10 @@ class TableStructParameter(Parameter):
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
-        if self.byte_position is not None and self.byte_position != decode_state.next_byte_position:
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             next_pos = self.byte_position if self.byte_position is not None else 0
             decode_state = copy(decode_state)
-            decode_state.next_byte_position = next_pos
+            decode_state.cursor_position = next_pos
 
         # find the selected table row
         key_name = self.table_key.short_name
@@ -162,4 +162,4 @@ class TableStructParameter(Parameter):
         else:
             # the table row associated with the key neither defines a
             # DOP not a structure -> ignore it
-            return (table_row.short_name, None), decode_state.next_byte_position
+            return (table_row.short_name, None), decode_state.cursor_position

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -91,7 +91,7 @@ class ParamLengthInfoType(DiagCodedType):
         # Extract the internal value and return.
         return self._extract_internal(
             decode_state.coded_message,
-            decode_state.next_byte_position,
+            decode_state.cursor_position,
             bit_position,
             bit_length,
             self.base_data_type,

--- a/odxtools/positioneddataobjectproperty.py
+++ b/odxtools/positioneddataobjectproperty.py
@@ -64,11 +64,11 @@ class PositionedDataObjectProperty:
 
     def convert_bytes_to_physical(self, decode_state: DecodeState) -> Tuple[Any, int]:
 
-        byte_code = decode_state.coded_message[decode_state.next_byte_position:]
+        byte_code = decode_state.coded_message[decode_state.cursor_position:]
         state = DecodeState(
             coded_message=byte_code[self.byte_position:],
             parameter_values={},
-            next_byte_position=0,
+            cursor_position=0,
         )
         bit_position_int = (self.bit_position if self.bit_position is not None else 0)
         return self.dop.convert_bytes_to_physical(state, bit_position=bit_position_int)

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -54,13 +54,13 @@ class StandardLengthType(DiagCodedType):
         )
 
     def convert_bytes_to_internal(self, decode_state: DecodeState, bit_position: int = 0):
-        internal_value, next_byte_position = self._extract_internal(
+        internal_value, cursor_position = self._extract_internal(
             decode_state.coded_message,
-            decode_state.next_byte_position,
+            decode_state.cursor_position,
             bit_position,
             self.bit_length,
             self.base_data_type,
             self.is_highlow_byte_order,
         )
         internal_value = self.__apply_mask(internal_value)
-        return internal_value, next_byte_position
+        return internal_value, cursor_position

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -41,7 +41,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x2, 0x34, 0x56]), [], 0)
-        internal, next_byte = dct.convert_bytes_to_internal(state, 0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
 
         dct = LeadingLengthInfoType(
@@ -53,7 +53,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), [], 1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=1)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
         self.assertEqual(internal, bytes([0x3]))
 
     def test_decode_leading_length_info_type_zero_length(self):
@@ -64,9 +64,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x0, 0x1]), [], 0)
-        internal, next_byte = dct.convert_bytes_to_internal(state, 0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, b'')
-        self.assertEqual(next_byte, 1)
+        self.assertEqual(cursor_position, 1)
 
     def test_encode_leading_length_info_type_bytefield(self):
         dct = LeadingLengthInfoType(
@@ -111,9 +111,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), [], 1)
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, "a9")
-        self.assertEqual(next_byte, 6)
+        self.assertEqual(cursor_position, 6)
 
         dct = LeadingLengthInfoType(
             base_data_type=DataType.A_UNICODE2STRING,
@@ -122,9 +122,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=False,
         )
         state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), [], 1)
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, "a9")
-        self.assertEqual(next_byte, 6)
+        self.assertEqual(cursor_position, 6)
 
     def test_encode_leading_length_info_type_unicode2string(self):
         dct = LeadingLengthInfoType(
@@ -309,9 +309,9 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x1, 0x72, 0x3]), [], 1)
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=1)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
         self.assertEqual(internal, 25)
-        self.assertEqual(next_byte, 2)
+        self.assertEqual(cursor_position, 2)
 
     def test_decode_standard_length_type_uint_byteorder(self):
         dct = StandardLengthType(
@@ -323,9 +323,9 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
         )
         state = DecodeState(bytes([0x1, 0x2, 0x3]), [], 1)
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, 0x0302)
-        self.assertEqual(next_byte, 3)
+        self.assertEqual(cursor_position, 3)
 
     def test_decode_standard_length_type_bytes(self):
         dct = StandardLengthType(
@@ -337,9 +337,9 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), [], 1)
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
-        self.assertEqual(next_byte, 3)
+        self.assertEqual(cursor_position, 3)
 
 
 class TestParamLengthInfoType(unittest.TestCase):
@@ -371,11 +371,11 @@ class TestParamLengthInfoType(unittest.TestCase):
         state = DecodeState(
             coded_message=bytes([0x10, 0x12, 0x34, 0x56]),
             parameter_values={length_key.short_name: 16},
-            next_byte_position=1,
+            cursor_position=1,
         )
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, 0x1234)
-        self.assertEqual(next_byte, 3)
+        self.assertEqual(cursor_position, 3)
 
     def test_encode_param_info_length_type_uint(self):
         length_key_id = OdxLinkId("param.length_key", doc_frags)
@@ -604,9 +604,9 @@ class TestMinMaxLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), [], 1)
-        internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, bytes([0xFF, 0x34, 0x56]))
-        self.assertEqual(next_byte, 5)
+        self.assertEqual(cursor_position, 5)
 
     def test_decode_min_max_length_type_too_short_pdu(self):
         """If the PDU ends before min length is reached, an error must be raised."""
@@ -633,9 +633,9 @@ class TestMinMaxLengthType(unittest.TestCase):
                 is_highlow_byte_order_raw=None,
             )
             state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), [], 1)
-            internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+            internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
             self.assertEqual(internal, bytes([0x34, 0x56, 0x78, 0x9A]))
-            self.assertEqual(next_byte, 5)
+            self.assertEqual(cursor_position, 5)
 
     def test_decode_min_max_length_type_max_length(self):
         """If the max length is smaller than the end of PDU, the extracted value ends after max length."""
@@ -649,9 +649,9 @@ class TestMinMaxLengthType(unittest.TestCase):
                 is_highlow_byte_order_raw=None,
             )
             state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), [], 1)
-            internal, next_byte = dct.convert_bytes_to_internal(state, bit_position=0)
+            internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
             self.assertEqual(internal, bytes([0x34, 0x56, 0x78]))
-            self.assertEqual(next_byte, 4)
+            self.assertEqual(cursor_position, 4)
 
     def test_encode_min_max_length_type_hex_ff(self):
         dct = MinMaxLengthType(


### PR DESCRIPTION
IMO, `.cursor_position` better captures the purpose of this attribute.

this is a spin-off of #210 proposed by @kayoub5.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)