### PR TITLE
NamedItemList: make tab completion for NamedItemList work again

### DIFF
--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -2,8 +2,8 @@
 import abc
 from collections import OrderedDict
 from keyword import iskeyword
-from typing import (Callable, Collection, Generic, Iterable, Iterator, List, Optional, Protocol,
-                    Tuple, TypeVar, Union, cast, overload, runtime_checkable)
+from typing import (Any, Callable, Collection, Dict, Generic, Iterable, Iterator, List, Optional,
+                    Protocol, Tuple, TypeVar, Union, cast, overload, runtime_checkable)
 
 from .exceptions import odxraise
 
@@ -101,6 +101,11 @@ class ItemAttributeList(Generic[T]):
 
     def __len__(self) -> int:
         return len(self._item_list)
+
+    def __dir__(self) -> Dict[str, Any]:
+        result = dict(self.__dict__)
+        result.update(self._item_dict)
+        return result
 
     @overload
     def __getitem__(self, key: int) -> T:


### PR DESCRIPTION
it turns out that an *explicit* list with all possibilities is required for the REPL tab completion code to show the list of all possibilities (duh!). (The `__getattr__()` method is obviously implicit, but we still need it to keep mypy happy...)

note that this change doesn't have an effect on scripts because tab completion is a purely interactive thing.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)