### PR TITLE
DiagDataDictionarySpec: re-introduce the all_data_object_properties attribute

### DIFF
--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -8,6 +8,7 @@ from .basicstructure import BasicStructure
 from .createanystructure import create_any_structure_from_et
 from .createsdgs import create_sdgs_from_et
 from .dataobjectproperty import DataObjectProperty
+from .dopbase import DopBase
 from .dtcdop import DtcDop
 from .dynamiclengthfield import DynamicLengthField
 from .endofpdufield import EndOfPduField
@@ -39,6 +40,19 @@ class DiagDataDictionarySpec:
     muxs: NamedItemList[Multiplexer]
     unit_spec: Optional[UnitSpec]
     sdgs: List[SpecialDataGroup]
+
+    def __post_init__(self) -> None:
+        self._all_data_object_properties: NamedItemList[DopBase] = NamedItemList(
+            chain(
+                self.dtc_dops,
+                self.data_object_props,
+                self.structures,
+                self.end_of_pdu_fields,
+                self.dynamic_length_fields,
+                self.env_data_descs,
+                self.env_datas,
+                self.muxs,
+            ))
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
@@ -209,3 +223,7 @@ class DiagDataDictionarySpec:
 
         if self.unit_spec is not None:
             self.unit_spec._resolve_snrefs(diag_layer)
+
+    @property
+    def all_data_object_properties(self) -> NamedItemList[DopBase]:
+        return self._all_data_object_properties

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -45,14 +45,8 @@ class ParameterWithDOP(Parameter):
         super()._resolve_snrefs(diag_layer)
 
         if self.dop_snref:
-            spec = diag_layer.diag_data_dictionary_spec
-            self._dop = (
-                spec.end_of_pdu_fields.get(self.dop_snref) or
-                spec.dynamic_length_fields.get(self.dop_snref) or
-                spec.data_object_props.get(self.dop_snref) or spec.structures.get(self.dop_snref) or
-                spec.muxs.get(self.dop_snref) or spec.dtc_dops.get(self.dop_snref) or
-                spec.muxs.get(self.dop_snref) or spec.env_data_descs.get(self.dop_snref) or
-                spec.env_datas.get(self.dop_snref))
+            ddds = diag_layer.diag_data_dictionary_spec
+            self._dop = odxrequire(ddds.all_data_object_properties.get(self.dop_snref))
 
     @property
     def dop(self) -> DopBase:

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -25,8 +25,12 @@ class TableRow(IdentifiableElement):
     key_raw: str
     structure_ref: Optional[OdxLinkRef]
     structure_snref: Optional[str]
+
+    # the referenced DOP must be a simple DOP (i.e.,
+    # DataObjectProperty, cf section 7.3.6.11 of the spec)!
     dop_ref: Optional[OdxLinkRef]
     dop_snref: Optional[str]
+
     semantic: Optional[str]
     sdgs: List[SpecialDataGroup]
 
@@ -114,9 +118,9 @@ class TableRow(IdentifiableElement):
         ddd_spec = diag_layer.diag_data_dictionary_spec
 
         if self.structure_snref is not None:
-            self._structure = ddd_spec.structures[self.structure_snref]
+            self._structure = odxrequire(ddd_spec.structures.get(self.structure_snref))
         if self.dop_snref is not None:
-            self._dop = ddd_spec.data_object_props[self.dop_snref]
+            self._dop = odxrequire(ddd_spec.data_object_props.get(self.dop_snref))
 
         for sdg in self.sdgs:
             sdg._resolve_snrefs(diag_layer)

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -6,8 +6,9 @@ from xml.etree import ElementTree
 from .basicstructure import BasicStructure
 from .createsdgs import create_sdgs_from_et
 from .dataobjectproperty import DataObjectProperty
+from .dtcdop import DtcDop
 from .element import IdentifiableElement
-from .exceptions import odxassert, odxrequire
+from .exceptions import odxassert, odxraise, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import AtomicOdxType
 from .specialdatagroup import SpecialDataGroup
@@ -27,7 +28,7 @@ class TableRow(IdentifiableElement):
     structure_snref: Optional[str]
 
     # the referenced DOP must be a simple DOP (i.e.,
-    # DataObjectProperty, cf section 7.3.6.11 of the spec)!
+    # DataObjectProperty or DtcDop, cf section 7.3.6.11 of the spec)!
     dop_ref: Optional[OdxLinkRef]
     dop_snref: Optional[str]
 
@@ -90,7 +91,9 @@ class TableRow(IdentifiableElement):
         if self.structure_ref is not None:
             self._structure = odxlinks.resolve(self.structure_ref, BasicStructure)
         if self.dop_ref is not None:
-            self._dop = odxlinks.resolve(self.dop_ref, DataObjectProperty)
+            self._dop = odxlinks.resolve(self.dop_ref)
+            if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
+                odxraise("The DOP-REF of TABLE-ROWs must reference a simple DOP!")
 
         self._table = odxlinks.resolve(self.table_ref)
 

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -293,6 +293,14 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         self.assertEqual(len(ddds.structures), 0)
         self.assertEqual(len(ddds.end_of_pdu_fields), 0)
 
+        ddds = ecu.diag_data_dictionary_spec
+        self.assertEqual({x.short_name
+                          for x in ddds.all_data_object_properties}, {
+                              "num_flips", "soberness_check", "dizzyness_level", "happiness_level",
+                              "duration", "temperature", "error_code", "boolean", "uint8", "float",
+                              "flip_env_data_desc", "flip_env_data", "flip_preference"
+                          })
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
it turned out that this is useful. this time, we add a unit test and also use it internally to resolve DOP-SNREFs for places where complex DOPs can be referenced via SNREF (i.e., some of the parameters).

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)