### PR TITLE
Get ready for release

### DIFF
--- a/odxtools/message.py
+++ b/odxtools/message.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
+from deprecation import deprecated
+
 from .odxtypes import ParameterValue, ParameterValueDict
 
 if TYPE_CHECKING:
@@ -27,3 +29,8 @@ class Message:
 
     def __getitem__(self, key: str) -> ParameterValue:
         return self.param_dict[key]
+
+    @property
+    @deprecated("use .coding_object")
+    def structure(self) -> Union["Request", "Response"]:
+        return self.coding_object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ exclude = [
 ]
 
 ignore_missing_imports = true
+disallow_untyped_defs = true
 
 [tool.ruff]
 select = [


### PR DESCRIPTION
This PR enables the `--disallow-untyped-defs` mypy option by default, and adds back the `Message.structure` attribute as a deprecated alias for `Message.coding_object` (this should significantly reduce the pain of upgrading from an older version).

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)