### PR TITLE
Make `NamedItemList` a list when it comes to type checking

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1274,7 +1274,7 @@ somersault_env_datas = {
                     sdgs=[],
                 ),
             ]),
-            all_value=None,
+            all_value=True,
         )
 }
 

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -183,7 +183,7 @@ class BasicStructure(ComplexDop):
             # but it could be that bit_length was mis calculated and not the actual bytes are wrong
             # Could happen with overlapping parameters and parameters with gaps
             warnings.warn(
-                "Verification of coded message {coded_message.hex()} possibly failed: Size may be incorrect.",
+                f"Verification of coded message '{coded_message.hex()}' possibly failed: Size may be incorrect.",
                 OdxWarning,
                 stacklevel=1)
 

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -57,7 +57,7 @@ class ComparamSubset(IdentifiableElement):
             ComplexComparam.from_et(el, doc_frags)
             for el in et_element.iterfind("COMPLEX-COMPARAMS/COMPLEX-COMPARAM")
         ])
-        if unit_spec_elem := et_element.find("UNIT-SPEC"):
+        if (unit_spec_elem := et_element.find("UNIT-SPEC")) is not None:
             unit_spec = UnitSpec.from_et(unit_spec_elem, doc_frags)
         else:
             unit_spec = None

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Optional
 from xml.etree import ElementTree
 from zipfile import ZipFile
+
 from packaging.version import Version
 
 from .comparamspec import ComparamSpec

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -11,7 +11,7 @@ from .comparamsubset import ComparamSubset
 from .diaglayer import DiagLayer
 from .diaglayercontainer import DiagLayerContainer
 from .exceptions import odxraise
-from .nameditemlist import NamedItemList, short_name_as_key
+from .nameditemlist import NamedItemList
 from .odxlink import OdxLinkDatabase
 
 
@@ -84,11 +84,8 @@ class Database:
                     comparam_specs.append(ComparamSpec.from_et(cp_spec, []))
 
         self._diag_layer_containers = NamedItemList(dlcs)
-        self._diag_layer_containers.sort(key=short_name_as_key)
         self._comparam_subsets = NamedItemList(comparam_subsets)
-        self._comparam_subsets.sort(key=short_name_as_key)
         self._comparam_specs = NamedItemList(comparam_specs)
-        self._comparam_specs.sort(key=short_name_as_key)
 
         self.refresh()
 

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -2,8 +2,8 @@
 import abc
 from collections import OrderedDict
 from keyword import iskeyword
-from typing import (Any, Callable, Collection, Dict, Generic, Iterable, Iterator, List, Optional,
-                    Protocol, Tuple, TypeVar, Union, cast, overload, runtime_checkable)
+from typing import (Any, Callable, Collection, Dict, Iterable, Iterator, List, Optional, Protocol,
+                    SupportsIndex, Tuple, TypeVar, Union, cast, overload, runtime_checkable)
 
 from .exceptions import odxraise
 
@@ -20,7 +20,7 @@ T = TypeVar("T")
 TNamed = TypeVar("TNamed", bound=OdxNamed)
 
 
-class ItemAttributeList(Generic[T]):
+class ItemAttributeList(List[T]):
     """A list that provides direct access to its items as named attributes.
 
     This is a hybrid between a list and a user-defined object: One can
@@ -76,7 +76,7 @@ class ItemAttributeList(Generic[T]):
         self._item_dict[item_name] = item
         self._item_list.append(item)
 
-    def sort(self, key: Optional[Callable[[T], str]] = None, reverse: bool = False) -> None:
+    def sort(self, *, key: Any = None, reverse: bool = False) -> None:
         if key is None:
             self._item_dict = OrderedDict(
                 sorted(self._item_dict.items(), key=lambda x: x[0], reverse=reverse))
@@ -96,7 +96,7 @@ class ItemAttributeList(Generic[T]):
     def items(self) -> Collection[Tuple[str, T]]:
         return self._item_dict.items()
 
-    def __contains__(self, x: T) -> bool:
+    def __contains__(self, x: object) -> bool:
         return x in self._item_list
 
     def __len__(self) -> int:
@@ -108,7 +108,7 @@ class ItemAttributeList(Generic[T]):
         return result
 
     @overload
-    def __getitem__(self, key: int) -> T:
+    def __getitem__(self, key: SupportsIndex) -> T:
         ...
 
     @overload
@@ -119,8 +119,8 @@ class ItemAttributeList(Generic[T]):
     def __getitem__(self, key: slice) -> List[T]:
         ...
 
-    def __getitem__(self, key: Union[int, str, slice]) -> Union[T, List[T]]:
-        if isinstance(key, int):
+    def __getitem__(self, key: Union[SupportsIndex, str, slice]) -> Union[T, List[T]]:
+        if isinstance(key, SupportsIndex):
             return self._item_list[key]
         elif isinstance(key, slice):
             return self._item_list[key]
@@ -161,7 +161,7 @@ class ItemAttributeList(Generic[T]):
         return self.__str__()
 
 
-class NamedItemList(Generic[TNamed], ItemAttributeList[TNamed]):
+class NamedItemList(ItemAttributeList[TNamed]):
 
     def _get_item_key(self, obj: OdxNamed) -> str:
         """Transform an object's `short_name` attribute into a valid

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -161,32 +161,28 @@ class ItemAttributeList(Generic[T]):
         return self.__str__()
 
 
