### PR TITLE
Add type annotations, part 3

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -107,18 +107,18 @@ class BasicStructure(DopBase):
         print(parameter_info(self.free_parameters), end="")
 
     def convert_physical_to_internal(self,
-                                     param_values: ParameterValue,
+                                     param_value: ParameterValue,
                                      triggering_coded_request: Optional[bytes],
                                      is_end_of_pdu: bool = True) -> bytes:
 
-        if not isinstance(param_values, dict):
+        if not isinstance(param_value, dict):
             raise EncodeError(
                 f"Expected a dictionary for the values of structure {self.short_name}, "
-                f"got {type(param_values)}")
+                f"got {type(param_value)}")
 
         encode_state = EncodeState(
             b'',
-            dict(param_values),
+            dict(param_value),
             triggering_request=triggering_coded_request,
             is_end_of_pdu=False,
         )

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -11,7 +11,7 @@ from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, OdxWarning, odxassert
 from .nameditemlist import NamedItemList
 from .odxlink import OdxLinkDatabase
-from .odxtypes import ParameterDict, ParameterValueDict
+from .odxtypes import ParameterDict, ParameterValue
 from .parameters.codedconstparameter import CodedConstParameter
 from .parameters.lengthkeyparameter import LengthKeyParameter
 from .parameters.matchingrequestparameter import MatchingRequestParameter
@@ -107,9 +107,14 @@ class BasicStructure(DopBase):
         print(parameter_info(self.free_parameters), end="")
 
     def convert_physical_to_internal(self,
-                                     param_values: ParameterValueDict,
+                                     param_values: ParameterValue,
                                      triggering_coded_request: Optional[bytes],
                                      is_end_of_pdu: bool = True) -> bytes:
+
+        if not isinstance(param_values, dict):
+            raise EncodeError(
+                f"Expected a dictionary for the values of structure {self.short_name}, "
+                f"got {type(param_values)}")
 
         encode_state = EncodeState(
             b'',
@@ -181,9 +186,13 @@ class BasicStructure(DopBase):
                    "\n".join(self.__message_format_lines()))
 
     def convert_physical_to_bytes(self,
-                                  param_values: ParameterValueDict,
+                                  param_values: ParameterValue,
                                   encode_state: EncodeState,
                                   bit_position: int = 0) -> bytes:
+        if not isinstance(param_values, dict):
+            raise EncodeError(
+                f"Expected a dictionary for the values of structure {self.short_name}, "
+                f"got {type(param_values)}")
         if bit_position != 0:
             raise EncodeError("Structures must be aligned, i.e. bit_position=0, but "
                               f"{self.short_name} was passed the bit position {bit_position}")
@@ -195,7 +204,7 @@ class BasicStructure(DopBase):
 
     def convert_bytes_to_physical(self,
                                   decode_state: DecodeState,
-                                  bit_position: int = 0) -> Tuple[ParameterValueDict, int]:
+                                  bit_position: int = 0) -> Tuple[ParameterValue, int]:
         if bit_position != 0:
             raise DecodeError("Structures must be aligned, i.e. bit_position=0, but "
                               f"{self.short_name} was passed the bit position {bit_position}")
@@ -230,7 +239,7 @@ class BasicStructure(DopBase):
             triggering_coded_request=coded_request,
             is_end_of_pdu=True)
 
-    def decode(self, message: bytes) -> ParameterValueDict:
+    def decode(self, message: bytes) -> ParameterValue:
         # dummy decode state to be passed to convert_bytes_to_physical
         decode_state = DecodeState(parameter_values={}, coded_message=message, cursor_position=0)
         param_values, cursor_position = self.convert_bytes_to_physical(decode_state)
@@ -302,8 +311,8 @@ class BasicStructure(DopBase):
         # replace structure parameters by their sub parameters
         params: List[Parameter] = []
         for p in sorted_params:
-            if isinstance(p, ValueParameter) and isinstance(p.dop, BasicStructure):
-                params += p.dop.parameters
+            if isinstance(p, ValueParameter) and isinstance(p._dop, BasicStructure):
+                params += p._dop.parameters
             else:
                 params.append(p)
 
