### PR TITLE
Add type annotations, part 5

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1247,7 +1247,7 @@ somersault_env_datas = {
             is_visible_raw=None,
             byte_size=None,
             dtc_values=[],
-            parameters=[
+            parameters=NamedItemList([
                 ValueParameter(
                     short_name="flip_speed",
                     long_name="Flip Speed",
@@ -1272,7 +1272,7 @@ somersault_env_datas = {
                     bit_position=None,
                     sdgs=[],
                 ),
-            ],
+            ]),
         )
 }
 

--- a/odxtools/__init__.py
+++ b/odxtools/__init__.py
@@ -71,7 +71,7 @@ from .write_pdx_file import write_pdx_file
 __author__ = "Katrin Bauer"
 
 
-def _main():
+def _main() -> None:
     # Command line tool
     from .cli import main as _main
 

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from itertools import chain
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from xml.etree import ElementTree
 from zipfile import ZipFile
 
@@ -13,7 +13,7 @@ from .nameditemlist import NamedItemList, short_name_as_key
 from .odxlink import OdxLinkDatabase
 
 
-def version(v: str):
+def version(v: str) -> Tuple[int, ...]:
     return tuple(map(int, (v.split("."))))
 
 
@@ -135,13 +135,13 @@ class Database:
         return self._diag_layers
 
     @property
-    def diag_layer_containers(self):
+    def diag_layer_containers(self) -> NamedItemList[DiagLayerContainer]:
         return self._diag_layer_containers
 
     @diag_layer_containers.setter
-    def diag_layer_containers(self, value):
+    def diag_layer_containers(self, value: NamedItemList[DiagLayerContainer]) -> None:
         self._diag_layer_containers = value
 
     @property
-    def comparam_subsets(self):
+    def comparam_subsets(self) -> NamedItemList[ComparamSubset]:
         return self._comparam_subsets

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -15,7 +15,7 @@ from .element import IdentifiableElement
 from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, odxassert, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
-from .odxtypes import odxstr_to_bool
+from .odxtypes import AtomicOdxType, ParameterValue, odxstr_to_bool
 from .physicaltype import PhysicalType
 from .unit import Unit
 from .utils import dataclass_fields_asdict
@@ -99,7 +99,7 @@ class DataObjectProperty(DopBase):
         result.update(self.diag_coded_type._build_odxlinks())
         return result
 
-    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase):
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
         """Resolves the reference to the unit"""
         super()._resolve_odxlinks(odxlinks)
 
@@ -165,5 +165,5 @@ class DataObjectProperty(DopBase):
                 f"DOP {self.short_name} could not convert the coded value "
                 f" {repr(internal)} to physical type {self.physical_type.base_data_type}.")
 
-    def is_valid_physical_value(self, physical_value):
-        return self.compu_method.is_valid_physical_value(physical_value)
+    def is_valid_physical_value(self, physical_value: ParameterValue) -> bool:
+        return self.compu_method.is_valid_physical_value(cast(AtomicOdxType, physical_value))

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -40,17 +40,6 @@ class DiagDataDictionarySpec:
     unit_spec: Optional[UnitSpec]
     sdgs: List[SpecialDataGroup]
 
-    def __post_init__(self):
-        self._all_data_object_properties = NamedItemList(
-            chain(
-                self.data_object_props,
-                self.structures,
-                self.end_of_pdu_fields,
-                self.dynamic_length_fields,
-                self.dtc_dops,
-                self.tables,
-            ),)
-
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "DiagDataDictionarySpec":
@@ -220,7 +209,3 @@ class DiagDataDictionarySpec:
 
         if self.unit_spec is not None:
             self.unit_spec._resolve_snrefs(diag_layer)
-
-    @property
-    def all_data_object_properties(self):
-        return self._all_data_object_properties

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -350,7 +350,7 @@ class DiagLayer:
     #####
     # <value inheritance mechanism helpers>
     #####
-    def _get_parent_refs_sorted_by_priority(self, reverse=False) -> Iterable[ParentRef]:
+    def _get_parent_refs_sorted_by_priority(self, reverse: bool = False) -> Iterable[ParentRef]:
         return sorted(
             self.diag_layer_raw.parent_refs,
             key=lambda pr: pr.layer.variant_type.inheritance_priority,
@@ -444,10 +444,10 @@ class DiagLayer:
     def _compute_available_diag_comms(self, odxlinks: OdxLinkDatabase
                                      ) -> Iterable[Union[DiagService, SingleEcuJob]]:
 
-        def get_local_objects_fn(dl):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[Union[DiagService, SingleEcuJob]]:
             return dl._get_local_diag_comms(odxlinks)
 
-        def not_inherited_fn(parent_ref):
+        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
             return parent_ref.not_inherited_diag_comms
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -455,10 +455,10 @@ class DiagLayer:
     def _compute_available_global_neg_responses(self, odxlinks: OdxLinkDatabase) \
             -> Iterable[Response]:
 
-        def get_local_objects_fn(dl):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[Response]:
             return dl.diag_layer_raw.global_negative_responses
 
-        def not_inherited_fn(parent_ref):
+        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
             return parent_ref.not_inherited_global_neg_responses
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -469,7 +469,7 @@ class DiagLayer:
         exclude: Callable[["ParentRef"], List[str]],
     ) -> NamedItemList[TNamed]:
 