-def short_name_as_key(obj: OdxNamed) -> str:
-    """Transform an object's `short_name` attribute into a valid
-    python identifier
-
-    Although short names are almost identical to valid python
-    identifiers, their first character is allowed to be a number or
-    they may be python keywords. This method prepends an underscore to
-    such short names.
-
-    """
-    if not isinstance(obj, OdxNamed):
-        odxraise()
-    sn = obj.short_name
-    if not isinstance(sn, str):
-        odxraise()
-
-    # make sure that the name of the item in question is not a python
-    # keyword (this would lead to syntax errors) and that does not
-    # start with a digit
-    if sn[0].isdigit() or iskeyword(sn):
-        return f"_{sn}"
-
-    return sn
-
-
 class NamedItemList(Generic[TNamed], ItemAttributeList[TNamed]):
 
     def _get_item_key(self, obj: OdxNamed) -> str:
-        return short_name_as_key(obj)
+        """Transform an object's `short_name` attribute into a valid
+        python identifier
+
+        Although short names are almost identical to valid python
+        identifiers, their first character is allowed to be a number or
+        they may be python keywords. This method prepends an underscore to
+        such short names.
+
+        """
+        if not isinstance(obj, OdxNamed):
+            odxraise()
+        sn = obj.short_name
+        if not isinstance(sn, str):
+            odxraise()
+
+        # make sure that the name of the item in question is not a python
+        # keyword (this would lead to syntax errors) and that does not
+        # start with a digit
+        if sn[0].isdigit() or iskeyword(sn):
+            return f"_{sn}"
+
+        return sn

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -119,7 +119,7 @@ class TestNamedItemList(unittest.TestCase):
 
         # try to append an item that cannot be mapped to a name
         with self.assertRaises(OdxError):
-            foo.append((0, 3)) # type: ignore[arg-type]
+            foo.append((0, 3))  # type: ignore[arg-type]
 
         # add a keyword identifier
         foo.append(X("as", 3))

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 import unittest
 from dataclasses import dataclass
+from typing import List
 
 import odxtools
 from odxtools.exceptions import OdxError
@@ -97,7 +98,7 @@ class TestNamedItemList(unittest.TestCase):
             value: int
 
         foo = NamedItemList([X("hello", 0), X("world", 1)])
-        self.assertEqual(foo.hello, X("hello", 0))  # type: ignore[attr-defined]
+        self.assertEqual(foo.hello, X("hello", 0))
         self.assertEqual(foo[0], X("hello", 0))
         self.assertEqual(foo[1], X("world", 1))
         self.assertEqual(foo[:1], [X("hello", 0)])
@@ -106,31 +107,31 @@ class TestNamedItemList(unittest.TestCase):
             foo[2]
         self.assertEqual(foo["hello"], X("hello", 0))
         self.assertEqual(foo["world"], X("world", 1))
-        self.assertEqual(foo.hello, X("hello", 0))  # type: ignore[attr-defined]
-        self.assertEqual(foo.world, X("world", 1))  # type: ignore[attr-defined]
+        self.assertEqual(foo.hello, X("hello", 0))
+        self.assertEqual(foo.world, X("world", 1))
 
         foo.append(X("hello", 2))
         self.assertEqual(foo[2], X("hello", 2))
         self.assertEqual(foo["hello"], X("hello", 0))
         self.assertEqual(foo["hello_2"], X("hello", 2))
-        self.assertEqual(foo.hello, X("hello", 0))  # type: ignore[attr-defined]
-        self.assertEqual(foo.hello_2, X("hello", 2))  # type: ignore[attr-defined]
+        self.assertEqual(foo.hello, X("hello", 0))
+        self.assertEqual(foo.hello_2, X("hello", 2))
 
         # try to append an item that cannot be mapped to a name
         with self.assertRaises(OdxError):
-            foo.append((0, 3))  # type: ignore[arg-type]
+            foo.append((0, 3)) # type: ignore[arg-type]
 
         # add a keyword identifier
         foo.append(X("as", 3))
         self.assertEqual(foo[3], X("as", 3))
         self.assertEqual(foo["_as"], X("as", 3))
-        self.assertEqual(foo._as, X("as", 3))  # type: ignore[attr-defined]
+        self.assertEqual(foo._as, X("as", 3))
 
         # add an object which's name conflicts with a method of the class
         foo.append(X("sort", 4))
         self.assertEqual(foo[4], X("sort", 4))
         self.assertEqual(foo["sort_2"], X("sort", 4))
-        self.assertEqual(foo.sort_2, X("sort", 4))  # type: ignore[attr-defined]
+        self.assertEqual(foo.sort_2, X("sort", 4))
 
         # test the get() function
         self.assertEqual(foo.get(0), X("hello", 0))
@@ -149,6 +150,13 @@ class TestNamedItemList(unittest.TestCase):
         self.assertEqual(set(foo.keys()), {"hello", "world", "hello_2", "_as", "sort_2"})
         self.assertEqual(len(foo.items()), len(foo))
         self.assertEqual(len(foo.values()), len(foo))
+
+        # ensure that mypy accepts NamedItemList objecs where List
+        # objects are expected
+        def bar(x: List[X]) -> None:
+            pass
+
+        bar(foo)
 
 
 class TestNavigation(unittest.TestCase):


### PR DESCRIPTION
With this applied, whenever a `List` is expected by the type checker, a `NamedItemList` object can be used as well.

Besides this, I cleaned up the `short_name_as_key()` functionality slightly.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