@@ -350,8 +359,8 @@ class BasicStructure(DopBase):
                     # END-OF-PDU fields do not exhibit a fixed bit
                     # length, so they need special treatment here
                     dct = None
-                    if hasattr(params[param_idx], "dop"):
-                        dop = params[param_idx].dop  # type: ignore
+                    if hasattr(params[param_idx], "_dop"):
+                        dop = params[param_idx]._dop  # type: ignore[attr-defined]
                         if hasattr(dop, "diag_coded_type"):
                             dct = dop.diag_coded_type
 

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -121,10 +121,15 @@ class TabIntpCompuMethod(CompuMethod):
                               "either int or float")
 
         reference_points = list(zip(self.physical_points, self.internal_points))
-        result = self._piecewise_linear_interpolate(physical_value, reference_points)
+        odxassert(
+            isinstance(physical_value, (int, float)),
+            "Only integers and floats can be piecewise linearly interpolated")
+        result = self._piecewise_linear_interpolate(
+            physical_value,  # type: ignore[arg-type]
+            reference_points)
 
         if result is None:
-            raise EncodeError(f"Internal value {physical_value} must be inside the range"
+            raise EncodeError(f"Internal value {physical_value!r} must be inside the range"
                               f" [{min(self.physical_points)}, {max(self.physical_points)}]")
         res = self.internal_type.make_from(result)
         if not isinstance(res, (int, float)):
@@ -137,10 +142,12 @@ class TabIntpCompuMethod(CompuMethod):
                               "either int or float")
 
         reference_points = list(zip(self.internal_points, self.physical_points))
-        result = self._piecewise_linear_interpolate(internal_value, reference_points)
+        result = self._piecewise_linear_interpolate(
+            internal_value,  # type: ignore[arg-type]
+            reference_points)
 
         if result is None:
