### PR TITLE
fix parsing and writing of COMPARAM-SPEC

### DIFF
--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -9,6 +9,7 @@ from .comparamspec import ComparamSpec
 from .comparamsubset import ComparamSubset
 from .diaglayer import DiagLayer
 from .diaglayercontainer import DiagLayerContainer
+from .exceptions import odxraise
 from .nameditemlist import NamedItemList, short_name_as_key
 from .odxlink import OdxLinkDatabase
 
@@ -27,6 +28,7 @@ class Database:
                  *,
                  pdx_zip: Optional[ZipFile] = None,
                  odx_d_file_name: Optional[str] = None) -> None:
+        self.model_version = None
 
         if pdx_zip is None and odx_d_file_name is None:
             # create an empty database object
@@ -60,6 +62,11 @@ class Database:
         comparam_specs: List[ComparamSpec] = []
         for root in documents:
             # ODX spec version
+            model_version = version(root.attrib.get("MODEL-VERSION", "2.0"))
+            if self.model_version is not None and self.model_version != model_version:
+                odxraise(f"Different ODX versions used in the same file (ODX {model_version} "
+                         f"and ODX {self.model_version}")
+            self.model_version = model_version
             dlc = root.find("DIAG-LAYER-CONTAINER")
             if dlc is not None:
                 dlcs.append(DiagLayerContainer.from_et(dlc, []))

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -81,7 +81,10 @@ class Database:
 
             cp_spec = root.find("COMPARAM-SPEC")
             if cp_spec is not None:
-                comparam_specs.append(ComparamSpec.from_et(cp_spec, []))
+                if model_version == "2.0":
+                    comparam_subsets.append(ComparamSubset.from_et(cp_spec, []))
+                else:  # odx >= 2.2
+                    comparam_specs.append(ComparamSpec.from_et(cp_spec, []))
 
         self._diag_layer_containers = NamedItemList(dlcs)
         self._diag_layer_containers.sort(key=short_name_as_key)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -43,10 +43,10 @@ class Database:
             names = list(pdx_zip.namelist())
             names.sort()
             for zip_member in names:
-                # file name can end with .odx, .odx-d, .odx-c,
-                # .odx-cs, .odx-e, .odx-f, .odx-fd, .odx-m, .odx-v We
-                # could test for all that, or just make sure suffix
-                # starts with .odx
+                # The name of ODX files can end with .odx, .odx-d,
+                # .odx-c, .odx-cs, .odx-e, .odx-f, .odx-fd, .odx-m,
+                # .odx-v .  We could test for all that, or just make
+                # sure that the file's suffix starts with .odx
                 if Path(zip_member).suffix.startswith(".odx"):
                     d = pdx_zip.read(zip_member)
                     root = ElementTree.fromstring(d)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -101,12 +101,18 @@ class Database:
         for subset in self.comparam_subsets:
             self._odxlinks.update(subset._build_odxlinks())
 
+        for spec in self.comparam_specs:
+            self._odxlinks.update(spec._build_odxlinks())
+
         for dlc in self.diag_layer_containers:
             self._odxlinks.update(dlc._build_odxlinks())
 
         # Resolve ODXLINK references
         for subset in self.comparam_subsets:
             subset._resolve_odxlinks(self._odxlinks)
+
+        for spec in self.comparam_specs:
+            spec._resolve_odxlinks(self._odxlinks)
 
         for dlc in self.diag_layer_containers:
             dlc._resolve_odxlinks(self._odxlinks)

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -12,6 +12,7 @@ from .additionalaudience import AdditionalAudience
 from .admindata import AdminData
 from .companydata import CompanyData
 from .comparaminstance import ComparamInstance
+from .comparamspec import ComparamSpec
 from .diagcomm import DiagComm
 from .diagdatadictionaryspec import DiagDataDictionarySpec
 from .diaglayerraw import DiagLayerRaw
@@ -24,6 +25,7 @@ from .message import Message
 from .nameditemlist import NamedItemList, OdxNamed
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .parentref import ParentRef
+from .protstack import ProtStack
 from .request import Request
 from .response import Response
 from .servicebinner import ServiceBinner
