### PR TITLE
slightly improve writing the sub-tags stemming from ELEMENT-ID

### DIFF
--- a/odxtools/templates/macros/printAudience.xml.jinja2
+++ b/odxtools/templates/macros/printAudience.xml.jinja2
@@ -3,11 +3,11 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printAdditionalAudience(audience) -%}
 <ADDITIONAL-AUDIENCE ID="{{audience.odx_id.local_id}}">
- {{ peid.printElementID(audience)|indent(1) }}
+ {{ peid.printElementIdSubtags(audience)|indent(1) }}
 </ADDITIONAL-AUDIENCE>
 {%- endmacro -%}
 

--- a/odxtools/templates/macros/printCompanyData.xml.jinja2
+++ b/odxtools/templates/macros/printCompanyData.xml.jinja2
@@ -3,12 +3,12 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printCompanyData(company_data) -%}
 <COMPANY-DATA ID="{{company_data.odx_id.local_id}}">
- {{ peid.printElementID(company_data)|indent(1) }}
+ {{ peid.printElementIdSubtags(company_data)|indent(1) }}
  {%- if company_data.roles is not none %}
  <ROLES>
   {%- for role in company_data.roles %}
@@ -20,7 +20,7 @@
  <TEAM-MEMBERS>
   {%- for team_member in company_data.team_members %}
   <TEAM-MEMBER ID="{{team_member.odx_id.local_id}}">
-   {{ peid.printElementID(team_member)|indent(3) }}
+   {{ peid.printElementIdSubtags(team_member)|indent(3) }}
    {%- if team_member.roles is not none %}
    <ROLES>
     {%- for role in team_member.roles %}
@@ -60,7 +60,7 @@
    <RELATED-DOC>
     {%- if rd.xdoc  is not none %}
     <XDOC>
-     {{ peid.printElementID(rd.xdoc)|indent(5) }}
+     {{ peid.printElementIdSubtags(rd.xdoc)|indent(5) }}
      {%- if rd.xdoc.number is not none %}
      <NUMBER>{{rd.xdoc.number|e}}</NUMBER>
      {%- endif %}

--- a/odxtools/templates/macros/printComparam.xml.jinja2
+++ b/odxtools/templates/macros/printComparam.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printComplexValue(cv, tag_name="COMPLEX-VALUE") %}
 <{{tag_name}}>
