### PR TITLE
use the correct value for the DOCREF in PARENT-REFs

### DIFF
--- a/odxtools/templates/macros/printParentRef.xml.jinja2
+++ b/odxtools/templates/macros/printParentRef.xml.jinja2
@@ -5,7 +5,7 @@
 
 {%- macro printParentRef(par) -%}
 <PARENT-REF ID-REF="{{par.layer.odx_id.local_id}}"
-            DOCREF="{{par.layer.short_name}}"
+            DOCREF="{{get_parent_container_name(par.layer.short_name)}}"
             DOCTYPE="CONTAINER"
             xsi:type="{{par.layer.variant_type.value}}-REF">
 {%- if par.not_inherited_diag_comms %}


### PR DESCRIPTION
this is supposed to be the short name of the container which contains the referenced layer, not the short name of the layer itself.

this might fix https://github.com/mercedes-benz/odxtools/issues/260. if it does, it is more generic than https://github.com/mercedes-benz/odxtools/pull/261 because with the approach suggested here, the parent of a layer does not necessarily need to be in the same container.

@willzhang05: can you check if the resulting files work with odxstudio for you?

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)