-            raise DecodeError(f"Internal value {internal_value} must be inside the range"
+            raise DecodeError(f"Internal value {internal_value!r} must be inside the range"
                               f" [{min(self.internal_points)}, {max(self.internal_points)}]")
         res = self.physical_type.make_from(result)
         if not isinstance(res, (int, float)):

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -28,7 +28,7 @@ class TexttableCompuMethod(CompuMethod):
     def category(self) -> CompuMethodCategory:
         return "TEXTTABLE"
 
-    def _get_scales(self) -> List[CompuScale]:
+    def get_scales(self) -> List[CompuScale]:
         scales = list(self.internal_to_phys)
         if self.compu_default_value:
             # Default is last, since it's a fallback
@@ -36,7 +36,7 @@ class TexttableCompuMethod(CompuMethod):
         return scales
 
     def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
-        matching_scales = [x for x in self._get_scales() if x.compu_const == physical_value]
+        matching_scales = [x for x in self.get_scales() if x.compu_const == physical_value]
         for scale in matching_scales:
             if scale.compu_inverse_value is not None:
                 return scale.compu_inverse_value
@@ -65,7 +65,7 @@ class TexttableCompuMethod(CompuMethod):
         scale = next(
             filter(
                 lambda scale: self.__is_internal_in_scale(internal_value, scale),
-                self._get_scales(),
+                self.get_scales(),
             ), None)
         if scale is None or scale.compu_const is None:
             raise DecodeError(
@@ -73,11 +73,8 @@ class TexttableCompuMethod(CompuMethod):
         return scale.compu_const
 
     def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
-        return physical_value in self.get_valid_physical_values()
+        return any(x.compu_const == physical_value for x in self.get_scales())
 
     def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
         return any(
-            self.__is_internal_in_scale(internal_value, scale) for scale in self._get_scales())
-
-    def get_valid_physical_values(self) -> List[Optional[AtomicOdxType]]:
-        return [x.compu_const for x in self._get_scales()]
+            self.__is_internal_in_scale(internal_value, scale) for scale in self.get_scales())

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -174,6 +174,3 @@ class DataObjectProperty(DopBase):
 
     def is_valid_physical_value(self, physical_value):
         return self.compu_method.is_valid_physical_value(physical_value)
-
-    def get_valid_physical_values(self):
-        return self.compu_method.get_valid_physical_values()

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -957,6 +957,11 @@ class DiagLayer:
                 for gnr in self.global_negative_responses:
                     try:
                         decoded_gnr = gnr.decode(message)
+                        if not isinstance(decoded_gnr, dict):
+                            raise DecodeError(f"Expected the decoded value of a global "
+                                              f"negative response to be a dictionary, "
+                                              f"got {type(decoded_gnr)} for {self.short_name}")
+
                         decoded_messages.append(
                             Message(
                                 coded_message=message,

--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -69,6 +69,6 @@ class DiagnosticTroubleCode(IdentifiableElement):
         for sdg in self.sdgs:
             sdg._resolve_odxlinks(odxlinks)
 
-    def _resolve_snrefs(self, diag_layer: "DiagLayer"):
+    def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         for sdg in self.sdgs:
             sdg._resolve_snrefs(diag_layer)

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -193,6 +193,10 @@ class DiagService(IdentifiableElement):
                 f"The service {self.short_name} cannot decode the message {raw_message.hex()}")
         coding_object = coding_objects[0]
         param_dict = coding_object.decode(raw_message)
+        if not isinstance(param_dict, dict):
+            # if this happens, this is probably due to a bug in
+            # coding_object.decode()
+            raise RuntimeError(f"Expected a set of decoded parameters, got {type(param_dict)}")
         return Message(
             coded_message=raw_message,
             service=self,

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from .decodestate import DecodeState
 from .element import IdentifiableElement
 from .encodestate import EncodeState
 from .odxlink import OdxLinkDatabase, OdxLinkId
+from .odxtypes import ParameterValue
 from .specialdatagroup import SpecialDataGroup
 
 if TYPE_CHECKING:
@@ -52,11 +53,13 @@ class DopBase(IdentifiableElement):
     def is_visible(self) -> bool:
         return self.is_visible_raw in (None, True)
 
-    def convert_physical_to_bytes(self, physical_value, encode_state: EncodeState,
+    def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
                                   bit_position: int) -> bytes:
         """Convert the physical value into bytes."""
         raise NotImplementedError
 
-    def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
+    def convert_bytes_to_physical(self,
+                                  decode_state: DecodeState,
+                                  bit_position: int = 0) -> Tuple[ParameterValue, int]:
         """Extract the bytes from the PDU and convert them to the physical value."""
         raise NotImplementedError

--- a/odxtools/dynamiclengthfield.py
+++ b/odxtools/dynamiclengthfield.py
@@ -9,7 +9,7 @@ from .encodestate import EncodeState
 from .exceptions import odxrequire
 from .field import Field
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
-from .odxtypes import ParameterValueDict
+from .odxtypes import ParameterValue
 from .utils import dataclass_fields_asdict
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ class DynamicLengthField(Field):
 
     def convert_physical_to_bytes(
         self,
-        physical_value: List[ParameterValueDict],
+        physical_value: ParameterValue,
         encode_state: EncodeState,
         bit_position: int = 0,
     ) -> bytes:

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -6,10 +6,10 @@ from xml.etree import ElementTree
 
 from .decodestate import DecodeState
 from .encodestate import EncodeState
-from .exceptions import odxassert
+from .exceptions import EncodeError, odxassert, odxraise
 from .field import Field
 from .odxlink import OdxDocFragment
-from .odxtypes import ParameterValueDict
+from .odxtypes import ParameterValue
 from .utils import dataclass_fields_asdict
 
 
@@ -42,25 +42,22 @@ class EndOfPduField(Field):
 
     def convert_physical_to_bytes(
         self,
-        physical_value: ParameterValueDict,
+        physical_values: ParameterValue,
         encode_state: EncodeState,
         bit_position: int = 0,
     ) -> bytes:
         odxassert(
             bit_position == 0, "End of PDU field must be byte aligned. "
-            "Is there an error in reading the .odx?")
-        if isinstance(physical_value, dict):
-            # If the value is given as a dict, the End of PDU field behaves like the underlying structure.
-            return self.structure.convert_physical_to_bytes(physical_value, encode_state)
-        else:
-            odxassert(
-                isinstance(physical_value, list),
-                "The value of an End-of-PDU-field must be a list or a dict.")
-            # If the value is given as a list, each list element is a encoded seperately using the structure.
-            coded_rpc = b''
-            for value in physical_value:
-                coded_rpc += self.structure.convert_physical_to_bytes(value, encode_state)
-            return coded_rpc
+            "Is there an error in reading the .odx?", EncodeError)
+        if not isinstance(physical_values, list):
+            odxraise(
+                f"Expected a list of values for structure {self.short_name}, "
+                f"got {type(physical_values)}", EncodeError)
+
+        coded_message = b''
+        for value in physical_values:
+            coded_message += self.structure.convert_physical_to_bytes(value, encode_state)
+        return coded_message
 
     def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
         decode_state = copy(decode_state)

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -89,13 +89,6 @@ class CodedConstParameter(Parameter):
 
         return coded_val, cursor_position
 
-    def _as_dict(self):
-        d = super()._as_dict()
-        if self.bit_length is not None:
-            d["bit_length"] = self.bit_length
-        d["coded_value"] = hex(self.coded_value)
-        return d
-
     @property
     def _coded_value_str(self):
         if isinstance(self.coded_value, int):

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -2,10 +2,9 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from ..encodestate import EncodeState
 from ..decodestate import DecodeState
+from ..encodestate import EncodeState
 from ..odxtypes import ParameterValue
-
 from .parameter import Parameter, ParameterType
 
 

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from typing import Tuple
+
+from ..encodestate import EncodeState
+from ..decodestate import DecodeState
+from ..odxtypes import ParameterValue
 
 from .parameter import Parameter, ParameterType
 
@@ -19,8 +24,8 @@ class DynamicParameter(Parameter):
     def is_settable(self) -> bool:
         raise NotImplementedError(".is_settable for a DynamicParameter")
 
-    def get_coded_value_as_bytes(self):
+    def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         raise NotImplementedError("Encoding a DynamicParameter is not implemented yet.")
 
-    def decode_from_pdu(self, coded_message, default_byte_position=None):
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         raise NotImplementedError("Decoding a DynamicParameter is not implemented yet.")

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -6,6 +6,7 @@ from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import odxrequire
 from ..odxlink import OdxLinkDatabase, OdxLinkId
+from ..odxtypes import ParameterValue
 from .parameter import ParameterType
 from .parameterwithdop import ParameterWithDOP
 
@@ -65,5 +66,5 @@ class LengthKeyParameter(ParameterWithDOP):
     def encode_into_pdu(self, encode_state: EncodeState) -> bytes:
         return super().encode_into_pdu(encode_state)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         return super().decode_from_pdu(decode_state)

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Tuple
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import EncodeError
+from ..odxtypes import ParameterValue
 from .parameter import Parameter, ParameterType
 
 
@@ -37,7 +38,7 @@ class MatchingRequestParameter(Parameter):
                                                .request_byte_position:self.request_byte_position +
                                                self.byte_length]
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         byte_position = (
             self.byte_position if self.byte_position is not None else decode_state.cursor_position)
         bit_position = self.bit_position if self.bit_position is not None else 0

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from typing import Any, Tuple
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
@@ -17,7 +18,7 @@ class MatchingRequestParameter(Parameter):
         return "MATCHING-REQUEST-PARAM"
 
     @property
-    def bit_length(self):
+    def bit_length(self) -> int:
         return 8 * self.byte_length
 
     @property
@@ -28,7 +29,7 @@ class MatchingRequestParameter(Parameter):
     def is_settable(self) -> bool:
         return False
 
-    def get_coded_value_as_bytes(self, encode_state: EncodeState):
+    def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         if not encode_state.triggering_request:
             raise EncodeError(f"Parameter '{self.short_name}' is of matching request type,"
                               " but no original request has been specified.")
@@ -36,7 +37,7 @@ class MatchingRequestParameter(Parameter):
                                                .request_byte_position:self.request_byte_position +
                                                self.byte_length]
 