@@ -43,7 +43,7 @@
           CPTYPE="{{cp.cptype.value}}"
          {{make_xml_attrib("DISPLAY-LEVEL", cp.display_level)}}{#- #}
           CPUSAGE="{{cp.cpusage.value}}">
-  {{ peid.printElementID(cp)|indent(1) }}
+  {{ peid.printElementIdSubtags(cp)|indent(1) }}
   <PHYSICAL-DEFAULT-VALUE>{{cp.physical_default_value}}</PHYSICAL-DEFAULT-VALUE>
  <DATA-OBJECT-PROP-REF ID-REF="{{cp.dop_ref.ref_id}}" />
 </COMPARAM>
@@ -57,7 +57,7 @@
                   CPUSAGE="{{cp.cpusage.value}}"
                  {{make_bool_xml_attrib("ALLOW-MULTIPLE-VALUES", cp.allow_multiple_values_raw)}}
                   {#- #}>
- {{ peid.printElementID(cp)|indent(1) }}
+ {{ peid.printElementIdSubtags(cp)|indent(1) }}
  {%- for sub_cp in cp.subparams %}
  {{- printAnyComparam(sub_cp) | indent(1, first=True) }}
  {%- if  hasattr(sub_cp, 'subparams') and sub_cp.physical_default_value is not none %}

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printAdminData.xml.jinja2') as pad %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
@@ -165,7 +165,7 @@
 
 {%- macro printDOP(dop, tag_name) %}
 <{{tag_name}} ID="{{dop.odx_id.local_id}}">
- {{ peid.printElementID(dop)|indent(1) }}
+ {{ peid.printElementIdSubtags(dop)|indent(1) }}
  {%- if dop.admin_data %}
  {{- pad.printAdminData(dop.admin_data)|indent(2, first=True) }}
  {%- endif %}
@@ -187,7 +187,7 @@
 
 {%- macro printDTCDOP(dop) %}
 <DTC-DOP ID="{{dop.odx_id.local_id}}">
- {{ peid.printElementID(dop)|indent(1) }}
+ {{ peid.printElementIdSubtags(dop)|indent(1) }}
  {{- psd.printSpecialDataGroups(dop.sdgs)|indent(1, first=True) }}
  {{- printDiagCodedType(dop.diag_coded_type)|indent(1, first=True) }}
  {{- printPhysicalType(dop.physical_type)|indent(1, first=True) }}

--- a/odxtools/templates/macros/printDiagComm.xml.jinja2
+++ b/odxtools/templates/macros/printDiagComm.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printAdminData.xml.jinja2') as pad %}
 {%- import('macros/printAudience.xml.jinja2') as paud %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
@@ -19,7 +19,7 @@
 
 
 {%- macro printDiagCommElems(dc) -%}
- {{ peid.printElementID(dc)|indent(1) }}
+ {{ peid.printElementIdSubtags(dc)|indent(1) }}
  {%- if dc.admin_data %}
   {{- pad.printAdminData(dc.admin_data)|indent(1, first=True) }}
  {%- endif %}

--- a/odxtools/templates/macros/printDynamicLengthField.xml.jinja2
+++ b/odxtools/templates/macros/printDynamicLengthField.xml.jinja2
@@ -3,11 +3,11 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printDynamicLengthField(dlf) -%}
 <DYNAMIC-LENGTH-FIELD ID="{{dlf.odx_id.local_id}}">
- {{ peid.printElementID(dlf)|indent(1) }}
+ {{ peid.printElementIdSubtags(dlf)|indent(1) }}
  <BASIC-STRUCTURE-REF ID-REF="{{dlf.structure_ref.ref_id}}" />
  <OFFSET>{{dlf.offset}}</OFFSET>
  <DETERMINE-NUMBER-OF-ITEMS>

--- a/odxtools/templates/macros/printElementId.xml.jinja2
+++ b/odxtools/templates/macros/printElementId.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- macro printElementID(obj) -%}
+{%- macro printElementIdSubtags(obj) -%}
 <SHORT-NAME>{{ obj.short_name }}</SHORT-NAME>
 {%- if obj.long_name %}
 <LONG-NAME>{{ obj.long_name|e }}</LONG-NAME>

--- a/odxtools/templates/macros/printEndOfPdu.xml.jinja2
+++ b/odxtools/templates/macros/printEndOfPdu.xml.jinja2
@@ -3,11 +3,11 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printEndOfPdu(eopdu) -%}
 <END-OF-PDU-FIELD ID="{{eopdu.odx_id.local_id}}">
- {{ peid.printElementID(eopdu)|indent(1) }}
+ {{ peid.printElementIdSubtags(eopdu)|indent(1) }}
  <BASIC-STRUCTURE-REF ID-REF="{{eopdu.structure_ref.ref_id}}" />
 </END-OF-PDU-FIELD>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printEnvData.xml.jinja2
+++ b/odxtools/templates/macros/printEnvData.xml.jinja2
@@ -3,12 +3,12 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printParam.xml.jinja2') as pparam %}
 
 {%- macro printEnvData(env_data) %}
 <ENV-DATA ID="{{env_data.odx_id.local_id}}">
-    {{ peid.printElementID(env_data)|indent(1) }}
+    {{ peid.printElementIdSubtags(env_data)|indent(1) }}
     <PARAMS>
       {%- for param in env_data.parameters %}
       {{pparam.printParam(param) | indent(6, first=True) }}

--- a/odxtools/templates/macros/printEnvDataDesc.xml.jinja2
+++ b/odxtools/templates/macros/printEnvDataDesc.xml.jinja2
@@ -3,11 +3,11 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printEnvDataDesc(env_data_desc) %}
 <ENV-DATA-DESC ID="{{env_data_desc.odx_id.local_id}}">
-  {{ peid.printElementID(env_data_desc)|indent(1) }}
+  {{ peid.printElementIdSubtags(env_data_desc)|indent(1) }}
   <PARAM-SNREF SHORT-NAME="{{env_data_desc.param_snref}}"/>
   <ENV-DATA-REFS>
     {%- for env_data_ref in env_data_desc.env_data_refs %}

