### PR TITLE
workflows: update the "bleeding edge" python version to 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Setup up YaPF formatting linter
         run: |
@@ -38,7 +38,7 @@ jobs:
       matrix:
         # restrict the matrix to the oldest and the latest Python
         # version being supported by odxtools
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         # restrict the matrix to the oldest and the latest Python
         # version being supported by odxtools
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
         # due to the slow windows runners, we refrain from testing every python
         # version on windows-latest


### PR DESCRIPTION
Python 3.12 has been released about a month ago. It would be nicer to increase the minimum required version to 3.10, but that has to wait at least until Ubuntu 20.04 falls out of support...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)