### PR TITLE
Introduce `ComplexDop` as a base class for non-simple data object properties

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -3,9 +3,9 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from .complexdop import ComplexDop
 from .dataobjectproperty import DataObjectProperty
 from .decodestate import DecodeState
-from .dopbase import DopBase
 from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, OdxWarning, odxassert, odxraise
 from .nameditemlist import NamedItemList
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class BasicStructure(DopBase):
+class BasicStructure(ComplexDop):
     parameters: NamedItemList[Parameter]
     byte_size: Optional[int]
 

--- a/odxtools/complexdop.py
+++ b/odxtools/complexdop.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+
+from .dopbase import DopBase
+
+
+@dataclass
+class ComplexDop(DopBase):
+    """Base class for all complex data object properties.
+
+    Complex DOPs are e.g., structures, fields and environment datas.
+    """
+    pass

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -3,10 +3,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from xml.etree import ElementTree
 
+from .complexdop import ComplexDop
 from .createsdgs import create_sdgs_from_et
 from .decodestate import DecodeState
-from .dopbase import DopBase
-from .element import IdentifiableElement
 from .encodestate import EncodeState
 from .environmentdata import EnvironmentData
 from .exceptions import DecodeError, EncodeError, odxrequire
@@ -19,7 +18,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class EnvironmentDataDescription(DopBase):
+class EnvironmentDataDescription(ComplexDop):
     """This class represents Environment Data Description, which is a complex DOP
     that is used to define the interpretation of environment data."""
 
@@ -38,7 +37,7 @@ class EnvironmentDataDescription(DopBase):
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "EnvironmentDataDescription":
         """Reads Environment Data Description from Diag Layer."""
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
         is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
         param_snref_elem = et_element.find("PARAM-SNREF")

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, List, Optional
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
+from .complexdop import ComplexDop
 from .createsdgs import create_sdgs_from_et
-from .dopbase import DopBase
 from .environmentdatadescription import EnvironmentDataDescription
 from .exceptions import odxassert, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Field(DopBase):
+class Field(ComplexDop):
     structure_ref: Optional[OdxLinkRef]
     structure_snref: Optional[str]
     env_data_desc_ref: Optional[OdxLinkRef]
@@ -38,7 +38,7 @@ class Field(DopBase):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Field":
-        kwargs = dataclass_fields_asdict(DopBase.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
         structure_ref = OdxLinkRef.from_et(et_element.find("BASIC-STRUCTURE-REF"), doc_frags)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -3,10 +3,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from xml.etree import ElementTree
 
+from .complexdop import ComplexDop
 from .createsdgs import create_sdgs_from_et
 from .decodestate import DecodeState
-from .dopbase import DopBase
-from .element import IdentifiableElement
 from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, odxrequire
 from .multiplexercase import MultiplexerCase
@@ -21,7 +20,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Multiplexer(DopBase):
+class Multiplexer(ComplexDop):
     """This class represents a Multiplexer (MUX) which are used to interpret data stream depending on the value
     of a switch-key (similar to switch-case statements in programming languages like C or Java)."""
 
@@ -33,7 +32,7 @@ class Multiplexer(DopBase):
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Multiplexer":
         """Reads a Multiplexer from Diag Layer."""
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
         is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
         sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
         byte_position = int(et_element.findtext("BYTE-POSITION", "0"))


### PR DESCRIPTION
This class does not do anything, but the ODX specification does it this way and it can be used to distinguish simple from complex DOPs more elegantly at runtime...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)