--- a/odxtools/templates/macros/printFunctionalClass.xml.jinja2
+++ b/odxtools/templates/macros/printFunctionalClass.xml.jinja2
@@ -4,10 +4,10 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printFunctionalClass(fc) -%}
 <FUNCT-CLASS ID="{{fc.odx_id.local_id}}">
- {{ peid.printElementID(fc)|indent(1) }}
+ {{ peid.printElementIdSubtags(fc)|indent(1) }}
 </FUNCT-CLASS>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printMux.xml.jinja2
+++ b/odxtools/templates/macros/printMux.xml.jinja2
@@ -3,11 +3,11 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printMux(mux) %}
 <MUX ID="{{mux.odx_id.local_id}}">
-  {{ peid.printElementID(mux)|indent(1) }}
+  {{ peid.printElementIdSubtags(mux)|indent(1) }}
   <BYTE-POSITION>{{mux.byte_position}}</BYTE-POSITION>
   <SWITCH-KEY>
     <BYTE-POSITION>{{mux.switch_key.byte_position}}</BYTE-POSITION>
@@ -18,7 +18,7 @@
   </SWITCH-KEY>
   {%- if mux.default_case is not none %}
   <DEFAULT-CASE>
-    {{ peid.printElementID(mux.default_case)|indent(4) }}
+    {{ peid.printElementIdSubtags(mux.default_case)|indent(4) }}
     {%- if mux.default_case.structure_ref is not none %}
     <STRUCTURE-REF ID-REF="{{mux.default_case.structure_ref.ref_id}}"/>
     {%- endif %}
@@ -31,7 +31,7 @@
   <CASES>
     {%- for case in mux.cases %}
     <CASE>
-      {{ peid.printElementID(case)|indent(6) }}
+      {{ peid.printElementIdSubtags(case)|indent(6) }}
       {%- if case.structure_ref is not none %}
       <STRUCTURE-REF ID-REF="{{case.structure_ref.ref_id}}"/>
       {%- endif %}

--- a/odxtools/templates/macros/printParam.xml.jinja2
+++ b/odxtools/templates/macros/printParam.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printDOP.xml.jinja2') as pdop %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
@@ -20,7 +20,7 @@
 {%- else %}
 <PARAM {{semattrib}} xsi:type="{{param.parameter_type}}">
 {%- endif%}
- {{ peid.printElementID(param)|indent(1) }}
+ {{ peid.printElementIdSubtags(param)|indent(1) }}
  {{- psd.printSpecialDataGroups(param.sdgs)|indent(1, first=True) }}
 {%- if param.byte_position is not none %}
  <BYTE-POSITION>{{param.byte_position}}</BYTE-POSITION>

--- a/odxtools/templates/macros/printRequest.xml.jinja2
+++ b/odxtools/templates/macros/printRequest.xml.jinja2
@@ -3,14 +3,14 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printDOP.xml.jinja2') as pdop %}
 {%- import('macros/printParam.xml.jinja2') as pp %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printRequest(request) -%}
 <REQUEST ID="{{request.odx_id.local_id}}">
- {{ peid.printElementID(request)|indent(1) }}
+ {{ peid.printElementIdSubtags(request)|indent(1) }}
 {%- if request.parameters %}
  <PARAMS>
  {%- for param in request.parameters -%}

--- a/odxtools/templates/macros/printResponse.xml.jinja2
+++ b/odxtools/templates/macros/printResponse.xml.jinja2
@@ -3,13 +3,13 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printParam.xml.jinja2') as pp %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printResponse(resp, tag_name="POS-RESPONSE") -%}
 <{{tag_name}} ID="{{resp.odx_id.local_id}}">
- {{ peid.printElementID(resp)|indent(1) }}
+ {{ peid.printElementIdSubtags(resp)|indent(1) }}
 {%- if resp.parameters %}
  <PARAMS>
 {%- for param in resp.parameters -%}

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printDiagComm.xml.jinja2') as pdc %}
 
 {%- macro printSingleEcuJob(job) -%}
