### PR TITLE
CLI: introduce a non-strict mode to all tools

### DIFF
--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -3,9 +3,9 @@ import argparse
 import logging
 import sys
 from typing import List, Optional, Union
-from tabulate import tabulate  # TODO: switch to rich tables
 
 import PyInquirer.prompt as PI_prompt
+from tabulate import tabulate  # TODO: switch to rich tables
 
 from ..database import Database
 from ..dataobjectproperty import DataObjectProperty

--- a/odxtools/cli/main.py
+++ b/odxtools/cli/main.py
@@ -60,11 +60,10 @@ def start_cli() -> None:
 
     for tool in tool_modules:
         if tool._odxtools_tool_name_ == args.subparser_name:
+            orig_strict = odxtools.exceptions.strict_mode
             odxtools.exceptions.strict_mode = not args.no_strict
             try:
                 tool.run(args)
-            except:
-                raise
             finally:
-                odxtools.exceptions.strict_mode = False
+                odxtools.exceptions.strict_mode = orig_strict
             return

--- a/odxtools/cli/main.py
+++ b/odxtools/cli/main.py
@@ -3,6 +3,8 @@ import argparse
 import importlib
 from typing import Any, List
 
+import odxtools
+
 from ..version import __version__ as odxtools_version
 from .dummy_sub_parser import DummyTool
 
@@ -32,6 +34,14 @@ def start_cli() -> None:
     )
 
     argparser.add_argument(
+        "--no-strict",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Load the dataset in non-strict mode (which is more robust but might lead to undefined behavior)",
+    )
+
+    argparser.add_argument(
         "--version", required=False, action="store_true", help="Print the odxtools version")
 
     subparsers = argparser.add_subparsers(help="Select a subcommand", dest="subparser_name")
@@ -50,4 +60,11 @@ def start_cli() -> None:
 
     for tool in tool_modules:
         if tool._odxtools_tool_name_ == args.subparser_name:
-            tool.run(args)
+            odxtools.exceptions.strict_mode = not args.no_strict
+            try:
+                tool.run(args)
+            except:
+                raise
+            finally:
+                odxtools.exceptions.strict_mode = False
+            return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ class UtilFunctions:
 
     @staticmethod
     def run_list_tool(path_to_pdx_file: str = "./examples/somersault.pdx",
+                      no_strict: bool = False,
                       ecu_variants: Optional[List[str]] = None,
                       print_neg_responses: bool = False,
                       ecu_services: Optional[List[str]] = None,
@@ -30,6 +31,7 @@ class UtilFunctions:
                       dump_database: bool = False) -> None:
         list_args = Namespace(
             pdx_file=path_to_pdx_file,
+            no_strict=no_strict,
             variants=ecu_variants,
             global_negative_responses=print_neg_responses,
             services=ecu_services,
@@ -71,12 +73,14 @@ class UtilFunctions:
 
     @staticmethod
     def run_compare_tool(path_to_pdx_file: str = "./examples/somersault.pdx",
+                         no_strict: bool = False,
                          ecu_variants: Optional[List[str]] = None,
                          database: Optional[List[str]] = None,
                          no_details: bool = True) -> None:
 
         compare_args = Namespace(
             pdx_file=path_to_pdx_file,
+            no_strict=no_strict,
             variants=ecu_variants,
             database=database,
             no_details=no_details)
@@ -89,6 +93,7 @@ class TestCommandLineTools(unittest.TestCase):
     def test_list_tool(self) -> None:
 
         UtilFunctions.run_list_tool()
+        UtilFunctions.run_list_tool(no_strict=True)
         UtilFunctions.run_list_tool(ecu_variants=["somersault"])
         UtilFunctions.run_list_tool(print_neg_responses=True)
         UtilFunctions.run_list_tool(print_params=True)
@@ -114,11 +119,12 @@ class TestCommandLineTools(unittest.TestCase):
     def test_compare_tool(self) -> None:
 
         UtilFunctions.run_compare_tool()
-        UtilFunctions.run_compare_tool(database=[r"./examples/somersault_modified.pdx"])
+        UtilFunctions.run_compare_tool(database=["./examples/somersault_modified.pdx"])
+        UtilFunctions.run_compare_tool(no_strict=True)
         UtilFunctions.run_compare_tool(
-            database=[r"./examples/somersault_modified.pdx"], no_details=False)
+            database=["./examples/somersault_modified.pdx"], no_details=False)
         UtilFunctions.run_compare_tool(
-            database=[r"./examples/somersault_modified.pdx"], ecu_variants=["somersault_lazy"])
+            database=["./examples/somersault_modified.pdx"], ecu_variants=["somersault_lazy"])
         UtilFunctions.run_compare_tool(ecu_variants=[
             "somersault_lazy", "somersault_assiduous", "somersault_young", "somersault_old"
         ])


### PR DESCRIPTION
This is a spin-off of #256: it adds a non-strict mode to all comand line tools whilst the patch that used to be in #256 only dealt with `list` and `compare`. using this mode is more robust regarding incorrect input files, bugs and unimplemented features in odxtools, but it might cause undefined behaviour.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)