### PR TITLE
Refactor decoding, part 1

### DIFF
--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict
 
 from .odxtypes import ParameterValueDict
+
+if TYPE_CHECKING:
+    from .tablerow import TableRow
 
 
 @dataclass
@@ -11,8 +15,22 @@ class DecodeState:
     #: bytes to be decoded
     coded_message: bytes
 
-    #: values of already decoded parameters
+    # TODO: remove this!
     parameter_values: ParameterValueDict
 
-    #: Position of the next parameter if its position is not specified in ODX
-    cursor_position: int
+    #: Absolute position of the origin
+    #:
+    #: i.e., the absolute byte position to which all relative positions
+    #: refer to, e.g. the position of the first byte of a structure.
+    origin_position: int = 0
+
+    #: Absolute position of the next undecoded byte to be considered
+    #:
+    #: (if not explicitly specified by the object to be decoded.)
+    cursor_position: int = 0
+
+    #: values of the length key parameters decoded so far
+    length_keys: Dict[str, int] = field(default_factory=dict)
+
+    #: values of the table key parameters decoded so far
+    table_keys: Dict[str, "TableRow"] = field(default_factory=dict)

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -2,8 +2,6 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict
 
-from .odxtypes import ParameterValueDict
-
 if TYPE_CHECKING:
     from .tablerow import TableRow
 
@@ -14,9 +12,6 @@ class DecodeState:
 
     #: bytes to be decoded
     coded_message: bytes
-
-    # TODO: remove this!
-    parameter_values: ParameterValueDict
 
     #: Absolute position of the origin
     #:

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-from copy import copy
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 from xml.etree import ElementTree
@@ -62,18 +61,16 @@ class EndOfPduField(Field):
     def convert_bytes_to_physical(self,
                                   decode_state: DecodeState,
                                   bit_position: int = 0) -> Tuple[ParameterValue, int]:
-        decode_state = copy(decode_state)
         cursor_position = decode_state.cursor_position
-        byte_code = decode_state.coded_message
 
         value = []
-        while len(byte_code) > cursor_position:
+        while cursor_position < len(decode_state.coded_message):
             # ATTENTION: the ODX specification is very misleading
             # here: it says that the item is repeated until the end of
             # the PDU, but it means that DOP of the items that are
             # repeated are identical, not their values
             new_value, cursor_position = self.structure.convert_bytes_to_physical(
-                decode_state, bit_position=bit_position)
+                decode_state, bit_position=0)
             # Update next byte_position
             decode_state.cursor_position = cursor_position
             value.append(new_value)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+from copy import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from xml.etree import ElementTree
@@ -114,12 +115,12 @@ class Multiplexer(ComplexDop):
                               f"{self.short_name} was passed the bit position {bit_position}")
         key_value, key_next_byte = self.switch_key.dop.convert_bytes_to_physical(decode_state)
 
-        byte_code = decode_state.coded_message[decode_state.cursor_position:]
-        case_decode_state = DecodeState(
-            coded_message=byte_code[self.byte_position:],
-            parameter_values={},
-            cursor_position=0,
-        )
+        case_decode_state = copy(decode_state)
+        if self.byte_position is not None:
+            case_decode_state.origin_position = decode_state.origin_position + self.byte_position
+        else:
+            case_decode_state.origin_position = decode_state.cursor_position
+
         case_found = False
         case_next_byte = 0
         case_value = None

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
-from ..exceptions import odxrequire
+from ..exceptions import odxraise, odxrequire
 from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import ParameterValue
 from .parameter import ParameterType