-        def get_local_objects_fn(dl: "DiagLayer"):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[TNamed]:
             if dl.diag_layer_raw.diag_data_dictionary_spec is None:
                 return []
             return include(dl.diag_layer_raw.diag_data_dictionary_spec)
@@ -479,40 +479,40 @@ class DiagLayer:
 
     def _compute_available_functional_classes(self) -> Iterable[FunctionalClass]:
 
-        def get_local_objects_fn(dl):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[FunctionalClass]:
             return dl.diag_layer_raw.functional_classes
 
-        def not_inherited_fn(parent_ref):
+        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_additional_audiences(self) -> Iterable[AdditionalAudience]:
 
-        def get_local_objects_fn(dl):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[AdditionalAudience]:
             return dl.diag_layer_raw.additional_audiences
 
-        def not_inherited_fn(parent_ref):
+        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_state_charts(self) -> Iterable[StateChart]:
 
-        def get_local_objects_fn(dl):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[StateChart]:
             return dl.diag_layer_raw.state_charts
 
-        def not_inherited_fn(parent_ref):
+        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
     def _compute_available_unit_groups(self) -> Iterable[UnitGroup]:
 
-        def get_local_objects_fn(dl):
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[UnitGroup]:
             return dl._get_local_unit_groups()
 
-        def not_inherited_fn(parent_ref):
+        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from itertools import chain
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -12,7 +12,7 @@ from .diaglayer import DiagLayer
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .specialdatagroup import SpecialDataGroup
 from .utils import dataclass_fields_asdict
 
@@ -82,7 +82,7 @@ class DiagLayerContainer(IdentifiableElement):
             sdgs=sdgs,
             **kwargs)
 
-    def _build_odxlinks(self):
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         if self.admin_data is not None:
@@ -137,7 +137,7 @@ class DiagLayerContainer(IdentifiableElement):
             ecu_variant._finalize_init(odxlinks)
 
     @property
-    def diag_layers(self):
+    def diag_layers(self) -> NamedItemList[DiagLayer]:
         return self._diag_layers
 
     def __getitem__(self, key: Union[int, str]) -> DiagLayer:

--- a/odxtools/dynamiclengthfield.py
+++ b/odxtools/dynamiclengthfield.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 from xml.etree import ElementTree
 
 from .decodestate import DecodeState
@@ -55,5 +55,7 @@ class DynamicLengthField(Field):
     ) -> bytes:
         raise NotImplementedError()
 
-    def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
+    def convert_bytes_to_physical(self,
+                                  decode_state: DecodeState,
+                                  bit_position: int = 0) -> Tuple[ParameterValue, int]:
         raise NotImplementedError()

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from copy import copy
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from xml.etree import ElementTree
 
 from .decodestate import DecodeState
@@ -59,7 +59,9 @@ class EndOfPduField(Field):
             coded_message += self.structure.convert_physical_to_bytes(value, encode_state)
         return coded_message
 
-    def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
+    def convert_bytes_to_physical(self,
+                                  decode_state: DecodeState,
+                                  bit_position: int = 0) -> Tuple[ParameterValue, int]:
         decode_state = copy(decode_state)
         cursor_position = decode_state.cursor_position
         byte_code = decode_state.coded_message

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -7,6 +7,7 @@ from .basicstructure import BasicStructure
 from .createsdgs import create_sdgs_from_et
 from .element import IdentifiableElement
 from .exceptions import odxrequire
+from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment
 from .odxtypes import odxstr_to_bool
 from .parameters.createanyparameter import create_any_parameter_from_et
@@ -18,10 +19,6 @@ class EnvironmentData(BasicStructure):
     """This class represents Environment Data that describes the circumstances in which the error occurred."""
 
     dtc_values: List[int]
-
-    def __init__(self, *, dtc_values: List[int], **kwargs):
-        super().__init__(**kwargs)
-        self.dtc_values = dtc_values
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
@@ -44,7 +41,7 @@ class EnvironmentData(BasicStructure):
         return EnvironmentData(
             sdgs=sdgs,
             is_visible_raw=is_visible_raw,
-            parameters=parameters,
+            parameters=NamedItemList(parameters),
             byte_size=byte_size,
             dtc_values=dtc_values,
             **kwargs)

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from xml.etree import ElementTree
 
 from .createsdgs import create_sdgs_from_et