@@ -297,6 +299,14 @@ class DiagLayer:
     @property
     def prot_stack_snref(self) -> Optional[str]:
         return self.diag_layer_raw.prot_stack_snref
+
+    @property
+    def comparam_spec(self) -> Optional[ComparamSpec]:
+        return self.diag_layer_raw.comparam_spec
+
+    @property
+    def prot_stack(self) -> Optional[ProtStack]:
+        return self.diag_layer_raw.prot_stack
 
     #####
     # </properties forwarded to the "raw" diag layer>

--- a/odxtools/protstack.py
+++ b/odxtools/protstack.py
@@ -49,3 +49,7 @@ class ProtStack(IdentifiableElement):
 
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         pass
+
+    @property
+    def comparam_subsets(self) -> NamedItemList[ComparamSubset]:
+        return self._comparam_subsets

--- a/odxtools/templates/comparam-spec.odx-c.xml.jinja2
+++ b/odxtools/templates/comparam-spec.odx-c.xml.jinja2
@@ -2,8 +2,8 @@
  #
  # SPDX-License-Identifier: MIT
  #
- # This template writes an .odx-cs file for a communication
- # parameter subset.
+ # This template writes an .odx-c file for a communication
+ # parameter specification.
 -#}
 {%- import('macros/printAdminData.xml.jinja2') as pad -%}
 {%- import('macros/printCompanyData.xml.jinja2') as pcd -%}

--- a/odxtools/templates/macros/printProtStack.xml.jinja2
+++ b/odxtools/templates/macros/printProtStack.xml.jinja2
@@ -3,12 +3,12 @@
  # SPDX-License-Identifier: MIT
 -#}
 
-{%- import('macros/printElementID.xml.jinja2') as peid %}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printProtStack(ps) %}
 <PROT-STACK ID="{{ps.odx_id.local_id}}">
- {{ peid.printElementID(ps) | indent(1) }}
+ {{ peid.printElementIdSubtags(ps) | indent(1) }}
  <PDU-PROTOCOL-TYPE>{{ ps.pdu_protocol_type }}</PDU-PROTOCOL-TYPE>
  <PHYSICAL-LINK-TYPE>{{ ps.physical_link_type }}</PHYSICAL-LINK-TYPE>
  {%- if ps.comparam_subset_refs %}

--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -134,14 +134,15 @@ def write_pdx_file(
             file_index.append((zf_file_name, zf_file_cdate, zf_mime_type))
 
             zf.writestr(zf_file_name, comparam_subset_tpl.render(**vars))
-        del vars["comparam_subset"]
+
+            del vars["comparam_subset"]
 
         # write the communication parameter specs
-        comparam_spec_tpl = jinja_env.get_template("comparam-spec.odx-cs.xml.jinja2")
+        comparam_spec_tpl = jinja_env.get_template("comparam-spec.odx-c.xml.jinja2")
         for comparam_spec in database.comparam_specs:
-            zf_file_name = f"{comparam_spec.short_name}.odx-cs"
+            zf_file_name = f"{comparam_spec.short_name}.odx-c"
             zf_file_cdate = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-            zf_mime_type = "application/x-asam.odx.odx-cs"
+            zf_mime_type = "application/x-asam.odx.odx-c"
 
             vars["comparam_spec"] = comparam_spec
 
@@ -149,7 +150,6 @@ def write_pdx_file(
 
             zf.writestr(zf_file_name, comparam_spec_tpl.render(**vars))
 
-        if "comparam_spec" in vars:
             del vars["comparam_spec"]
 
         # write the actual diagnostic data.
@@ -164,7 +164,7 @@ def write_pdx_file(
 
             file_index.append((file_name, creation_date, mime_type))
             zf.writestr(file_name, dlc_tpl.render(**vars))
-        del vars["dlc"]
+            del vars["dlc"]
 
         # write the index.xml file
         vars["file_index"] = file_index


### PR DESCRIPTION
It turns out that files containing "COMPARAM-SPEC" root elements were ignored for PDX files using ODX 2.2. (also, the writing code got slightly broken recently.)

I'm not 100% sure if this still works with ODX 2.0 files, though...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)