@@ -67,4 +67,11 @@ class LengthKeyParameter(ParameterWithDOP):
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        return super().decode_from_pdu(decode_state)
+        phys_val, cursor_position = super().decode_from_pdu(decode_state)
+
+        if not isinstance(phys_val, int):
+            odxraise(f"The pysical type of length keys must be an integer, "
+                     f"(is {type(phys_val).__name__})")
+        decode_state.length_keys[self.short_name] = phys_val
+
+        return phys_val, cursor_position

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -38,8 +38,9 @@ class MatchingRequestParameter(Parameter):
                                                self.byte_length]
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        byte_position = (
-            self.byte_position if self.byte_position is not None else decode_state.cursor_position)
+        byte_position = decode_state.cursor_position
+        if self.byte_position is not None:
+            byte_position = decode_state.origin_position + self.byte_position
         bit_position = self.bit_position or 0
         byte_length = (8 * self.byte_length + bit_position + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:byte_position + byte_length]

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -139,7 +139,6 @@ class TableKeyParameter(Parameter):
         if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
             cursor_position = self.byte_position
 
-        # update the decode_state's table key
         if self.table_row is not None:
             # the table row to be used is statically specified -> no
             # need to decode anything!
@@ -158,6 +157,10 @@ class TableKeyParameter(Parameter):
             elif len(table_row_candidates) > 1:
                 raise DecodeError(
                     f"Multiple rows exhibiting key '{str(key_dop_val)}' found in table")
-            phys_val = table_row_candidates[0].short_name
+            table_row = table_row_candidates[0]
+            phys_val = table_row.short_name
+
+            # update the decode_state's table key
+            decode_state.table_keys[self.short_name] = table_row
 
         return phys_val, cursor_position

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -135,13 +135,13 @@ class TableStructParameter(Parameter):
         # find the selected table row
         key_name = self.table_key.short_name
 
-        table = self.table_key.table
-        tr_short_name = decode_state.parameter_values[key_name]
-        candidate_trs = [tr for tr in table.table_rows if tr.short_name == tr_short_name]
-        if len(candidate_trs) != 1:
-            raise EncodeError(f"Could not uniquely resolve a table row named "
-                              f"'{str(tr_short_name)}' in table '{str(table.short_name)}' ")
-        table_row = candidate_trs[0]
+        decode_state.table_keys[key_name]
+        table_row = decode_state.table_keys.get(key_name)
+        if table_row is None:
+            raise odxraise(f"No table key '{key_name}' found when decoding "
+                           f"table struct parameter '{str(self.short_name)}'")
+            dummy_val = cast(str, None), cast(int, None)
+            return dummy_val, decode_state.cursor_position
 
         # Use DOP or structure to decode the value
         if table_row.dop is not None:
@@ -153,5 +153,5 @@ class TableStructParameter(Parameter):
             return (table_row.short_name, val), i
         else:
             # the table row associated with the key neither defines a
-            # DOP not a structure -> ignore it
+            # DOP nor a structure -> ignore it
             return (table_row.short_name, cast(int, None)), decode_state.cursor_position

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -107,10 +107,6 @@ class TableStructParameter(Parameter):
         bit_position = self.bit_position or 0
         if tr.structure is not None:
             # the selected table row references a structure
-            if not isinstance(tr_value, dict):
-                raise EncodeError(f"The value of `{tr_short_name}` must "
-                                  f"be a key-value dictionary.")
-
             inner_encode_state = EncodeState(
                 coded_message=b'',
                 parameter_values=tr_value,
@@ -153,8 +149,7 @@ class TableStructParameter(Parameter):
             val, i = dop.convert_bytes_to_physical(decode_state)
             return (table_row.short_name, val), i
         elif table_row.structure is not None:
-            structure = table_row.structure
-            val, i = structure.convert_bytes_to_physical(decode_state)
+            val, i = table_row.structure.convert_bytes_to_physical(decode_state)
             return (table_row.short_name, val), i
         else:
             # the table row associated with the key neither defines a

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -78,17 +78,17 @@ class ParamLengthInfoType(DiagCodedType):
                                   decode_state: DecodeState,
                                   bit_position: int = 0) -> Tuple[AtomicOdxType, int]:
         # Find length key with matching ID.