@@ -64,7 +64,7 @@
 {%- macro printInputParam(param) -%}
 <INPUT-PARAM {{-make_xml_attrib("OID", param.oid)}}
              {{-make_xml_attrib("SEMANTIC", param.semantic)}}>
- {{ peid.printElementID(param)|indent(1) }}
+ {{ peid.printElementIdSubtags(param)|indent(1) }}
 {%- if param.physical_default_value %}
  <PHYSICAL-DEFAULT-VALUE>{{param.physical_default_value}}</PHYSICAL-DEFAULT-VALUE>
 {%- endif %}
@@ -76,7 +76,7 @@
 <OUTPUT-PARAM ID="{{param.odx_id.local_id}}"
               {{-make_xml_attrib("OID", param.oid)}}
               {{-make_xml_attrib("SEMANTIC", param.semantic)}}>
- {{ peid.printElementID(param)|indent(1) }}
+ {{ peid.printElementIdSubtags(param)|indent(1) }}
  <DOP-BASE-REF ID-REF="{{param.dop_base_ref.ref_id}}" />
 </OUTPUT-PARAM>
 {%- endmacro -%}
@@ -84,7 +84,7 @@
 
 {%- macro printNegOutputParam(param) -%}
 <NEG-OUTPUT-PARAM>
- {{ peid.printElementID(param)|indent(1) }}
+ {{ peid.printElementIdSubtags(param)|indent(1) }}
  <DOP-BASE-REF ID-REF="{{param.dop_base_ref.ref_id}}" />
 </NEG-OUTPUT-PARAM>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printSpecialData.xml.jinja2
+++ b/odxtools/templates/macros/printSpecialData.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printSpecialData(sd) %}
 <SD
@@ -18,7 +18,7 @@
 
 {%- macro printSdgCaption(sdg_caption) %}
 <SDG-CAPTION ID="{{sdg_caption.odx_id.local_id}}">
- {{ peid.printElementID(sdg_caption)|indent(1) }}
+ {{ peid.printElementIdSubtags(sdg_caption)|indent(1) }}
 </SDG-CAPTION>
 {%- endmacro %}
 

--- a/odxtools/templates/macros/printState.xml.jinja2
+++ b/odxtools/templates/macros/printState.xml.jinja2
@@ -3,10 +3,10 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printState(state) -%}
 <STATE ID="{{state.odx_id.local_id}}">
- {{ peid.printElementID(state)|indent(1) }}
+ {{ peid.printElementIdSubtags(state)|indent(1) }}
 </STATE>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printStateChart.xml.jinja2
+++ b/odxtools/templates/macros/printStateChart.xml.jinja2
@@ -3,13 +3,13 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printState.xml.jinja2') as ps %}
 {%- import('macros/printStateTransition.xml.jinja2') as pst %}
 
 {%- macro printStateChart(state_chart) -%}
 <STATE-CHART ID="{{state_chart.odx_id.local_id}}">
- {{ peid.printElementID(state_chart)|indent(1) }}
+ {{ peid.printElementIdSubtags(state_chart)|indent(1) }}
  <SEMANTIC>{{state_chart.semantic}}</SEMANTIC>
  {%- if state_chart.state_transitions %}
  <STATE-TRANSITIONS>

--- a/odxtools/templates/macros/printStateTransition.xml.jinja2
+++ b/odxtools/templates/macros/printStateTransition.xml.jinja2
@@ -3,11 +3,11 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printStateTransition(state_transition) -%}
 <STATE-TRANSITION ID="{{state_transition.odx_id.local_id}}">
- {{ peid.printElementID(state_transition)|indent(1) }}
+ {{ peid.printElementIdSubtags(state_transition)|indent(1) }}
  <SOURCE-SNREF SHORT-NAME="{{state_transition.source_snref}}" />
  <TARGET-SNREF SHORT-NAME="{{state_transition.target_snref}}" />
 </STATE-TRANSITION>

--- a/odxtools/templates/macros/printStructure.xml.jinja2
+++ b/odxtools/templates/macros/printStructure.xml.jinja2
@@ -3,12 +3,12 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printParam.xml.jinja2') as pp %}
 
 {%- macro printStructure(st) -%}
 <STRUCTURE ID="{{st.odx_id.local_id}}">
