### PR TITLE
Split find into find and decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ send to/received from ECUs in an pythonic manner.
   - [The `browse` subcommand](#the-browse-subcommand)
   - [The `snoop` subcommand](#the-snoop-subcommand)
   - [The `find` subcommand](#the-find-subcommand)
+  - [The `decode` subcommand](#the-decode-subcommand)
 - [Testing](#testing)
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
@@ -292,7 +293,8 @@ positional arguments:
     list                Print a summary of automotive diagnostic files.
     browse              Interactively browse the content of automotive diagnostic files.
     snoop               Live decoding of a diagnostic session.
-    find                Find & display services by hex-data, or name, can also decodes requests.
+    find                Find & display services by their name
+    decode              Decode hex-data to service-name & optionally its parameters 
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -495,58 +497,45 @@ Tester: do_forward_flips(forward_soberness_check=18, num_flips=50)
 ### The `find` subcommand
 
 The `find` subcommand can be used to find a service and its associated 
-information by either a hex request, or partial name via cli. 
-
-In addition, it can also decode a hex request and display its parameters 
-mapped to a service. 
+information by a partial name via cli. 
 
 ```bash
 $ odxtools find -h
-usage: odxtools find [-h] [-v VARIANT [VARIANT ...]] [-d [DATA ...]] [-D [DECODE ...]] [-s [SERVICES ...]] [-nd]
-                     [-ro]
-                     PDX_FILE
+usage: odxtools find [-h] [-v VARIANT] -s [SERVICES ...] [-nd] [-ro] PDX_FILE
 
-Find & print services by hex-data, or name, can also decodes requests
+Find & print services by name
 
 Examples:
-  For displaying the service associated with the request 10 01:
-    odxtools find ./path/to/database.pdx -d 10 01
-  For displaying the service associated with the request 10 01, and decoding it:
-    odxtools find ./path/to/database.pdx -D 10 01
   For displaying the services associated with the partial name 'Reset' without details:
     odxtools find ./path/to/database.pdx -s "Reset" --no-details
   For more information use:
     odxtools find -h
 
 positional arguments:
-  PDX_FILE              path to the .pdx file
+  PDX_FILE              Location of the .pdx file
 
 options:
   -h, --help            show this help message and exit
-  -v VARIANT [VARIANT ...], --variants VARIANT [VARIANT ...]
+  -v VARIANT, --variants VARIANT
                         Specifies which ecu variants should be included.
-  -d [DATA ...], --data [DATA ...]
-                        Print a list of diagnostic services associated with the hex request.
-  -D [DECODE ...], --decode [DECODE ...]
-                        Print a list of diagnostic services associated with the hex request and decode the request.
   -s [SERVICES ...], --service-names [SERVICES ...]
                         Print a list of diagnostic services partially matching given service names
   -nd, --no-details     Don't show all service details
   -ro, --relaxed-output
                         Relax output formatting rules (allow unknown bitlengths for ascii representation)
 ```
-Example: Find diagnostic services associated with the hex request `10 00`
+
+Example: Find diagnostic services with the name `session_start`
 
 ```bash
-$ odxtools find $BASE_DIR/odxtools/examples/somersault.pdx -D 10 00
-
+$ odxtools find examples/somersault.pdx -s session_start
 
 =====================================
 somersault_lazy, somersault_assiduous
 =====================================
 
 
- session_start <ID: somersault.service.session_start>
+ session_start <ID: OdxLinkId('somersault.service.session_start')>
   Message format of a request:
            7     6     5     4     3     2     1     0  
         +-----+-----+-----+-----+-----+-----+-----+-----+
@@ -554,8 +543,8 @@ somersault_lazy, somersault_assiduous
         +-----+-----+-----+-----+-----+-----+-----+-----+
       1 | id (8 bits)                                   |
         +-----+-----+-----+-----+-----+-----+-----+-----+
-   Parameter(short_name='sid', type='CODED-CONST', semantic=None, byte_position=0, bit_length=8, coded_value='0x10')
-   Parameter(short_name='id', type='CODED-CONST', semantic=None, byte_position=1, bit_length=8, coded_value='0x0')
+   CodedConstParameter(short_name='sid', long_name=None, description=None, byte_position=0, bit_position=None, semantic=None, sdgs=[], diag_coded_type=StandardLengthType(base_data_type=<DataType.A_UINT32: 'A_UINT32'>, base_type_encoding=None, is_highlow_byte_order_raw=None, bit_length=8, bit_mask=None, is_condensed_raw=None), coded_value=16)
+   CodedConstParameter(short_name='id', long_name=None, description=None, byte_position=1, bit_position=None, semantic=None, sdgs=[], diag_coded_type=StandardLengthType(base_data_type=<DataType.A_UINT32: 'A_UINT32'>, base_type_encoding=None, is_highlow_byte_order_raw=None, bit_length=8, bit_mask=None, is_condensed_raw=None), coded_value=0)
   Number of positive responses: 1
   Message format of a positive response:
            7     6     5     4     3     2     1     0  
@@ -564,9 +553,8 @@ somersault_lazy, somersault_assiduous
         +-----+-----+-----+-----+-----+-----+-----+-----+
       1 | can_do_backward_flips (8 bits)                |
         +-----+-----+-----+-----+-----+-----+-----+-----+
-   Parameter(short_name='sid', type='CODED-CONST', semantic=None, byte_position=0, bit_length=8, coded_value='0x50')
-   Parameter(short_name='can_do_backward_flips', type='VALUE', semantic=None, byte_position=1, bit_length=8, dop_ref='somersault.DOP.boolean')
-    DataObjectProperty('boolean', category='TEXTTABLE', internal_type='A_UINT32', physical_type='A_UNICODE2STRING')
+   CodedConstParameter(short_name='sid', long_name=None, description=None, byte_position=0, bit_position=None, semantic=None, sdgs=[], diag_coded_type=StandardLengthType(base_data_type=<DataType.A_UINT32: 'A_UINT32'>, base_type_encoding=None, is_highlow_byte_order_raw=None, bit_length=8, bit_mask=None, is_condensed_raw=None), coded_value=80)
+   ValueParameter(short_name='can_do_backward_flips', long_name=None, description=None, byte_position=1, bit_position=None, semantic=None, sdgs=[], dop_ref=OdxLinkRef(ref_id='somersault.DOP.boolean', ref_docs=[OdxDocFragment(doc_name='somersault', doc_type='CONTAINER'), OdxDocFragment(doc_name='somersault', doc_type='LAYER')]), dop_snref=None, physical_default_value_raw=None)
   Number of negative responses: 1
   Message format of a negative response:
            7     6     5     4     3     2     1     0  
@@ -577,19 +565,59 @@ somersault_lazy, somersault_assiduous
         +-----+-----+-----+-----+-----+-----+-----+-----+
       2 | response_code (8 bits)                        |
         +-----+-----+-----+-----+-----+-----+-----+-----+
-   Parameter(short_name='sid', type='CODED-CONST', semantic=None, byte_position=0, bit_length=8, coded_value='0x7f')
-   Parameter(short_name='rq_sid', type='MATCHING-REQUEST-PARAM', semantic=None, byte_position=1)
-    Request byte position = 0, byte length = 1
-   Parameter(short_name='response_code', type='VALUE', semantic=None, byte_position=2, bit_length=8, dop_ref='somersault.DOP.error_code')
-    DataObjectProperty('error_code', category='IDENTICAL', internal_type='A_UINT32', physical_type='A_UINT32')
-
-Decoded Request('start_session'):
-	sid: 16
-	id: 0
+   CodedConstParameter(short_name='sid', long_name=None, description=None, byte_position=0, bit_position=None, semantic=None, sdgs=[], diag_coded_type=StandardLengthType(base_data_type=<DataType.A_UINT32: 'A_UINT32'>, base_type_encoding=None, is_highlow_byte_order_raw=None, bit_length=8, bit_mask=None, is_condensed_raw=None), coded_value=127)
+   MatchingRequestParameter(short_name='rq_sid', long_name=None, description=None, byte_position=1, bit_position=None, semantic=None, sdgs=[], request_byte_position=0, byte_length=1)
+   ValueParameter(short_name='response_code', long_name=None, description=None, byte_position=2, bit_position=None, semantic=None, sdgs=[], dop_ref=OdxLinkRef(ref_id='somersault.DOP.error_code', ref_docs=[OdxDocFragment(doc_name='somersault', doc_type='CONTAINER'), OdxDocFragment(doc_name='somersault', doc_type='LAYER')]), dop_snref=None, physical_default_value_raw=None)
 ```
 
-`odxtools find $BASE_DIR/odxtools/examples/somersault.pdx -d 10 00` would display the same information, 
-without the decoded request, and `-s <name>` can be used to find a service by partial name.
+### The `decode` subcommand
+
+The `decode` subcommand can be used to decode hex-data to a service, and its associated
+parameters.
+
+```bash
+$ odxtools decode -h
+usage: odxtools decode [-h] [-v VARIANT] -d DATA [-D] PDX_FILE
+
+Decode request by hex-data
+
+Examples:
+  For displaying the service associated with the request 10 01 & decoding it:
+    odxtools decode ./path/to/database.pdx -D -d '10 01'
+  For displaying the service associated with the request 10 01, without decoding it:
+    odxtools decode ./path/to/database.pdx -d '10 01'
+  For more information use:
+    odxtools decode -h
+
+positional arguments:
+  PDX_FILE              Location of the .pdx file
+
+options:
+  -h, --help            show this help message and exit
+  -v VARIANT, --variants VARIANT
+                        Specifies which ecu variants should be included.
+  -d DATA, --data DATA  Specify data of hex request
+  -D, --decode          Decode the given hex data
+```
+
+Example: Decode diagnostic services with the request `10 00`
+
+```bash
+$ odxtools decode examples/somersault.pdx -d '10 00'
+Binary data: 10 00
+Decoded by service 'session_start' (decoding ECUs: somersault_lazy, somersault_assiduous)
+```
+
+Example: Decode diagnostic services with the request `10 00`, and parameters
+
+```bash
+$ odxtools decode examples/somersault.pdx -d '10 00' -D
+Binary data: 10 00
+Decoded by service 'session_start' (decoding ECUs: somersault_lazy, somersault_assiduous)
+Decoded data:
+sid=16 (0x10)
+id=0 (0x0)
+```
 
 ## Testing
 

--- a/odxtools/cli/decode.py
+++ b/odxtools/cli/decode.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MIT
+import argparse
+import re
+from typing import Dict, List, Optional
+
+from ..database import Database
+from ..diagservice import DiagService
+from ..exceptions import odxraise
+from ..odxtypes import ParameterValue
+from ..singleecujob import SingleEcuJob
+from . import _parser_utils
+
+# name of the tool
+_odxtools_tool_name_ = "decode"
+
+
+def get_display_value(v: ParameterValue) -> str:
+    if isinstance(v, bytes):
+        return v.hex(" ")
+    elif isinstance(v, int):
+        return f"{v} (0x{v:x})"
+    else:
+        return str(v)
+
+
+def print_summary(
+    odxdb: Database,
+    ecu_variants: Optional[List[str]] = None,
+    data: bytes = b'',
+    decode: bool = False,
+) -> None:
+    ecu_names = ecu_variants if ecu_variants else [ecu.short_name for ecu in odxdb.ecus]
+    services: Dict[DiagService, List[str]] = {}
+    for ecu_name in ecu_names:
+        ecu = odxdb.ecus[ecu_name]
+        if not ecu:
+            print(f"The ecu variant '{ecu_name}' could not be found!")
+            continue
+        if data:
+            found_services = ecu._find_services_for_uds(data)
+            for found_service in found_services:
+                ecu_names = services.get(found_service, [])
+                ecu_names.append(ecu_name)
+                services[found_service] = ecu_names
+
+    print(f"Binary data: {data.hex(' ')}")
+    for service, ecu_names in services.items():
+        if isinstance(service, DiagService):
+            print(
+                f"Decoded by service '{service.short_name}' (decoding ECUs: {', '.join(ecu_names)})"
+            )
+        elif isinstance(service, SingleEcuJob):
+            print(
+                f"Decoded by single ecu job '{service.short_name}' (decoding ECUs: {', '.join(ecu_names)})"
+            )
+        else:
+            print(f"Decoded by unknown diagnostic communication: '{service.short_name}' "
+                  f"(decoding ECUs: {', '.join(ecu_names)})")
+
+        if decode:
+            if data is None:
+                odxraise("Data is required for decoding")
+
+            decoded = service.decode_message(data)
+            print(f"Decoded data:")
+            for param_name, param_value in decoded.param_dict.items():
+                print(f"  {param_name}={get_display_value(param_value)}")
+
+
+def add_subparser(subparsers: "argparse._SubParsersAction") -> None:
+    parser = subparsers.add_parser(
+        "decode",
+        description="\n".join([
+            "Decode request by hex-data",
+            "",
+            "Examples:",
+            "  For displaying the service associated with the request 10 01 & decoding it:",
+            "    odxtools decode ./path/to/database.pdx -D -d '10 01'",
+            "  For displaying the service associated with the request 10 01, without decoding it:",
+            "    odxtools decode ./path/to/database.pdx -d '10 01'",
+            "  For more information use:",
+            "    odxtools decode -h",
+        ]),
+        help="Find & print service by hex-data. Can also decode the hex-data to into their named parameters.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    _parser_utils.add_pdx_argument(parser)
+
+    parser.add_argument(
+        "-v",
+        "--variants",
+        nargs=1,
+        metavar="VARIANT",
+        required=False,
+        help="Specifies which ecu variants should be included.",
+        default="all",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--data",
+        metavar="DATA",
+        required=True,
+        help="Specify data of hex request",
+    )
+
+    parser.add_argument(
+        "-D",
+        "--decode",
+        action="store_true",
+        required=False,
+        help="Decode the given hex data",
+    )
+
+
+def hex_to_binary(data_str: str) -> bytes:
+    return bytes.fromhex(data_str)
+
+
+def run(args: argparse.Namespace) -> None:
+    data = bytes.fromhex(re.sub('[^0-9a-fA-F]', '', args.data))
+    odxdb = _parser_utils.load_file(args)
+    variants = args.variants
+
+    print_summary(
+        odxdb,
+        ecu_variants=None if variants == "all" else variants,
+        data=data,
+        decode=args.decode,
+    )

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional
 
 from ..database import Database
 from ..diagservice import DiagService
-from ..exceptions import odxraise
 from ..odxtypes import ParameterValue
 from ..singleecujob import SingleEcuJob
 from . import _parser_utils
+from ._print_utils import print_diagnostic_service
 
 # name of the tool
 _odxtools_tool_name_ = "find"
@@ -22,15 +22,11 @@ def get_display_value(v: ParameterValue) -> str:
         return str(v)
 
 
-def print_summary(
-    odxdb: Database,
-    ecu_variants: Optional[List[str]] = None,
-    data: bytes = b'',
-    service_names: Optional[List[str]] = None,
-    decode: bool = False,
-    print_params: bool = False,
-    allow_unknown_bit_lengths: bool = False,
-) -> None:
+def print_summary(odxdb: Database,
+                  service_names: List[str],
+                  ecu_variants: Optional[List[str]] = None,
+                  allow_unknown_bit_lengths: bool = False,
+                  print_params: bool = False) -> None:
     ecu_names = ecu_variants if ecu_variants else [ecu.short_name for ecu in odxdb.ecus]
     services: Dict[DiagService, List[str]] = {}
     for ecu_name in ecu_names:
@@ -38,12 +34,6 @@ def print_summary(
         if not ecu:
             print(f"The ecu variant '{ecu_name}' could not be found!")
             continue
-        if data:
-            found_services = ecu._find_services_for_uds(data)
-            for found_service in found_services:
-                ecu_names = services.get(found_service, [])
-                ecu_names.append(ecu_name)
-                services[found_service] = ecu_names
 
         if service_names:
             for service_name_search in service_names:
@@ -53,41 +43,34 @@ def print_summary(
                         ecu_names.append(ecu_name)
                         services[service] = ecu_names
 
-    print(f"Binary data: {data.hex(' ')}")
     for service, ecu_names in services.items():
+        display_names = ", ".join(ecu_names)
+        filler = str.ljust("", len(display_names), "=")
+        print(f"\n{filler}")
+        print(f"{', '.join(ecu_names)}")
+        print(f"{filler}\n\n")
         if isinstance(service, DiagService):
-            print(
-                f"Decoded by service '{service.short_name}' (decoding ECUs: {', '.join(ecu_names)})"
+            print_diagnostic_service(
+                service,
+                print_params=print_params,
+                allow_unknown_bit_lengths=allow_unknown_bit_lengths,
+                print_pre_condition_states=True,
+                print_state_transitions=True,
+                print_audiences=True,
             )
         elif isinstance(service, SingleEcuJob):
-            print(
-                f"Decoded by single ecu job '{service.short_name}' (decoding ECUs: {', '.join(ecu_names)})"
-            )
+            print(f"SingleEcuJob: {service.odx_id}")
         else:
-            print(f"Decoded by unknown diagnostic communication: '{service.short_name}' "
-                  f"(decoding ECUs: {', '.join(ecu_names)})")
-
-        if decode:
-            if data is None:
-                odxraise("Data is required for decoding")
-
-            decoded = service.decode_message(data)
-            print(f"Decoded data:")
-            for param_name, param_value in decoded.param_dict.items():
-                print(f"  {param_name}={get_display_value(param_value)}")
+            print(f"Unknown service: {service}")
 
 
 def add_subparser(subparsers: "argparse._SubParsersAction") -> None:
     parser = subparsers.add_parser(
         "find",
         description="\n".join([
-            "Find & print services by hex-data, or name, can also decodes requests",
+            "Find & print services by name",
             "",
             "Examples:",
-            "  For displaying the service associated with the request 10 01:",
-            "    odxtools find ./path/to/database.pdx -d 10 01",
-            "  For displaying the service associated with the request 10 01, and decoding it:",
-            "    odxtools find ./path/to/database.pdx -D 10 01",
             "  For displaying the services associated with the partial name 'Reset' without details:",
             '    odxtools find ./path/to/database.pdx -s "Reset" --no-details',
             "  For more information use:",
@@ -109,38 +92,19 @@ def add_subparser(subparsers: "argparse._SubParsersAction") -> None:
     )
 
     parser.add_argument(
-        "-d",
-        "--data",
-        nargs=1,
-        default=None,
-        metavar="DATA",
-        required=True,
-        help="Print a list of diagnostic services associated with the hex request.",
-    )
-
-    parser.add_argument(
-        "-D",
-        "--decode",
-        default=False,
-        action="store_true",
-        required=False,
-        help="Decode the specified hex request.",
-    )
-
-    parser.add_argument(
         "-s",
         "--service-names",
         nargs="*",
         default=None,
         metavar="SERVICES",
-        required=False,
+        required=True,
         help="Print a list of diagnostic services partially matching given service names",
     )
 
     parser.add_argument(
         "-nd",
         "--no-details",
-        action="store_false",
+        action="store_true",
         required=False,
         help="Don't show all service details",
     )
@@ -154,22 +118,14 @@ def add_subparser(subparsers: "argparse._SubParsersAction") -> None:
     )
 
 
-def hex_to_binary(data_str: str) -> bytes:
-    return bytes.fromhex(data_str)
-
-
 def run(args: argparse.Namespace) -> None:
     odxdb = _parser_utils.load_file(args)
     variants = args.variants
-    data = bytes.fromhex(args.data[0])
-    decode = args.decode
 
     print_summary(
         odxdb,
         ecu_variants=None if variants == "all" else variants,
-        data=data,
-        decode=decode,
         service_names=args.service_names,
-        print_params=args.no_details,
+        print_params=not args.no_details,
         allow_unknown_bit_lengths=args.relaxed_output,
     )

--- a/odxtools/cli/main.py
+++ b/odxtools/cli/main.py
@@ -9,7 +9,7 @@ from .dummy_sub_parser import DummyTool
 # import the tool modules which can be loaded. if a tool
 # can't be loaded, add a dummy one
 tool_modules: List[Any] = []
-for tool_name in ["list", "browse", "snoop", "find"]:
+for tool_name in ["list", "browse", "snoop", "find", "decode"]:
     try:
         tool_modules.append(importlib.import_module(f".{tool_name}", package="odxtools.cli"))
     except Exception as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import unittest
 from argparse import Namespace
 from typing import List, Optional
 
+import odxtools.cli.decode as decode
 import odxtools.cli.find as find
 import odxtools.cli.list as list_tool
 
@@ -37,21 +38,29 @@ class UtilFunctions:
         list_tool.run(list_args)
 
     @staticmethod
-    def run_find_tool(data: str,
+    def run_decode_tool(
+        data: str,
+        decode_data: bool = False,
+        path_to_pdx_file: str = "./examples/somersault.pdx",
+        ecu_variants: Optional[List[str]] = None,
+    ) -> None:
+        decode_args = Namespace(
+            pdx_file=path_to_pdx_file, variants=ecu_variants, data=data, decode=decode_data)
+
+        decode.run(decode_args)
+
+    @staticmethod
+    def run_find_tool(service_names: List[str],
                       path_to_pdx_file: str = "./examples/somersault.pdx",
                       ecu_variants: Optional[List[str]] = None,
-                      decode: bool = False,
-                      ecu_services: Optional[List[str]] = None,
-                      no_details: bool = True,
-                      relaxed_output: bool = False) -> None:
+                      allow_unknown_bit_lengths: bool = False,
+                      no_details: bool = False) -> None:
         find_args = Namespace(
             pdx_file=path_to_pdx_file,
             variants=ecu_variants,
-            data=[data],
-            decode=decode,
-            service_names=ecu_services,
-            no_details=no_details,
-            relaxed_output=relaxed_output)
+            service_names=service_names,
+            relaxed_output=allow_unknown_bit_lengths,
+            no_details=no_details)
 
         find.run(find_args)
 
@@ -68,14 +77,19 @@ class TestCommandLineTools(unittest.TestCase):
         UtilFunctions.run_list_tool(print_all=True)
         UtilFunctions.run_list_tool(ecu_services=["session_start"])
 
-    def test_find_tool(self) -> None:
+    def test_decode_tool(self) -> None:
 
-        UtilFunctions.run_find_tool(data="3E00", ecu_services=["session_start"])
-        UtilFunctions.run_find_tool(data="3e00", ecu_services=["session_start"], no_details=False)
-        UtilFunctions.run_find_tool(data="3E 00")
-        UtilFunctions.run_find_tool(data="3E 00", ecu_variants=["somersault_lazy"])
-        UtilFunctions.run_find_tool(data="3E 00", decode=True)
-        UtilFunctions.run_find_tool(data="3E 00", decode=True, relaxed_output=True)
+        UtilFunctions.run_decode_tool(data="3E00")
+        UtilFunctions.run_decode_tool(data="3e00")
+        UtilFunctions.run_decode_tool(data="3E 00", decode_data=True)
+        UtilFunctions.run_decode_tool(data="3E 00", ecu_variants=["somersault_lazy"])
+        UtilFunctions.run_decode_tool(data="3E 00")
+
+    def test_find_tool(self) -> None:
+        UtilFunctions.run_find_tool(service_names=["headstand"])
+        UtilFunctions.run_find_tool(service_names=["headstand"], allow_unknown_bit_lengths=True)
+        UtilFunctions.run_find_tool(
+            service_names=["headstand"], allow_unknown_bit_lengths=True, no_details=True)
 
     @unittest.skipIf(import_failed, "import of PyInquirer failed")
     def test_browse_tool(self) -> None:


### PR DESCRIPTION
Fix issue with find command requiring data, by splitting the decode and find (by service name) functionalities
into separate commands.