-        bit_length = None
-        for parameter_name, value in decode_state.parameter_values.items():
-            if parameter_name == self.length_key.short_name:
-                # The bit length of the parameter to be extracted is given by the length key.
-                bit_length = value
-                if not isinstance(bit_length, int):
-                    odxraise(f"The bit length must be an integer, is {type(bit_length)}")
-                break
+        bit_length = 0
 
-        if not isinstance(bit_length, int):
-            odxraise(f"Did not find any length key with short name {self.length_key.short_name}")
+        # The bit length of the parameter to be extracted is given by the length key.
+        if self.length_key.short_name not in decode_state.length_keys:
+            odxraise(f"Unspecified mandatory length key parameter "
+                     f"{self.length_key.short_name}")
+        else:
+            bit_length = decode_state.length_keys[self.length_key.short_name]
+            if not isinstance(bit_length, int):
+                odxraise(f"The bit length must be an integer, is {type(bit_length)}")
+                bit_length = 0
 
         # Extract the internal value and return.
         return self._extract_internal_value(

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -888,7 +888,7 @@ class TestDecoding(unittest.TestCase):
         diag_layer._resolve_odxlinks(odxlinks)
         diag_layer._finalize_init(odxlinks)
 
-        coded_message = bytes([0x12, 0x34, 0x34])
+        coded_message = bytes([0x12, 0x34, 0x54])
         expected_message = Message(
             coded_message=coded_message,
             service=service,
@@ -903,7 +903,7 @@ class TestDecoding(unittest.TestCase):
                     },
                     {
                         "struct_param_1": 4,
-                        "struct_param_2": 3
+                        "struct_param_2": 5
                     },
                 ],
             },

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -40,7 +40,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x2, 0x34, 0x56]), {}, 0)
+        state = DecodeState(bytes([0x2, 0x34, 0x56]), {}, cursor_position=0)
         internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
 
@@ -50,7 +50,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), {}, 1)
+        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), {}, cursor_position=1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
@@ -63,7 +63,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x0, 0x1]), {}, 0)
+        state = DecodeState(bytes([0x0, 0x1]), {}, cursor_position=0)
         internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, b'')
         self.assertEqual(cursor_position, 1)
@@ -110,7 +110,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), {}, 1)
+        state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), {}, cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, "a9")
         self.assertEqual(cursor_position, 6)
@@ -121,7 +121,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=False,
         )
-        state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), {}, 1)
+        state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), {}, cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, "a9")
         self.assertEqual(cursor_position, 6)
@@ -312,7 +312,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x72, 0x3]), {}, 1)
+        state = DecodeState(bytes([0x1, 0x72, 0x3]), {}, cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
         self.assertEqual(internal, 25)
         self.assertEqual(cursor_position, 2)
@@ -326,7 +326,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=False,
             is_condensed_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x2, 0x3]), {}, 1)
+        state = DecodeState(bytes([0x1, 0x2, 0x3]), {}, cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, 0x0302)
         self.assertEqual(cursor_position, 3)
@@ -340,7 +340,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), {}, 1)
+        state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), {}, cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
         self.assertEqual(cursor_position, 3)
@@ -613,7 +613,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             termination="HEX-FF",
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), {}, 1)
+        state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), {}, cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, bytes([0xFF, 0x34, 0x56]))
         self.assertEqual(cursor_position, 5)
@@ -628,7 +628,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             termination="HEX-FF",
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0xFF]), {}, 1)
+        state = DecodeState(bytes([0x12, 0xFF]), {}, cursor_position=1)
         self.assertRaises(DecodeError, dct.convert_bytes_to_internal, state)
 
     def test_decode_min_max_length_type_end_of_pdu(self) -> None:
@@ -642,7 +642,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 termination=termination,
                 is_highlow_byte_order_raw=None,
             )