- {{ peid.printElementID(st)|indent(1) }}
+ {{ peid.printElementIdSubtags(st)|indent(1) }}
 {%- if st.byte_size is not none %}
  <BYTE-SIZE>{{st.byte_size}}</BYTE-SIZE>
 {%- endif %}

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -3,13 +3,13 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printTable(table) %}
 <TABLE ID="{{table.odx_id.local_id}}"
        {{-make_xml_attrib("SEMANTIC", table.semantic)}}>
- {{ peid.printElementID(table)|indent(1) }}
+ {{ peid.printElementIdSubtags(table)|indent(1) }}
 {%- if table.key_dop_ref %}
  <KEY-DOP-REF ID-REF="{{ table.key_dop_ref.ref_id }}" />
 {%- endif %}

--- a/odxtools/templates/macros/printUnitSpec.xml.jinja2
+++ b/odxtools/templates/macros/printUnitSpec.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printUnitSpec(spec) -%}
@@ -37,7 +37,7 @@
 {%- macro printUnit(unit) -%}
 <UNIT ID="{{unit.odx_id.local_id}}"
       {{-make_xml_attrib("OID", unit.oid)}}>
- {{ peid.printElementID(unit)|indent(1) }}
+ {{ peid.printElementIdSubtags(unit)|indent(1) }}
  <DISPLAY-NAME>{{ unit.display_name }}</DISPLAY-NAME>
  {%- if unit.factor_si_to_unit is not none %}
  <FACTOR-SI-TO-UNIT>{{ unit.factor_si_to_unit }}</FACTOR-SI-TO-UNIT>
@@ -53,7 +53,7 @@
 
 {%- macro printUnitGroup(group) -%}
 <UNIT-GROUP {%- if group.oid %} OID="{{group.oid}}" {%- endif %}>
- {{ peid.printElementID(group)|indent(1) }}
+ {{ peid.printElementIdSubtags(group)|indent(1) }}
  <CATEGORY>{{ group.category.value }}</CATEGORY>
  {%- if group.unit_refs %}
  <UNIT-REFS>
@@ -68,7 +68,7 @@
 {%- macro printPhysicalDimesion(dim) -%}
 <PHYSICAL-DIMENSION ID="{{dim.odx_id.local_id}}"
                     {{-make_xml_attrib("OID",dim.oid)}}>
- {{ peid.printElementID(dim)|indent(1) }}
+ {{ peid.printElementIdSubtags(dim)|indent(1) }}
  {%- if dim.length_exp %}
  <LENGTH-EXP>{{ dim.length_exp }}</LENGTH-EXP>
  {%- endif %}

--- a/odxtools/templates/macros/printVariant.xml.jinja2
+++ b/odxtools/templates/macros/printVariant.xml.jinja2
@@ -3,7 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printDOP.xml.jinja2') as pdop %}
 {%- import('macros/printTable.xml.jinja2') as pt %}
 {%- import('macros/printFunctionalClass.xml.jinja2') as pfc %}
@@ -27,7 +27,7 @@
 {%- macro printVariant(dl) -%}
 {%- set dlr = dl.diag_layer_raw %}
 <{{dlr.variant_type.value}} ID="{{dlr.odx_id.local_id}}">
- {{ peid.printElementID(dlr)|indent(1) }}
+ {{ peid.printElementIdSubtags(dlr)|indent(1) }}
 {%- if dlr.functional_classes %}
  <FUNCT-CLASSS>
 {%- for fc in dlr.functional_classes %}


### PR DESCRIPTION
The jinja macro for writing the SHORT-NAME, LONG-NAME and DESC tags is now called `printElementIdSubtags` to avoid giving the impression that it writes a full `ELEMENT-ID` tag instead of just its contents.

Unless a better scheme comes along, this will also be the new way to deal with inherited classes when writing XML files: If Bar derives from Foo, there will be `printFooSubtags` and `printFooAttributes` macros, which are then called by `printBar`. The first two macros do not write the complete tag, but only the contents and the attributes defined by Foo.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