-    def decode_from_pdu(self, decode_state: DecodeState):
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
         byte_position = (
             self.byte_position if self.byte_position is not None else decode_state.cursor_position)
         bit_position = self.bit_position if self.bit_position is not None else 0

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -104,13 +104,6 @@ class NrcConstParameter(Parameter):
 
         return coded_value, cursor_position
 
-    def _as_dict(self):
-        d = super()._as_dict()
-        if self.bit_length is not None:
-            d["bit_length"] = self.bit_length
-        d["coded_values"] = self.coded_values
-        return d
-
     def get_description_of_valid_values(self) -> str:
         """return a human-understandable description of valid physical values"""
         return f"One of the constant internal values: {self.coded_values}"

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -180,18 +180,3 @@ class Parameter(NamedElement, abc.ABC):
             result_blob[byte_idx_rpc] |= new_data[byte_idx_val]
 
         return result_blob
-
-    def _as_dict(self) -> Dict[str, Any]:
-        """
-        Mostly for pretty printing purposes (specifically not for reconstructing the object)
-        """
-        d: Dict[str, Any] = {
-            "short_name": self.short_name,
-            "type": self.parameter_type,
-            "semantic": self.semantic
-        }
-        if self.byte_position is not None:
-            d["byte_position"] = self.byte_position
-        if self.bit_position is not None:
-            d["bit_position"] = self.bit_position
-        return d

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -9,6 +9,7 @@ from ..element import NamedElement
 from ..encodestate import EncodeState
 from ..exceptions import OdxWarning
 from ..odxlink import OdxLinkDatabase, OdxLinkId
