### PR TITLE
Add type annotations, part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ send to/received from ECUs in an pythonic manner.
 - [Installation](#installation)
 - [Usage Examples](#usage-examples)
   - [Python snippets](#python-snippets)
+- [Using the non-strict mode](#using-the-non-strict-mode)
 - [Interactive Usage](#interactive-usage)
   - [Python REPL](#python-repl)
 - [Command line usage](#command-line-usage)
@@ -608,10 +609,6 @@ project, please read the [contributing guide](https://github.com/mercedes-benz/o
 
 Please read our [Code of Conduct](https://github.com/mercedes-benz/daimler-foss/blob/master/CODE_OF_CONDUCT.md)
 as it is our base for interaction.
-
-## License
-
-This project is licensed under the [MIT LICENSE](https://github.com/mercedes-benz/odxtools/blob/main/LICENSE).
 
 ## Provider Information
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <!-- SPDX-License-Identifier: MIT -->
+[![PyPi - Version](https://img.shields.io/pypi/v/odxtools)](https://pypi.org/project/odxtools)
+[![PyPI - License](https://img.shields.io/pypi/l/odxtools)](LICENSE)
+[![CI Status](https://github.com/mercedes-benz/odxtools/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/mercedes-benz/odxtools/actions?query=branch%3Amain)
+
 # odxtools
 
 `odxtools` is a set of utilities for working with diagnostic

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import abc
 from dataclasses import dataclass
-from typing import List, Literal, Optional
+from typing import Literal
 
 from ..odxtypes import AtomicOdxType, DataType
 
@@ -35,6 +35,3 @@ class CompuMethod(abc.ABC):
 
     def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
         raise NotImplementedError()
-
-    def get_valid_physical_values(self) -> Optional[List[DataType]]:
-        return None

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 import abc
 from dataclasses import dataclass
-from typing import Literal, Union
+from typing import List, Literal, Optional
 
-from ..odxtypes import DataType
+from ..odxtypes import AtomicOdxType, DataType
 
 CompuMethodCategory = Literal[
     "IDENTICAL",
@@ -24,17 +24,17 @@ class CompuMethod(abc.ABC):
     def category(self) -> CompuMethodCategory:
         pass
 
-    def convert_physical_to_internal(self, physical_value):
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
         raise NotImplementedError()
 
-    def convert_internal_to_physical(self, internal_value) -> Union[int, float, str]:
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
         raise NotImplementedError()
 
-    def is_valid_physical_value(self, physical_value):
+    def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
         raise NotImplementedError()
 
-    def is_valid_internal_value(self, internal_value):
+    def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
         raise NotImplementedError()
 
-    def get_valid_physical_values(self):
+    def get_valid_physical_values(self) -> Optional[List[DataType]]:
         return None

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -19,12 +19,12 @@ from .texttablecompumethod import TexttableCompuMethod
 
 def _parse_compu_scale_to_linear_compu_method(
     *,
-    scale_element,
+    scale_element: ElementTree.Element,
     internal_type: DataType,
     physical_type: DataType,
-    is_scale_linear=False,
-    **kwargs,
-):
+    is_scale_linear: bool = False,
+    **kwargs: Any,
+) -> LinearCompuMethod:
     odxassert(physical_type in [
         DataType.A_FLOAT32,
         DataType.A_FLOAT64,
@@ -47,12 +47,12 @@ def _parse_compu_scale_to_linear_compu_method(
     kwargs["internal_type"] = internal_type
     kwargs["physical_type"] = physical_type
 
-    coeffs = scale_element.find("COMPU-RATIONAL-COEFFS")
+    coeffs = odxrequire(scale_element.find("COMPU-RATIONAL-COEFFS"))
     nums = coeffs.iterfind("COMPU-NUMERATOR/V")
 
-    offset = computation_python_type(next(nums).text)
+    offset = computation_python_type(odxrequire(next(nums).text))
     factor_el = next(nums, None)
-    factor = computation_python_type(factor_el.text if factor_el is not None else "0")
+    factor = computation_python_type(odxrequire(factor_el.text) if factor_el is not None else "0")
     denominator = 1.0
     if (string := coeffs.findtext("COMPU-DENOMINATOR/V")) is not None:
         denominator = float(string)

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 
+from ..odxtypes import AtomicOdxType
 from .compumethod import CompuMethod, CompuMethodCategory
 
 
@@ -11,14 +12,14 @@ class IdenticalCompuMethod(CompuMethod):
     def category(self) -> CompuMethodCategory:
         return "IDENTICAL"
 
-    def convert_physical_to_internal(self, physical_value):
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
         return physical_value
 
-    def convert_internal_to_physical(self, internal_value):
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
         return internal_value
 
-    def is_valid_physical_value(self, physical_value):
+    def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
         return self.physical_type.isinstance(physical_value)
 
-    def is_valid_internal_value(self, internal_value):
+    def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
         return self.internal_type.isinstance(internal_value)

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional
 from xml.etree import ElementTree
 
 from ..exceptions import odxassert, odxraise, odxrequire
-from ..odxtypes import DataType
+from ..odxtypes import AtomicOdxType, DataType
 
 
 class IntervalType(Enum):
@@ -16,7 +16,7 @@ class IntervalType(Enum):
 
 @dataclass
 class Limit:
-    value: Union[str, int, float, bytes]
+    value: AtomicOdxType
     interval_type: IntervalType = IntervalType.CLOSED
 
     def __post_init__(self) -> None:
@@ -53,7 +53,7 @@ class Limit:
         else:
             return Limit(internal_type.from_string(odxrequire(et_element.text)), interval_type)
 
-    def complies_to_upper(self, value):
+    def complies_to_upper(self, value: AtomicOdxType) -> bool:
         """Checks if the value is in the range w.r.t. the upper limit.
 
         * If the interval type is closed, return `value <= limit.value`.
@@ -61,13 +61,13 @@ class Limit:
         * If the interval type is infinite, return `True`.
         """
         if self.interval_type == IntervalType.CLOSED:
-            return value <= self.value
+            return value <= self.value  # type: ignore[operator]
         elif self.interval_type == IntervalType.OPEN:
-            return value < self.value
+            return value < self.value  # type: ignore[operator]
         elif self.interval_type == IntervalType.INFINITE:
             return True
 
-    def complies_to_lower(self, value):
+    def complies_to_lower(self, value: AtomicOdxType) -> bool:
         """Checks if the value is in the range w.r.t. the lower limit.
 
         * If the interval type is closed, return `limit.value <= value`.
@@ -75,8 +75,8 @@ class Limit:
         * If the interval type is infinite, return `True`.
         """
         if self.interval_type == IntervalType.CLOSED:
-            return self.value <= value
+            return self.value <= value  # type: ignore[operator]
         elif self.interval_type == IntervalType.OPEN:
-            return self.value < value
+            return self.value < value  # type: ignore[operator]
         elif self.interval_type == IntervalType.INFINITE:
             return True

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import List
 
 from ..exceptions import odxassert
+from ..odxtypes import AtomicOdxType
 from .compumethod import CompuMethod, CompuMethodCategory
 from .linearcompumethod import LinearCompuMethod
 
@@ -15,24 +16,24 @@ class ScaleLinearCompuMethod(CompuMethod):
     def category(self) -> CompuMethodCategory:
         return "SCALE-LINEAR"
 
-    def convert_physical_to_internal(self, physical_value):
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
         odxassert(
             self.is_valid_physical_value(physical_value),
-            f"cannot convert the invalid physical value {physical_value} "
+            f"cannot convert the invalid physical value {physical_value!r} "
             f"of type {type(physical_value)}")
         lin_method = next(
             scale for scale in self.linear_methods if scale.is_valid_physical_value(physical_value))
         return lin_method.convert_physical_to_internal(physical_value)
 
-    def convert_internal_to_physical(self, internal_value):
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
         lin_method = next(
             scale for scale in self.linear_methods if scale.is_valid_internal_value(internal_value))
         return lin_method.convert_internal_to_physical(internal_value)
 
-    def is_valid_physical_value(self, physical_value):
+    def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
         return any(
             True for scale in self.linear_methods if scale.is_valid_physical_value(physical_value))
 
-    def is_valid_internal_value(self, internal_value):
+    def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
         return any(
             True for scale in self.linear_methods if scale.is_valid_internal_value(internal_value))

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List, Tuple, Union
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..odxtypes import DataType
+from ..odxtypes import AtomicOdxType, DataType
 from .compumethod import CompuMethod, CompuMethodCategory
 from .limit import IntervalType, Limit
 
@@ -115,7 +115,11 @@ class TabIntpCompuMethod(CompuMethod):
 
         return None
 
-    def convert_physical_to_internal(self, physical_value: Union[int, float]) -> Union[int, float]:
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
+        if not isinstance(physical_value, (int, float)):
+            raise EncodeError("The type of values of tab-intp compumethods must "
+                              "either int or float")
+
         reference_points = list(zip(self.physical_points, self.internal_points))
         result = self._piecewise_linear_interpolate(physical_value, reference_points)
 
@@ -127,7 +131,11 @@ class TabIntpCompuMethod(CompuMethod):
             odxraise()
         return res
 
-    def convert_internal_to_physical(self, internal_value: Union[int, float]) -> Union[int, float]:
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
+        if not isinstance(internal_value, (int, float)):
+            raise EncodeError("The internal type of values of tab-intp compumethods must "
+                              "either int or float")
+
         reference_points = list(zip(self.internal_points, self.physical_points))
         result = self._piecewise_linear_interpolate(internal_value, reference_points)
 
@@ -139,10 +147,16 @@ class TabIntpCompuMethod(CompuMethod):
             odxraise()
         return res
 
-    def is_valid_physical_value(self, physical_value: Union[int, float]) -> bool:
+    def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
+        if not isinstance(physical_value, (int, float)):
+            return False
+
         return min(self.physical_points) <= physical_value and physical_value <= max(
             self.physical_points)
 
-    def is_valid_internal_value(self, internal_value: Union[int, float]) -> bool:
+    def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
+        if not isinstance(internal_value, (int, float)):
+            return False
+
         return min(self.internal_points) <= internal_value and internal_value <= max(
             self.internal_points)

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from ..exceptions import DecodeError, EncodeError, odxassert
-from ..odxtypes import DataType
+from ..odxtypes import AtomicOdxType, DataType
 from .compumethod import CompuMethod, CompuMethodCategory
 from .compuscale import CompuScale
 
@@ -28,25 +28,30 @@ class TexttableCompuMethod(CompuMethod):
     def category(self) -> CompuMethodCategory:
         return "TEXTTABLE"
 
-    def _get_scales(self):
+    def _get_scales(self) -> List[CompuScale]:
         scales = list(self.internal_to_phys)
         if self.compu_default_value:
             # Default is last, since it's a fallback
             scales.append(self.compu_default_value)
         return scales
 
-    def convert_physical_to_internal(self, physical_value):
-        scale: CompuScale = next(
-            filter(lambda scale: scale.compu_const == physical_value, self._get_scales()), None)
-        if scale is not None:
-            res = (
-                scale.compu_inverse_value
-                if scale.compu_inverse_value is not None else scale.lower_limit.value)
-            odxassert(self.internal_type.isinstance(res))
-            return res
-        raise EncodeError(f"Texttable compu method could not encode '{physical_value}'.")
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
+        scales = [x for x in self._get_scales() if x.compu_const == physical_value]
+        if scales:
+            inverse_value: Optional[AtomicOdxType] = scales[0].compu_inverse_value
+            if inverse_value is not None:
+                res = inverse_value
+            elif scales[0].lower_limit is not None:
+                res = scales[0].lower_limit.value
+            else:
+                res = None
 
-    def __is_internal_in_scale(self, internal_value, scale: CompuScale):
+            odxassert(self.internal_type.isinstance(res))
+            return res  # type: ignore[return-value]
+
+        raise EncodeError(f"Texttable compu method could not encode '{physical_value!r}'.")
+
+    def __is_internal_in_scale(self, internal_value: AtomicOdxType, scale: CompuScale) -> bool:
         if scale == self.compu_default_value:
             return True
         if scale.lower_limit is not None and not scale.lower_limit.complies_to_lower(
@@ -60,23 +65,23 @@ class TexttableCompuMethod(CompuMethod):
         # value complies to the defined limits
         return True
 
-    def convert_internal_to_physical(self, internal_value):
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
         scale = next(
             filter(
                 lambda scale: self.__is_internal_in_scale(internal_value, scale),
                 self._get_scales(),
             ), None)
-        if scale is None:
+        if scale is None or scale.compu_const is None:
             raise DecodeError(
-                f"Texttable compu method could not decode {internal_value} to string.")
+                f"Texttable compu method could not decode {internal_value!r} to string.")
         return scale.compu_const
 
-    def is_valid_physical_value(self, physical_value):
+    def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
         return physical_value in self.get_valid_physical_values()
 
-    def is_valid_internal_value(self, internal_value):
+    def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
         return any(
             self.__is_internal_in_scale(internal_value, scale) for scale in self._get_scales())
 
-    def get_valid_physical_values(self):
+    def get_valid_physical_values(self) -> List[Optional[AtomicOdxType]]:
         return [x.compu_const for x in self._get_scales()]

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -36,18 +36,14 @@ class TexttableCompuMethod(CompuMethod):
         return scales
 
     def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
-        scales = [x for x in self._get_scales() if x.compu_const == physical_value]
-        if scales:
-            inverse_value: Optional[AtomicOdxType] = scales[0].compu_inverse_value
-            if inverse_value is not None:
-                res = inverse_value
-            elif scales[0].lower_limit is not None:
-                res = scales[0].lower_limit.value
-            else:
-                res = None
-
-            odxassert(self.internal_type.isinstance(res))
-            return res  # type: ignore[return-value]
+        matching_scales = [x for x in self._get_scales() if x.compu_const == physical_value]
+        for scale in matching_scales:
+            if scale.compu_inverse_value is not None:
+                return scale.compu_inverse_value
+            elif scale.lower_limit is not None:
+                return scale.lower_limit.value
+            elif scale.upper_limit is not None:
+                return scale.upper_limit.value
 
         raise EncodeError(f"Texttable compu method could not encode '{physical_value!r}'.")
 

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -145,10 +145,7 @@ class DataObjectProperty(DopBase):
         """
         if not self.is_valid_physical_value(physical_value):
             raise EncodeError(f"The value {repr(physical_value)} of type {type(physical_value)}"
-                              f" is not a valid." +
-                              (f" Valid values are {self.compu_method.get_valid_physical_values()}"
-                               if self.compu_method.get_valid_physical_values(
-                               ) else f" Expected type {self.physical_type.base_data_type.value}."))
+                              f" is not a valid.")
 
         internal_val = self.convert_physical_to_internal(physical_value)
         return self.diag_coded_type.convert_internal_to_bytes(

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -15,6 +15,7 @@ from .odxtypes import AtomicOdxType, DataType
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
 
+# format specifiers for the data type using the bitstruct module
 ODX_TYPE_TO_FORMAT_LETTER = {
     DataType.A_INT32: "s",
     DataType.A_UINT32: "u",
@@ -26,6 +27,7 @@ ODX_TYPE_TO_FORMAT_LETTER = {
     DataType.A_UTF8STRING: "t",
 }
 
+# Allowed diag-coded types
 DctType = Literal[
     "LEADING-LENGTH-INFO-TYPE",
     "MIN-MAX-LENGTH-TYPE",

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -114,10 +114,6 @@ class IsoTpStateMachine:
         """
 
         if isinstance(bus, can.Bus):
-            # this is a bit of a hack: passing any object which
-            # exhibits a set_filters() method is assumed to be a can
-            # bus object.
-
             # create an "on receive" event for the can bus
             rx_event = asyncio.Event()
             loop = asyncio.get_running_loop()

--- a/odxtools/modification.py
+++ b/odxtools/modification.py
@@ -24,8 +24,8 @@ class Modification:
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return {}
 
-    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase):
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
         pass
 
-    def _resolve_snrefs(self, diag_layer: "DiagLayer"):
+    def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         pass

--- a/odxtools/parameterinfo.py
+++ b/odxtools/parameterinfo.py
@@ -86,8 +86,8 @@ def parameter_info(param_list: Iterable[Union[Parameter, EndOfPduField]]) -> str
             ul = cm.physical_upper_limit
             result += (f" range: "
                        f"{'[' if ll.interval_type == IntervalType.CLOSED else '('}"
-                       f"{ll.value}, "
-                       f"{ul.value}"
+                       f"{ll.value!r}, "
+                       f"{ul.value!r}"
                        f"{']' if ul.interval_type == IntervalType.CLOSED else ')'}\n")
 
             unit = dop.unit

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -55,9 +55,6 @@ class CodedConstParameter(Parameter):
     def is_settable(self) -> bool:
         return False
 
-    def get_coded_value(self):
-        return self.coded_value
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         if (self.short_name in encode_state.parameter_values and
                 encode_state.parameter_values[self.short_name] != self.coded_value):

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -19,9 +19,6 @@ class DynamicParameter(Parameter):
     def is_settable(self) -> bool:
         raise NotImplementedError(".is_settable for a DynamicParameter")
 
-    def get_coded_value(self):
-        raise NotImplementedError("Encoding a DynamicParameter is not implemented yet.")
-
     def get_coded_value_as_bytes(self):
         raise NotImplementedError("Encoding a DynamicParameter is not implemented yet.")
 

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -28,9 +28,6 @@ class MatchingRequestParameter(Parameter):
     def is_settable(self) -> bool:
         return False
 
-    def get_coded_value(self, request_value=None):
-        return request_value
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         if not encode_state.triggering_request:
             raise EncodeError(f"Parameter '{self.short_name}' is of matching request type,"

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -63,9 +63,6 @@ class NrcConstParameter(Parameter):
     def is_settable(self) -> bool:
         return False
 
-    def get_coded_value(self):
-        return self.coded_value
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         if self.short_name in encode_state.parameter_values:
             if encode_state.parameter_values[self.short_name] not in self.coded_values:

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -86,10 +86,6 @@ class Parameter(NamedElement, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_coded_value(self):
-        pass
-
-    @abc.abstractmethod
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         """Get the coded value of the parameter given the encode state.
         Note that this method is called by `encode_into_pdu`.

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -73,9 +73,6 @@ class ParameterWithDOP(Parameter):
         else:
             return None
 
-    def get_coded_value(self, physical_value=None):
-        return self.dop.convert_physical_to_internal(physical_value)
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         dop = odxrequire(self.dop, "Reference to DOP is not resolved")
         physical_value = encode_state.parameter_values[self.short_name]

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -52,9 +52,6 @@ class PhysicalConstantParameter(ParameterWithDOP):
     def is_settable(self) -> bool:
         return False
 
-    def get_coded_value(self):
-        return self.dop.convert_physical_to_internal(self.physical_constant_value)
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState):
         dop = odxrequire(self.dop, "Reference to DOP is not resolved")
         if (self.short_name in encode_state.parameter_values and

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -32,9 +32,6 @@ class ReservedParameter(Parameter):
         # need to take the "bit_length_raw" detour...
         return self.bit_length_raw
 
-    def get_coded_value(self):
-        return 0
-
     def get_coded_value_as_bytes(self, encode_state):
         bit_position_int = self.bit_position if self.bit_position is not None else 0
         return (0).to_bytes((self.bit_length + bit_position_int + 7) // 8, "big")

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -21,9 +21,6 @@ class SystemParameter(ParameterWithDOP):
     def is_settable(self) -> bool:
         raise NotImplementedError("SystemParameter.is_settable is not implemented yet.")
 
-    def get_coded_value(self):
-        raise NotImplementedError("Encoding a SystemParameter is not implemented yet.")
-
     def get_coded_value_as_bytes(self):
         raise NotImplementedError("Encoding a SystemParameter is not implemented yet.")
 

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -22,9 +22,6 @@ class TableEntryParameter(Parameter):
     def is_settable(self) -> bool:
         raise NotImplementedError("TableKeyParameter.is_settable is not implemented yet.")
 
-    def get_coded_value(self):
-        raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")
-
     def get_coded_value_as_bytes(self):
         raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")
 

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -94,14 +94,6 @@ class TableKeyParameter(Parameter):
     def is_settable(self) -> bool:
         return True
 
-    def get_coded_value(self, physical_value=None) -> Any:
-        key_dop = self.table.key_dop
-        if key_dop is None:
-            raise EncodeError(f"Table '{self.table.short_name}' does not define "
-                              f"a KEY-DOP, but is used in TABLE-KEY parameter "
-                              f"'{self.short_name}'")
-        return key_dop.convert_physical_to_internal(physical_value)
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         tr_short_name = encode_state.parameter_values.get(self.short_name)
 

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -60,10 +60,6 @@ class TableStructParameter(Parameter):
     def is_settable(self):
         return True
 
-    def get_coded_value(self, physical_value=None):
-        raise EncodeError("TableStructParameters cannot be converted to "
-                          "internal values without a table row.")
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         physical_value = encode_state.parameter_values.get(self.short_name)
 

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -55,15 +55,6 @@ class ValueParameter(ParameterWithDOP):
     def is_settable(self) -> bool:
         return True
 
-    def get_coded_value(self, physical_value: Optional[AtomicOdxType] = None):
-        if physical_value is not None:
-            dop = odxrequire(self.dop)
-            if not isinstance(dop, DataObjectProperty):
-                odxraise()
-            return dop.convert_physical_to_internal(physical_value)
-        else:
-            return self.physical_default_value
-
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         physical_value = encode_state.parameter_values.get(self.short_name,
                                                            self.physical_default_value)

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -58,7 +58,7 @@ class PhysicalDimension(IdentifiableElement):
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
         oid = et_element.get("OID")
 
-        def read_optional_int(element, name):
+        def read_optional_int(element: ElementTree.Element, name: str) -> int:
             if val_str := element.findtext(name):
                 return int(val_str)
             else:

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -51,13 +51,13 @@ class PhysicalType:
     The precision is only applicable if the base data type is A_FLOAT32 or A_FLOAT64.
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.base_data_type = DataType(self.base_data_type)
         if self.display_radix is not None:
             self.display_radix = Radix(self.display_radix)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]):
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "PhysicalType":
         base_data_type_str = et_element.get("BASE-DATA-TYPE")
         if base_data_type_str not in DataType.__members__:
             odxraise(f"Encountered unknown base data type '{base_data_type_str}'")

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -60,7 +60,7 @@ class Unit(IdentifiableElement):
     offset_si_to_unit: Optional[float]
     physical_dimension_ref: Optional[OdxLinkRef]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._physical_dimension = None
 
     @staticmethod
@@ -69,9 +69,9 @@ class Unit(IdentifiableElement):
         oid = et_element.get("OID")
         display_name = odxrequire(et_element.findtext("DISPLAY-NAME"))
 
-        def read_optional_float(element, name):
-            if element.findtext(name):
-                return float(element.findtext(name))
+        def read_optional_float(element: ElementTree.Element, name: str) -> Optional[float]:
+            if (elem_str := element.findtext(name)) is not None:
+                return float(elem_str)
             else:
                 return None
 
@@ -89,7 +89,7 @@ class Unit(IdentifiableElement):
             **kwargs)
 
     @property
-    def physical_dimension(self) -> PhysicalDimension:
+    def physical_dimension(self) -> Optional[PhysicalDimension]:
         return self._physical_dimension
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:


### PR DESCRIPTION
This is the second part of the quest for comprehensive type annotations. Besides the on-topic changes, it also contains a minor cleanup of the README, and the removal of the completely unused but confusingly named `Parameter.get_coded_value()` method.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)