### PR TITLE
Add some convenience for communication parameters

### DIFF
--- a/odxtools/cli/snoop.py
+++ b/odxtools/cli/snoop.py
@@ -244,10 +244,10 @@ def run(args: argparse.Namespace) -> None:
 
     # if no can IDs have been explicitly specified, take them from the DL
     if args.rx is None and odx_diag_layer:
-        args.rx = str(odx_diag_layer.get_can_receive_id(protocol_name=protocol_name))
+        args.rx = str(odx_diag_layer.get_can_receive_id(protocol=protocol_name))
 
     if args.tx is None and odx_diag_layer:
-        args.tx = str(odx_diag_layer.get_can_send_id(protocol_name=protocol_name))
+        args.tx = str(odx_diag_layer.get_can_send_id(protocol=protocol_name))
 
     if args.rx is None:
         print(f"Could not determine a CAN receive ID.")


### PR DESCRIPTION
This adds a few communication parameter related convenience functions (`get_can_mtu()`, `use_can_fd()`, `get_can_baudrate()` and `get_can_fd_baudrate()`) and it allows to specify the protocol to be used by either passing the name of the protocol as a string or using the whole protocol diaglayer. The latter is useful to specify the protocol like `ecu.get_can_receive_address(ecu.protocols.OBD_CAN)` instead of `ecu.get_can_receive_address(ecu.protocols.OBD_CAN.short_name)`.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)