-            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), {}, 1)
+            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), {}, cursor_position=1)
             internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
             self.assertEqual(internal, bytes([0x34, 0x56, 0x78, 0x9A]))
             self.assertEqual(cursor_position, 5)
@@ -658,7 +658,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 termination=termination,
                 is_highlow_byte_order_raw=None,
             )
-            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), {}, 1)
+            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), {}, cursor_position=1)
             internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
             self.assertEqual(internal, bytes([0x34, 0x56, 0x78]))
             self.assertEqual(cursor_position, 4)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -40,7 +40,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x2, 0x34, 0x56]), {}, cursor_position=0)
+        state = DecodeState(bytes([0x2, 0x34, 0x56]), cursor_position=0)
         internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
 
@@ -50,7 +50,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), cursor_position=1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
@@ -63,7 +63,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x0, 0x1]), {}, cursor_position=0)
+        state = DecodeState(bytes([0x0, 0x1]), cursor_position=0)
         internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
         self.assertEqual(internal, b'')
         self.assertEqual(cursor_position, 1)
@@ -110,7 +110,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, "a9")
         self.assertEqual(cursor_position, 6)
@@ -121,7 +121,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=False,
         )
-        state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, "a9")
         self.assertEqual(cursor_position, 6)
@@ -312,7 +312,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x72, 0x3]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x1, 0x72, 0x3]), cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
         self.assertEqual(internal, 25)
         self.assertEqual(cursor_position, 2)
@@ -326,7 +326,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=False,
             is_condensed_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x2, 0x3]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x1, 0x2, 0x3]), cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, 0x0302)
         self.assertEqual(cursor_position, 3)
@@ -340,7 +340,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, bytes([0x34, 0x56]))
         self.assertEqual(cursor_position, 3)
@@ -374,7 +374,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         dct._resolve_odxlinks(odxlinks)
         state = DecodeState(
             coded_message=bytes([0x10, 0x12, 0x34, 0x56]),
-            parameter_values={length_key.short_name: 16},
+            length_keys={length_key.short_name: 16},
             cursor_position=1,
         )
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
@@ -613,7 +613,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             termination="HEX-FF",
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), cursor_position=1)
         internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
         self.assertEqual(internal, bytes([0xFF, 0x34, 0x56]))
         self.assertEqual(cursor_position, 5)
@@ -628,7 +628,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             termination="HEX-FF",
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0xFF]), {}, cursor_position=1)
+        state = DecodeState(bytes([0x12, 0xFF]), cursor_position=1)
         self.assertRaises(DecodeError, dct.convert_bytes_to_internal, state)
 
     def test_decode_min_max_length_type_end_of_pdu(self) -> None:
@@ -642,7 +642,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 termination=termination,
                 is_highlow_byte_order_raw=None,
             )
-            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), {}, cursor_position=1)
+            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
             internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
             self.assertEqual(internal, bytes([0x34, 0x56, 0x78, 0x9A]))
             self.assertEqual(cursor_position, 5)
@@ -658,7 +658,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 termination=termination,
                 is_highlow_byte_order_raw=None,
             )
-            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), {}, cursor_position=1)
+            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
             internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
             self.assertEqual(internal, bytes([0x34, 0x56, 0x78]))
             self.assertEqual(cursor_position, 4)


### PR DESCRIPTION
This is the first PR of a mini series to refactor the decoding code of odxtools. In this PR, we refactor the `DecodeState` class with the aim of not having to create copies during the decoding process:

- the attributes `cursor_position` and `origin_position` are introduced. The former points to the first undecoded byte whilst the latter points to the byte to which relative positions given by the BYTE-POSITION tag refer to.
- the `parameter_values` property is removed. Instead, the parameter values are kept as local variables in the respective decoding functions.
- `length_keys` and `table_keys` attributes are introduced, to keep track of inter-parameter dependencies

note that the "do not create copies" aim is not yet fully reached after this PR, but it will be at the end of this PR series...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)