@@ -11,7 +11,7 @@ from .encodestate import EncodeState
 from .environmentdata import EnvironmentData
 from .exceptions import DecodeError, EncodeError, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
-from .odxtypes import odxstr_to_bool
+from .odxtypes import ParameterValue, odxstr_to_bool
 from .utils import dataclass_fields_asdict
 
 if TYPE_CHECKING:
@@ -93,7 +93,7 @@ class EnvironmentDataDescription(DopBase):
             for ed in self.env_datas:
                 ed._resolve_snrefs(diag_layer)
 
-    def convert_physical_to_bytes(self, physical_value, encode_state: EncodeState,
+    def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
                                   bit_position: int) -> bytes:
         """Convert the physical value into bytes.
 
@@ -102,7 +102,9 @@ class EnvironmentDataDescription(DopBase):
         """
         raise EncodeError("EnvironmentDataDescription DOPs cannot be encoded or decoded")
 
-    def convert_bytes_to_physical(self, decode_state: DecodeState, bit_position: int = 0):
+    def convert_bytes_to_physical(self,
+                                  decode_state: DecodeState,
+                                  bit_position: int = 0) -> Tuple[ParameterValue, int]:
         """Extract the bytes from the PDU and convert them to the physical value.
 
         Since environmental data is supposed to never appear on the

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -69,9 +69,6 @@ class Field(DopBase):
     def get_static_bit_length(self) -> Optional[int]:
         return None
 
-    def convert_physical_to_internal(self, physical_value):
-        return self.structure.convert_physical_to_internal(physical_value)
-
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
         """Recursively resolve any odxlinks references"""
         if self.structure_ref is not None:

--- a/odxtools/load_file.py
+++ b/odxtools/load_file.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MIT
+from .database import Database
 from .load_odx_d_file import load_odx_d_file
 from .load_pdx_file import load_pdx_file
 
 
-def load_file(file_name: str):
+def load_file(file_name: str) -> Database:
     if file_name.lower().endswith(".pdx"):
         return load_pdx_file(file_name)
     elif file_name.lower().endswith(".odx-d"):

--- a/odxtools/load_odx_d_file.py
+++ b/odxtools/load_odx_d_file.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: MIT
 from .database import Database
-from .globals import logger
 
 
-def load_odx_d_file(odx_d_file_name: str):
-    container = Database(odx_d_file_name=odx_d_file_name)
-    logger.info(f"--- --- --- Done with parsing --- --- ---")
-    return container
+def load_odx_d_file(odx_d_file_name: str) -> Database:
+    return Database(odx_d_file_name=odx_d_file_name)

--- a/odxtools/load_pdx_file.py
+++ b/odxtools/load_pdx_file.py
@@ -2,11 +2,7 @@
 from zipfile import ZipFile
 
 from .database import Database
-from .globals import logger
 
 
-def load_pdx_file(pdx_file: str):
-    u = ZipFile(pdx_file)
-    container = Database(pdx_zip=u)
-    logger.info(f"--- --- --- Done with parsing --- --- ---")
-    return container
+def load_pdx_file(pdx_file: str) -> Database:
+    return Database(pdx_zip=ZipFile(pdx_file))

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .basicstructure import BasicStructure
+from .odxtypes import ParameterValue
 from .parameters.matchingrequestparameter import MatchingRequestParameter
 
 
@@ -10,7 +11,7 @@ from .parameters.matchingrequestparameter import MatchingRequestParameter
 class Response(BasicStructure):
     response_type: str  # "POS-RESPONSE" or "NEG-RESPONSE"
 
-    def encode(self, coded_request: Optional[bytes] = None, **params) -> bytes:
+    def encode(self, coded_request: Optional[bytes] = None, **params: ParameterValue) -> bytes:
         if coded_request is not None:
             # Extract MATCHING-REQUEST-PARAMs from the coded
             # request. TODO: this should be done by

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -293,11 +293,6 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         self.assertEqual(len(ddds.structures), 0)
         self.assertEqual(len(ddds.end_of_pdu_fields), 0)
 
-        self.assertEqual({x.short_name
-                          for x in ddds.all_data_object_properties},
-                         {x.short_name
-                          for x in (dtc_dop, dop_1, dop_2, table)})
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -12,7 +12,7 @@ odxdb = load_pdx_file("./examples/somersault.pdx")
 
 # use the diag layer container's document fragments as the default for
 # resolving references
-container_doc_frags = odxdb.diag_layer_containers.somersault.odx_id.doc_fragments
+container_doc_frags = odxdb.diag_layer_containers["somersault"].odx_id.doc_fragments
 
 
 class TestStrictMode(unittest.TestCase):


### PR DESCRIPTION
After this, `mypy --disallow-untyped-defs` does not complain about anything of the "core" odxtools anymore. To do: The CLI tools, unit tests and examples.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)