+from ..odxtypes import ParameterValue
 from ..specialdatagroup import SpecialDataGroup
 
 if TYPE_CHECKING:
@@ -93,7 +94,7 @@ class Parameter(NamedElement, abc.ABC):
         pass
 
     @abc.abstractmethod
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         """Decode the parameter value from the coded message.
 
         If the parameter does have a byte position property, the coded bytes the parameter covers are extracted
@@ -180,11 +181,15 @@ class Parameter(NamedElement, abc.ABC):
 
         return result_blob
 
-    def _as_dict(self):
+    def _as_dict(self) -> Dict[str, Any]:
         """
         Mostly for pretty printing purposes (specifically not for reconstructing the object)
         """
-        d = {"short_name": self.short_name, "type": self.parameter_type, "semantic": self.semantic}
+        d: Dict[str, Any] = {
+            "short_name": self.short_name,
+            "type": self.parameter_type,
+            "semantic": self.semantic
+        }
         if self.byte_position is not None:
             d["byte_position"] = self.byte_position
         if self.bit_position is not None:

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -95,16 +95,3 @@ class ParameterWithDOP(Parameter):
             decode_state, bit_position=bit_position_int)
 
         return phys_val, cursor_position
-
-    def _as_dict(self):
-        d = super()._as_dict()
-        if self.dop is not None:
-            if self.bit_length is not None:
-                d["bit_length"] = self.bit_length
-            d["dop_ref"] = OdxLinkRef.from_id(self.dop.odx_id)
-        elif self.dop_ref is not None:
-            d["dop_ref"] = self.dop_ref
-        elif self.dop_snref is not None:
-            d["dop_snref"] = self.dop_snref
-
-        return d

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -8,8 +8,9 @@ from ..decodestate import DecodeState
 from ..dopbase import DopBase
 from ..dtcdop import DtcDop
 from ..encodestate import EncodeState
-from ..exceptions import odxassert, odxraise, odxrequire
+from ..exceptions import odxassert, odxrequire
 from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxtypes import ParameterValue
 from ..physicaltype import PhysicalType
 from .parameter import Parameter
 
@@ -57,11 +58,9 @@ class ParameterWithDOP(Parameter):
     def dop(self) -> DopBase:
         """may be a DataObjectProperty, a Structure or None"""
 
-        if self._dop is None:
-            odxraise("Specifying a data object property is mandatory but it could "
-                     "not be resolved")
-
-        return self._dop
+        return odxrequire(
+            self._dop, "Specifying a data object property is mandatory but it "
+            "could not be resolved")
 
     @property
     def bit_length(self):
@@ -84,7 +83,7 @@ class ParameterWithDOP(Parameter):
         return dop.convert_physical_to_bytes(
             physical_value, encode_state, bit_position=bit_position_int)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         decode_state = copy(decode_state)
         if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             decode_state.cursor_position = self.byte_position

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Tuple, cast
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError
+from ..odxtypes import ParameterValue
 from .parameter import Parameter, ParameterType
 
 
@@ -38,7 +39,7 @@ class ReservedParameter(Parameter):
         bit_position_int = self.bit_position if self.bit_position is not None else 0
         return (0).to_bytes((self.bit_length + bit_position_int + 7) // 8, "big")
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         byte_position = (
             self.byte_position if self.byte_position is not None else decode_state.cursor_position)
         bit_position_int = self.bit_position if self.bit_position is not None else 0
@@ -62,4 +63,4 @@ class ReservedParameter(Parameter):
                 stacklevel=1,
             )
 
-        return None, cursor_position
+        return cast(int, None), cursor_position

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from dataclasses import dataclass
+from typing import Any, Tuple
 
 from ..decodestate import DecodeState
+from ..encodestate import EncodeState
 from ..exceptions import DecodeError
 from .parameter import Parameter, ParameterType
 
@@ -32,11 +34,11 @@ class ReservedParameter(Parameter):
         # need to take the "bit_length_raw" detour...
         return self.bit_length_raw
 
-    def get_coded_value_as_bytes(self, encode_state):
+    def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         bit_position_int = self.bit_position if self.bit_position is not None else 0
         return (0).to_bytes((self.bit_length + bit_position_int + 7) // 8, "big")
 
-    def decode_from_pdu(self, decode_state: DecodeState):
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
         byte_position = (
             self.byte_position if self.byte_position is not None else decode_state.cursor_position)
         bit_position_int = self.bit_position if self.bit_position is not None else 0

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Tuple
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..odxlink import OdxLinkRef
+from ..odxtypes import ParameterValue
 from .parameter import Parameter, ParameterType
 
 
@@ -28,5 +29,5 @@ class TableEntryParameter(Parameter):
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         raise NotImplementedError("Decoding a TableKeyParameter is not implemented yet.")

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -2,9 +2,9 @@
 from dataclasses import dataclass
 from typing import Any, Tuple
 
-from ..odxlink import OdxLinkRef
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
+from ..odxlink import OdxLinkRef
 from .parameter import Parameter, ParameterType
 
 

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from typing import Any, Tuple
 
 from ..odxlink import OdxLinkRef
+from ..decodestate import DecodeState
+from ..encodestate import EncodeState
 from .parameter import Parameter, ParameterType
 
 
@@ -22,8 +25,8 @@ class TableEntryParameter(Parameter):
     def is_settable(self) -> bool:
         raise NotImplementedError("TableKeyParameter.is_settable is not implemented yet.")
 
-    def get_coded_value_as_bytes(self):
+    def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")
 
-    def decode_from_pdu(self, coded_message, default_byte_position=None):
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
         raise NotImplementedError("Decoding a TableKeyParameter is not implemented yet.")

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -6,6 +6,7 @@ from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, EncodeError, odxraise, odxrequire
 from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxtypes import ParameterValue
 from .parameter import Parameter, ParameterType
 
 if TYPE_CHECKING:
@@ -134,7 +135,7 @@ class TableKeyParameter(Parameter):
     def encode_into_pdu(self, encode_state: EncodeState) -> bytes:
         return super().encode_into_pdu(encode_state)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             cursor_position = self.byte_position
 

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -2,12 +2,13 @@
 import warnings
 from copy import copy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import EncodeError, OdxWarning, odxraise
 from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxtypes import ParameterValue
 from .parameter import Parameter, ParameterType
 from .tablekeyparameter import TableKeyParameter
 
@@ -129,7 +130,7 @@ class TableStructParameter(Parameter):
     def encode_into_pdu(self, encode_state: EncodeState) -> bytes:
         return super().encode_into_pdu(encode_state)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[Any, int]:
+    def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             next_pos = self.byte_position if self.byte_position is not None else 0
             decode_state = copy(decode_state)
@@ -158,4 +159,4 @@ class TableStructParameter(Parameter):
         else:
             # the table row associated with the key neither defines a
             # DOP not a structure -> ignore it
-            return (table_row.short_name, None), decode_state.cursor_position
+            return (table_row.short_name, cast(int, None)), decode_state.cursor_position

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -53,11 +53,11 @@ class TableStructParameter(Parameter):
         return self._table_key
 
     @property
-    def is_required(self):
+    def is_required(self) -> bool:
         return True
 
     @property
-    def is_settable(self):
+    def is_settable(self) -> bool:
         return True
 
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -38,7 +38,8 @@ class ValueParameter(ParameterWithDOP):
                 odxraise("Value parameters can only define a physical default "
                          "value if they use a simple DOP")
             base_data_type = dop.physical_type.base_data_type
-            self._physical_default_value = base_data_type.from_string(self.physical_default_value_raw)
+            self._physical_default_value = base_data_type.from_string(
+                self.physical_default_value_raw)
 
     @property
     def physical_default_value(self) -> Optional[AtomicOdxType]:
@@ -65,7 +66,3 @@ class ValueParameter(ParameterWithDOP):
         bit_position_int = self.bit_position if self.bit_position is not None else 0
         return dop.convert_physical_to_bytes(
             physical_value, encode_state=encode_state, bit_position=bit_position_int)
-
-    def get_valid_physical_values(self):
-        if isinstance(self.dop, DataObjectProperty):
-            return self.dop.get_valid_physical_values()

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -31,17 +31,14 @@ class ValueParameter(ParameterWithDOP):
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         super()._resolve_snrefs(diag_layer)
 
-        self._physical_default_value: Optional[AtomicOdxType]
-        pdvr = self.physical_default_value_raw
-        if pdvr is None:
-            self._physical_default_value = None
-            return
-
-        dop = odxrequire(self.dop)
-        if not isinstance(dop, DataObjectProperty):
-            odxraise("The type of PHYS-CONST parameters must be a simple DOP")
-        base_data_type = dop.physical_type.base_data_type
-        self._physical_default_value = base_data_type.from_string(pdvr)
+        self._physical_default_value: Optional[AtomicOdxType] = None
+        if self.physical_default_value_raw is not None:
+            dop = odxrequire(self.dop)
+            if not isinstance(dop, DataObjectProperty):
+                odxraise("Value parameters can only define a physical default "
+                         "value if they use a simple DOP")
+            base_data_type = dop.physical_type.base_data_type
+            self._physical_default_value = base_data_type.from_string(self.physical_default_value_raw)
 
     @property
     def physical_default_value(self) -> Optional[AtomicOdxType]:

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -30,7 +30,7 @@ class UnitGroup(NamedElement):
     unit_refs: List[OdxLinkRef]
     oid: Optional[str]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._units = NamedItemList[Unit]()
 
     @staticmethod

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -33,13 +33,13 @@ class UnitSpec:
     physical_dimensions: Union[NamedItemList[PhysicalDimension], List[PhysicalDimension]]
     sdgs: List[SpecialDataGroup]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.unit_groups = NamedItemList(self.unit_groups)
         self.units = NamedItemList(self.units)
         self.physical_dimensions = NamedItemList(self.physical_dimensions)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]):
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "UnitSpec":
 
         unit_groups = [
             UnitGroup.from_et(el, doc_frags) for el in et_element.iterfind("UNIT-GROUPS/UNIT-GROUP")


### PR DESCRIPTION
This is the third part of the quest for comprehensive type annotations. It is mainly concerned about the parameter classes, but as usual, it also contains a few drive-by fixes, namely the removal of the confusingly named and functionally unused method `DataObjectProperty.get_valid_physical_values()` and the removal of the unused `.as_dict()` methods of various classes.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)