### PR TITLE
Address hardcoded DOCTYPE attribute for PARENT-REF

### DIFF
--- a/odxtools/templates/macros/printParentRef.xml.jinja2
+++ b/odxtools/templates/macros/printParentRef.xml.jinja2
@@ -5,8 +5,6 @@
 
 {%- macro printParentRef(par) -%}
 <PARENT-REF ID-REF="{{par.layer.odx_id.local_id}}"
-            DOCREF="{{par.layer.short_name}}"
-            DOCTYPE="CONTAINER"
             xsi:type="{{par.layer.variant_type.value}}-REF">
 {%- if par.not_inherited_diag_comms %}
  <NOT-INHERITED-DIAG-COMMS>


### PR DESCRIPTION
Addresses https://github.com/mercedes-benz/odxtools/issues/260

I'm not quite sure of the correct way to best handle this, I'm not 100% sure on the spec for PARENT-REF, but looking at the ISO 22901-1 document, I don't see any instances where the DOCTYPE attribute is used with PARENT-REF. Is there somewhere in the spec that lists DOCTYPE as a valid attribute for PARENT-REF?