### PR TITLE
Refactor decoding, part 2

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -234,20 +234,21 @@ class BasicStructure(ComplexDop):
 
         # move the origin since positions specified by sub-parameters of
         # structures are relative to the beginning of the structure object.
-        orig_origin = decode_state.origin_position
-        decode_state.origin_position = decode_state.cursor_position
+        orig_origin = decode_state.origin_byte_position
+        decode_state.origin_byte_position = decode_state.cursor_byte_position
 
         result = {}
         for param in self.parameters:
-            value, cursor_position = param.decode_from_pdu(decode_state)
+            value, cursor_byte_position = param.decode_from_pdu(decode_state)
 
             result[param.short_name] = value
-            decode_state.cursor_position = max(decode_state.cursor_position, cursor_position)
+            decode_state.cursor_byte_position = max(decode_state.cursor_byte_position,
+                                                    cursor_byte_position)
 
         # decoding of the structure finished. move back the origin.
-        decode_state.origin_position = orig_origin
+        decode_state.origin_byte_position = orig_origin
 
-        return result, decode_state.cursor_position
+        return result, decode_state.cursor_byte_position
 
     def encode(self, coded_request: Optional[bytes] = None, **params: ParameterValue) -> bytes:
         """
@@ -267,14 +268,14 @@ class BasicStructure(ComplexDop):
     def decode(self, message: bytes) -> ParameterValueDict:
         # dummy decode state to be passed to convert_bytes_to_physical
         decode_state = DecodeState(coded_message=message)
-        param_values, cursor_position = self.convert_bytes_to_physical(decode_state)
+        param_values, cursor_byte_position = self.convert_bytes_to_physical(decode_state)
         if not isinstance(param_values, dict):
             odxraise(f"Decoding a structure must result in a dictionary of parameter "
                      f"values (is {type(param_values)})")
-        if len(message) != cursor_position:
+        if len(message) != cursor_byte_position:
             warnings.warn(
                 f"The message {message.hex()} is longer than could be parsed."
-                f" Expected {cursor_position} but got {len(message)}.",
+                f" Expected {cursor_byte_position} but got {len(message)}.",
                 DecodeError,
                 stacklevel=1,
             )

--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from typing import List, Optional, Union
 
-import PyInquirer.prompt as PI_prompt
+from InquirerPy import prompt as PI_prompt
 from tabulate import tabulate  # TODO: switch to rich tables
 
 from ..database import Database

--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import sys
+import traceback
+from io import StringIO
 
 
 class DummyTool:
@@ -19,10 +21,17 @@ class DummyTool:
         self._error = error
 
     def add_subparser(self, subparser_list: "argparse._SubParsersAction") -> None:
+        desc = StringIO()
+
+        print(f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}", file=desc)
+        print(file=desc)
+        print(f"Traceback:", file=desc)
+        traceback.print_tb(self._error.__traceback__, file=desc)
+
         subparser_list.add_parser(
             self._odxtools_tool_name_,
-            description=f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}",
-            help="Dummy tool",
+            description=desc.getvalue(),
+            help="Tool unavailable",
             formatter_class=argparse.RawTextHelpFormatter,
         )
 

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -143,11 +143,11 @@ class DataObjectProperty(DopBase):
         """
         odxassert(0 <= bit_position and bit_position < 8)
 
-        internal, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
-            decode_state, bit_position=bit_position)
+        internal = self.diag_coded_type.decode_from_pdu(decode_state, bit_position=bit_position)
 
         if self.compu_method.is_valid_internal_value(internal):
-            return self.compu_method.convert_internal_to_physical(internal), cursor_position
+            return self.compu_method.convert_internal_to_physical(
+                internal), decode_state.cursor_position
         else:
             # TODO: How to prevent this?
             raise DecodeError(

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -148,7 +148,7 @@ class DataObjectProperty(DopBase):
 
         if self.compu_method.is_valid_internal_value(internal):
             return self.compu_method.convert_internal_to_physical(
-                internal), decode_state.cursor_position
+                internal), decode_state.cursor_byte_position
         else:
             # TODO: How to prevent this?
             raise DecodeError(

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -143,7 +143,8 @@ class DataObjectProperty(DopBase):
         """
         odxassert(0 <= bit_position and bit_position < 8)
 
-        internal = self.diag_coded_type.decode_from_pdu(decode_state, bit_position=bit_position)
+        decode_state.cursor_bit_position = bit_position
+        internal = self.diag_coded_type.decode_from_pdu(decode_state)
 
         if self.compu_method.is_valid_internal_value(internal):
             return self.compu_method.convert_internal_to_physical(

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -17,12 +17,12 @@ class DecodeState:
     #:
     #: i.e., the absolute byte position to which all relative positions
     #: refer to, e.g. the position of the first byte of a structure.
-    origin_position: int = 0
+    origin_byte_position: int = 0
 
     #: Absolute position of the next undecoded byte to be considered
     #:
     #: (if not explicitly specified by the object to be decoded.)
-    cursor_position: int = 0
+    cursor_byte_position: int = 0
 
     #: the bit position [0, 7] where the object to be extracted begins
     #:

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Optional
 
 if TYPE_CHECKING:
     from .tablerow import TableRow
@@ -23,6 +23,12 @@ class DecodeState:
     #:
     #: (if not explicitly specified by the object to be decoded.)
     cursor_position: int = 0
+
+    #: the bit position [0, 7] where the object to be extracted begins
+    #:
+    #: If bit position is undefined (`None`), the object to be extracted
+    #: starts at bit 0.
+    cursor_bit_position: Optional[int] = None
 
     #: values of the length key parameters decoded so far
     length_keys: Dict[str, int] = field(default_factory=dict)

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from .tablerow import TableRow
@@ -28,7 +28,7 @@ class DecodeState:
     #:
     #: If bit position is undefined (`None`), the object to be extracted
     #: starts at bit 0.
-    cursor_bit_position: Optional[int] = None
+    cursor_bit_position: int = 0
 
     #: values of the length key parameters decoded so far
     length_keys: Dict[str, int] = field(default_factory=dict)

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -254,9 +254,7 @@ class DiagCodedType(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def convert_bytes_to_internal(self,
-                                  decode_state: DecodeState,
-                                  bit_position: int = 0) -> Tuple[AtomicOdxType, int]:
+    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
         """Decode the parameter value from the coded message.
 
         Parameters

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -91,8 +91,8 @@ class DiagCodedType(abc.ABC):
         byte_length = (bit_length + bit_position + 7) // 8
         if byte_position + byte_length > len(coded_message):
             raise DecodeError(f"Expected a longer message.")
-        cursor_position = byte_position + byte_length
-        extracted_bytes = coded_message[byte_position:cursor_position]
+        cursor_byte_position = byte_position + byte_length
+        extracted_bytes = coded_message[byte_position:cursor_byte_position]
 
         # Apply byteorder for numerical objects. Note that doing this
         # here might lead to garbage data being included in the result
@@ -129,7 +129,7 @@ class DiagCodedType(abc.ABC):
             text_encoding = "utf-16-be" if is_highlow_byte_order else "utf-16-le"
             internal_value = internal_value.decode(encoding=text_encoding, errors=text_errors)
 
-        return internal_value, cursor_position
+        return internal_value, cursor_byte_position
 
     @staticmethod
     def _encode_internal_value(

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -254,7 +254,7 @@ class DiagCodedType(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
+    def decode_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
         """Decode the parameter value from the coded message.
 
         Parameters

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -91,7 +91,7 @@ class DtcDop(DopBase):
                                   decode_state: DecodeState,
                                   bit_position: int = 0) -> Tuple[ParameterValue, int]:
 
-        int_trouble_code, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
+        int_trouble_code = self.diag_coded_type.decode_from_pdu(
             decode_state, bit_position=bit_position)
 
         if self.compu_method.is_valid_internal_value(int_trouble_code):
@@ -110,7 +110,7 @@ class DtcDop(DopBase):
 
         if len(dtcs) == 1:
             # we found exactly one described DTC
-            return dtcs[0], cursor_position
+            return dtcs[0], decode_state.cursor_position
 
         # the DTC was not specified. This probably means that the
         # diagnostic description file is incomplete. We do not bail
@@ -129,7 +129,7 @@ class DtcDop(DopBase):
             sdgs=[],
         )
 
-        return dtc, cursor_position
+        return dtc, decode_state.cursor_position
 
     def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
                                   bit_position: int) -> bytes:

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -91,8 +91,8 @@ class DtcDop(DopBase):
                                   decode_state: DecodeState,
                                   bit_position: int = 0) -> Tuple[ParameterValue, int]:
 
-        int_trouble_code = self.diag_coded_type.decode_from_pdu(
-            decode_state, bit_position=bit_position)
+        decode_state.cursor_bit_position = bit_position
+        int_trouble_code = self.diag_coded_type.decode_from_pdu(decode_state)
 
         if self.compu_method.is_valid_internal_value(int_trouble_code):
             trouble_code = self.compu_method.convert_internal_to_physical(int_trouble_code)

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -110,7 +110,7 @@ class DtcDop(DopBase):
 
         if len(dtcs) == 1:
             # we found exactly one described DTC
-            return dtcs[0], decode_state.cursor_position
+            return dtcs[0], decode_state.cursor_byte_position
 
         # the DTC was not specified. This probably means that the
         # diagnostic description file is incomplete. We do not bail
@@ -129,7 +129,7 @@ class DtcDop(DopBase):
             sdgs=[],
         )
 
-        return dtc, decode_state.cursor_position
+        return dtc, decode_state.cursor_byte_position
 
     def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
                                   bit_position: int) -> bytes:

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -61,18 +61,18 @@ class EndOfPduField(Field):
     def convert_bytes_to_physical(self,
                                   decode_state: DecodeState,
                                   bit_position: int = 0) -> Tuple[ParameterValue, int]:
-        cursor_position = decode_state.cursor_position
+        cursor_byte_position = decode_state.cursor_byte_position
 
         value = []
-        while cursor_position < len(decode_state.coded_message):
+        while cursor_byte_position < len(decode_state.coded_message):
             # ATTENTION: the ODX specification is very misleading
             # here: it says that the item is repeated until the end of
             # the PDU, but it means that DOP of the items that are
             # repeated are identical, not their values
-            new_value, cursor_position = self.structure.convert_bytes_to_physical(
+            new_value, cursor_byte_position = self.structure.convert_bytes_to_physical(
                 decode_state, bit_position=0)
             # Update next byte_position
-            decode_state.cursor_position = cursor_position
+            decode_state.cursor_byte_position = cursor_byte_position
             value.append(new_value)
 
-        return value, cursor_position
+        return value, cursor_byte_position

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
@@ -65,9 +65,7 @@ class LeadingLengthInfoType(DiagCodedType):
 
         return length_bytes + value_bytes
 
-    def convert_bytes_to_internal(self,
-                                  decode_state: DecodeState,
-                                  bit_position: int = 0) -> Tuple[AtomicOdxType, int]:
+    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
         coded_message = decode_state.coded_message
 
         # Extract length of the parameter value
@@ -95,4 +93,5 @@ class LeadingLengthInfoType(DiagCodedType):
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
 
-        return value, cursor_position
+        decode_state.cursor_position = cursor_position
+        return value

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -65,18 +65,19 @@ class LeadingLengthInfoType(DiagCodedType):
 
         return length_bytes + value_bytes
 
-    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
+    def decode_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
         coded_message = decode_state.coded_message
 
         # Extract length of the parameter value
         byte_length, byte_position = self._extract_internal_value(
             coded_message=coded_message,
             byte_position=decode_state.cursor_position,
-            bit_position=bit_position,
+            bit_position=decode_state.cursor_bit_position or 0,
             bit_length=self.bit_length,
             base_data_type=DataType.A_UINT32,  # length is an integer
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
+        decode_state.cursor_bit_position = None
 
         if not isinstance(byte_length, int):
             odxraise()

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -72,12 +72,12 @@ class LeadingLengthInfoType(DiagCodedType):
         byte_length, byte_position = self._extract_internal_value(
             coded_message=coded_message,
             byte_position=decode_state.cursor_byte_position,
-            bit_position=decode_state.cursor_bit_position or 0,
+            bit_position=decode_state.cursor_bit_position,
             bit_length=self.bit_length,
             base_data_type=DataType.A_UINT32,  # length is an integer
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
-        decode_state.cursor_bit_position = None
+        decode_state.cursor_bit_position = 0
 
         if not isinstance(byte_length, int):
             odxraise()

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -71,7 +71,7 @@ class LeadingLengthInfoType(DiagCodedType):
         # Extract length of the parameter value
         byte_length, byte_position = self._extract_internal_value(
             coded_message=coded_message,
-            byte_position=decode_state.cursor_position,
+            byte_position=decode_state.cursor_byte_position,
             bit_position=decode_state.cursor_bit_position or 0,
             bit_length=self.bit_length,
             base_data_type=DataType.A_UINT32,  # length is an integer
@@ -85,7 +85,7 @@ class LeadingLengthInfoType(DiagCodedType):
         # Extract actual value
         # TODO: The returned value is None if the byte_length is 0. Maybe change it
         #       to some default value like an empty bytearray() or 0?
-        value, cursor_position = self._extract_internal_value(
+        value, cursor_byte_position = self._extract_internal_value(
             coded_message=coded_message,
             byte_position=byte_position,
             bit_position=0,
@@ -94,5 +94,5 @@ class LeadingLengthInfoType(DiagCodedType):
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
 
-        decode_state.cursor_position = cursor_position
+        decode_state.cursor_byte_position = cursor_byte_position
         return value

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -101,11 +101,11 @@ class MinMaxLengthType(DiagCodedType):
         return value_bytes
 
     def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
-        if decode_state.cursor_position + self.min_length > len(decode_state.coded_message):
+        if decode_state.cursor_byte_position + self.min_length > len(decode_state.coded_message):
             raise DecodeError("The PDU ended before minimum length was reached.")
 
         coded_message = decode_state.coded_message
-        cursor_pos = decode_state.cursor_position
+        cursor_pos = decode_state.cursor_byte_position
         termination_seq = self.__termination_sequence()
 
         max_terminator_pos = len(coded_message)
@@ -156,7 +156,7 @@ class MinMaxLengthType(DiagCodedType):
                 byte_pos += len(termination_seq)
 
             # next byte starts after the actual data and the termination sequence
-            decode_state.cursor_position = byte_pos
+            decode_state.cursor_byte_position = byte_pos
             decode_state.cursor_bit_position = None
 
             return value
@@ -174,7 +174,7 @@ class MinMaxLengthType(DiagCodedType):
                 is_highlow_byte_order=self.is_highlow_byte_order,
             )
 
-            decode_state.cursor_position = byte_pos
+            decode_state.cursor_byte_position = byte_pos
             decode_state.cursor_bit_position = None
 
             return value

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -157,7 +157,7 @@ class MinMaxLengthType(DiagCodedType):
 
             # next byte starts after the actual data and the termination sequence
             decode_state.cursor_byte_position = byte_pos
-            decode_state.cursor_bit_position = None
+            decode_state.cursor_bit_position = 0
 
             return value
         else:
@@ -175,6 +175,6 @@ class MinMaxLengthType(DiagCodedType):
             )
 
             decode_state.cursor_byte_position = byte_pos
-            decode_state.cursor_bit_position = None
+            decode_state.cursor_bit_position = 0
 
             return value

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -146,7 +146,7 @@ class MinMaxLengthType(DiagCodedType):
             value, byte_pos = self._extract_internal_value(
                 decode_state.coded_message,
                 byte_position=cursor_pos,
-                bit_position=bit_position,
+                bit_position=0,
                 bit_length=8 * byte_length,
                 base_data_type=self.base_data_type,
                 is_highlow_byte_order=self.is_highlow_byte_order,
@@ -157,6 +157,8 @@ class MinMaxLengthType(DiagCodedType):
 
             # next byte starts after the actual data and the termination sequence
             decode_state.cursor_position = byte_pos
+            decode_state.cursor_bit_position = None
+
             return value
         else:
             # If termination == "END-OF-PDU", the parameter ends after max_length
@@ -166,11 +168,13 @@ class MinMaxLengthType(DiagCodedType):
             value, byte_pos = self._extract_internal_value(
                 decode_state.coded_message,
                 byte_position=cursor_pos,
-                bit_position=bit_position,
+                bit_position=0,
                 bit_length=8 * byte_length,
                 base_data_type=self.base_data_type,
                 is_highlow_byte_order=self.is_highlow_byte_order,
             )
 
             decode_state.cursor_position = byte_pos
+            decode_state.cursor_bit_position = None
+
             return value

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 
 from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
@@ -100,9 +100,7 @@ class MinMaxLengthType(DiagCodedType):
 
         return value_bytes
 
-    def convert_bytes_to_internal(self,
-                                  decode_state: DecodeState,
-                                  bit_position: int = 0) -> Tuple[AtomicOdxType, int]:
+    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
         if decode_state.cursor_position + self.min_length > len(decode_state.coded_message):
             raise DecodeError("The PDU ended before minimum length was reached.")
 
@@ -158,7 +156,8 @@ class MinMaxLengthType(DiagCodedType):
                 byte_pos += len(termination_seq)
 
             # next byte starts after the actual data and the termination sequence
-            return value, byte_pos
+            decode_state.cursor_position = byte_pos
+            return value
         else:
             # If termination == "END-OF-PDU", the parameter ends after max_length
             # or at the end of the PDU.
@@ -172,4 +171,6 @@ class MinMaxLengthType(DiagCodedType):
                 base_data_type=self.base_data_type,
                 is_highlow_byte_order=self.is_highlow_byte_order,
             )
-            return value, byte_pos
+
+            decode_state.cursor_position = byte_pos
+            return value

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -117,9 +117,9 @@ class Multiplexer(ComplexDop):
 
         case_decode_state = copy(decode_state)
         if self.byte_position is not None:
-            case_decode_state.origin_position = decode_state.origin_position + self.byte_position
+            case_decode_state.origin_byte_position = decode_state.origin_byte_position + self.byte_position
         else:
-            case_decode_state.origin_position = decode_state.cursor_position
+            case_decode_state.origin_byte_position = decode_state.cursor_byte_position
 
         case_found = False
         case_next_byte = 0
@@ -144,7 +144,7 @@ class Multiplexer(ComplexDop):
                 f"Failed to find a matching case in {self.short_name} for value {key_value!r}")
 
         mux_value = {case.short_name: cast(ParameterValue, case_value)}
-        mux_next_byte = decode_state.cursor_position + max(
+        mux_next_byte = decode_state.cursor_byte_position + max(
             key_next_byte + self.switch_key.byte_position, case_next_byte + self.byte_position)
         return mux_value, mux_next_byte
 

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -68,10 +68,8 @@ class CodedConstParameter(Parameter):
         if self.byte_position is not None:
             decode_state.cursor_position = decode_state.origin_position + self.byte_position
 
-        coded_val, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
-            decode_state, bit_position=self.bit_position or 0)
-
-        decode_state.cursor_position = orig_cursor_pos
+        bit_pos = self.bit_position or 0
+        coded_val = self.diag_coded_type.decode_from_pdu(decode_state, bit_position=bit_pos)
 
         # Check if the coded value in the message is correct.
         if self.coded_value != coded_val:
@@ -85,7 +83,9 @@ class CodedConstParameter(Parameter):
                 stacklevel=1,
             )
 
-        return coded_val, cursor_position
+        decode_state.cursor_position = max(orig_cursor_pos, decode_state.cursor_position)
+
+        return coded_val, decode_state.cursor_position
 
     @property
     def _coded_value_str(self) -> str:

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -68,8 +68,8 @@ class CodedConstParameter(Parameter):
         if self.byte_position is not None:
             decode_state.cursor_position = decode_state.origin_position + self.byte_position
 
-        bit_pos = self.bit_position or 0
-        coded_val = self.diag_coded_type.decode_from_pdu(decode_state, bit_position=bit_pos)
+        decode_state.cursor_bit_position = self.bit_position
+        coded_val = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.
         if self.coded_value != coded_val:

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -64,9 +64,9 @@ class CodedConstParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[AtomicOdxType, int]:
         # Extract coded values
-        orig_cursor_pos = decode_state.cursor_position
+        orig_cursor_pos = decode_state.cursor_byte_position
         if self.byte_position is not None:
-            decode_state.cursor_position = decode_state.origin_position + self.byte_position
+            decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
 
         decode_state.cursor_bit_position = self.bit_position
         coded_val = self.diag_coded_type.decode_from_pdu(decode_state)
@@ -77,15 +77,15 @@ class CodedConstParameter(Parameter):
                 f"Coded constant parameter does not match! "
                 f"The parameter {self.short_name} expected coded "
                 f"value {str(self._coded_value_str)} but got {str(coded_val)} "
-                f"at byte position {decode_state.cursor_position} "
+                f"at byte position {decode_state.cursor_byte_position} "
                 f"in coded message {decode_state.coded_message.hex()}.",
                 DecodeError,
                 stacklevel=1,
             )
 
-        decode_state.cursor_position = max(orig_cursor_pos, decode_state.cursor_position)
+        decode_state.cursor_byte_position = max(orig_cursor_pos, decode_state.cursor_byte_position)
 
-        return coded_val, decode_state.cursor_position
+        return coded_val, decode_state.cursor_byte_position
 
     @property
     def _coded_value_str(self) -> str:

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -68,7 +68,7 @@ class CodedConstParameter(Parameter):
         if self.byte_position is not None:
             decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
 
-        decode_state.cursor_bit_position = self.bit_position
+        decode_state.cursor_bit_position = self.bit_position or 0
         coded_val = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -67,11 +67,11 @@ class LengthKeyParameter(ParameterWithDOP):
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        phys_val, cursor_position = super().decode_from_pdu(decode_state)
+        phys_val, cursor_byte_position = super().decode_from_pdu(decode_state)
 
         if not isinstance(phys_val, int):
             odxraise(f"The pysical type of length keys must be an integer, "
                      f"(is {type(phys_val).__name__})")
         decode_state.length_keys[self.short_name] = phys_val
 
-        return phys_val, cursor_position
+        return phys_val, cursor_byte_position

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -38,9 +38,9 @@ class MatchingRequestParameter(Parameter):
                                                self.byte_length]
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        byte_position = decode_state.cursor_position
+        byte_position = decode_state.cursor_byte_position
         if self.byte_position is not None:
-            byte_position = decode_state.origin_position + self.byte_position
+            byte_position = decode_state.origin_byte_position + self.byte_position
         bit_position = self.bit_position or 0
         byte_length = (8 * self.byte_length + bit_position + 7) // 8
         val_as_bytes = decode_state.coded_message[byte_position:byte_position + byte_length]

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -80,9 +80,9 @@ class NrcConstParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[AtomicOdxType, int]:
         decode_state = copy(decode_state)
-        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_byte_position:
             # Update byte position
-            decode_state.cursor_position = self.byte_position
+            decode_state.cursor_byte_position = self.byte_position
 
         # Extract coded values
         decode_state.cursor_bit_position = self.bit_position
@@ -94,13 +94,13 @@ class NrcConstParameter(Parameter):
                 f"Coded constant parameter does not match! "
                 f"The parameter {self.short_name} expected a coded "
                 f"value in {str(self.coded_values)} but got {str(coded_value)} "
-                f"at byte position {decode_state.cursor_position} "
+                f"at byte position {decode_state.cursor_byte_position} "
                 f"in coded message {decode_state.coded_message.hex()}.",
                 DecodeError,
                 stacklevel=1,
             )
 
-        return coded_value, decode_state.cursor_position
+        return coded_value, decode_state.cursor_byte_position
 
     def get_description_of_valid_values(self) -> str:
         """return a human-understandable description of valid physical values"""

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -86,7 +86,7 @@ class NrcConstParameter(Parameter):
 
         # Extract coded values
         bit_position_int = self.bit_position if self.bit_position is not None else 0
-        coded_value, cursor_position = self.diag_coded_type.convert_bytes_to_internal(
+        coded_value = self.diag_coded_type.decode_from_pdu(
             decode_state, bit_position=bit_position_int)
 
         # Check if the coded value in the message is correct.
@@ -101,7 +101,7 @@ class NrcConstParameter(Parameter):
                 stacklevel=1,
             )
 
-        return coded_value, cursor_position
+        return coded_value, decode_state.cursor_position
 
     def get_description_of_valid_values(self) -> str:
         """return a human-understandable description of valid physical values"""

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -85,7 +85,7 @@ class NrcConstParameter(Parameter):
             decode_state.cursor_byte_position = self.byte_position
 
         # Extract coded values
-        decode_state.cursor_bit_position = self.bit_position
+        decode_state.cursor_bit_position = self.bit_position or 0
         coded_value = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -85,9 +85,8 @@ class NrcConstParameter(Parameter):
             decode_state.cursor_position = self.byte_position
 
         # Extract coded values
-        bit_position_int = self.bit_position if self.bit_position is not None else 0
-        coded_value = self.diag_coded_type.decode_from_pdu(
-            decode_state, bit_position=bit_position_int)
+        decode_state.cursor_bit_position = self.bit_position
+        coded_value = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.
         if coded_value not in self.coded_values:

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -76,16 +76,16 @@ class ParameterWithDOP(Parameter):
             physical_value, encode_state, bit_position=bit_position_int)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        orig_cursor_pos = decode_state.cursor_position
+        orig_cursor_pos = decode_state.cursor_byte_position
         if (pos := getattr(self, "byte_position", None)) is not None:
-            decode_state.cursor_position = decode_state.origin_position + pos
+            decode_state.cursor_byte_position = decode_state.origin_byte_position + pos
 
         bit_position = self.bit_position or 0
 
         # Use DOP to decode
-        phys_val, cursor_position = self.dop.convert_bytes_to_physical(
+        phys_val, cursor_byte_position = self.dop.convert_bytes_to_physical(
             decode_state, bit_position=bit_position)
 
-        decode_state.cursor_position = max(orig_cursor_pos, cursor_position)
+        decode_state.cursor_byte_position = max(orig_cursor_pos, cursor_byte_position)
 
-        return phys_val, cursor_position
+        return phys_val, cursor_byte_position

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -66,16 +66,16 @@ class PhysicalConstantParameter(ParameterWithDOP):
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         # Decode value
-        phys_val, cursor_position = super().decode_from_pdu(decode_state)
+        phys_val, cursor_byte_position = super().decode_from_pdu(decode_state)
 
         # Check if decoded value matches expected value
         if phys_val != self.physical_constant_value:
             warnings.warn(
                 f"Physical constant parameter does not match! "
                 f"The parameter {self.short_name} expected physical value {self.physical_constant_value!r} but got {phys_val!r} "
-                f"at byte position {cursor_position} "
+                f"at byte position {cursor_byte_position} "
                 f"in coded message {decode_state.coded_message.hex()}.",
                 DecodeError,
                 stacklevel=1,
             )
-        return phys_val, cursor_position
+        return phys_val, cursor_byte_position

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -33,13 +33,14 @@ class ReservedParameter(Parameter):
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
         byte_position = (
-            self.byte_position if self.byte_position is not None else decode_state.cursor_position)
+            self.byte_position
+            if self.byte_position is not None else decode_state.cursor_byte_position)
         abs_bit_position = byte_position * 8 + (self.bit_position or 0)
         bit_length = self.bit_length
 
         # the cursor points to the first byte which has not been fully
         # consumed
-        cursor_position = (abs_bit_position + bit_length) // 8
+        cursor_byte_position = (abs_bit_position + bit_length) // 8
 
         # ignore the value of the parameter data
-        return cast(int, None), cursor_position
+        return cast(int, None), cursor_byte_position

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -136,19 +136,19 @@ class TableKeyParameter(Parameter):
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
-            cursor_position = self.byte_position
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_byte_position:
+            cursor_byte_position = self.byte_position
 
         if self.table_row is not None:
             # the table row to be used is statically specified -> no
             # need to decode anything!
             phys_val = self.table_row.short_name
-            cursor_position = decode_state.cursor_position
+            cursor_byte_position = decode_state.cursor_byte_position
         else:
             # Use DOP to decode
             key_dop = odxrequire(self.table.key_dop)
             bit_position_int = self.bit_position if self.bit_position is not None else 0
-            key_dop_val, cursor_position = key_dop.convert_bytes_to_physical(
+            key_dop_val, cursor_byte_position = key_dop.convert_bytes_to_physical(
                 decode_state, bit_position=bit_position_int)
 
             table_row_candidates = [x for x in self.table.table_rows if x.key == key_dop_val]
@@ -163,4 +163,4 @@ class TableKeyParameter(Parameter):
             # update the decode_state's table key
             decode_state.table_keys[self.short_name] = table_row
 
-        return phys_val, cursor_position
+        return phys_val, cursor_byte_position

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -127,10 +127,10 @@ class TableStructParameter(Parameter):
         return super().encode_into_pdu(encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> Tuple[ParameterValue, int]:
-        if self.byte_position is not None and self.byte_position != decode_state.cursor_position:
+        if self.byte_position is not None and self.byte_position != decode_state.cursor_byte_position:
             next_pos = self.byte_position if self.byte_position is not None else 0
             decode_state = copy(decode_state)
-            decode_state.cursor_position = next_pos
+            decode_state.cursor_byte_position = next_pos
 
         # find the selected table row
         key_name = self.table_key.short_name
@@ -141,7 +141,7 @@ class TableStructParameter(Parameter):
             raise odxraise(f"No table key '{key_name}' found when decoding "
                            f"table struct parameter '{str(self.short_name)}'")
             dummy_val = cast(str, None), cast(int, None)
-            return dummy_val, decode_state.cursor_position
+            return dummy_val, decode_state.cursor_byte_position
 
         # Use DOP or structure to decode the value
         if table_row.dop is not None:
@@ -154,4 +154,4 @@ class TableStructParameter(Parameter):
         else:
             # the table row associated with the key neither defines a
             # DOP nor a structure -> ignore it
-            return (table_row.short_name, cast(int, None)), decode_state.cursor_position
+            return (table_row.short_name, cast(int, None)), decode_state.cursor_byte_position

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, cast
 
 from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
@@ -82,22 +82,25 @@ class ParamLengthInfoType(DiagCodedType):
         if self.length_key.short_name not in decode_state.length_keys:
             odxraise(f"Unspecified mandatory length key parameter "
                      f"{self.length_key.short_name}")
-        else:
-            bit_length = decode_state.length_keys[self.length_key.short_name]
-            if not isinstance(bit_length, int):
-                odxraise(f"The bit length must be an integer, is {type(bit_length)}")
-                bit_length = 0
+            decode_state.cursor_bit_position = None
+            return cast(None, AtomicOdxType)
+
+        bit_length = decode_state.length_keys[self.length_key.short_name]
+        if not isinstance(bit_length, int):
+            odxraise(f"The bit length must be an integer, is {type(bit_length)}")
+            bit_length = 0
 
         # Extract the internal value and return.
         value, cursor_position = self._extract_internal_value(
             decode_state.coded_message,
             decode_state.cursor_position,
-            bit_position,
+            decode_state.cursor_bit_position or 0,
             bit_length,
             self.base_data_type,
             self.is_highlow_byte_order,
         )
 
+        decode_state.cursor_bit_position = None
         decode_state.cursor_position = cursor_position
 
         return value

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -91,9 +91,9 @@ class ParamLengthInfoType(DiagCodedType):
             bit_length = 0
 
         # Extract the internal value and return.
-        value, cursor_position = self._extract_internal_value(
+        value, cursor_byte_position = self._extract_internal_value(
             decode_state.coded_message,
-            decode_state.cursor_position,
+            decode_state.cursor_byte_position,
             decode_state.cursor_bit_position or 0,
             bit_length,
             self.base_data_type,
@@ -101,6 +101,6 @@ class ParamLengthInfoType(DiagCodedType):
         )
 
         decode_state.cursor_bit_position = None
-        decode_state.cursor_position = cursor_position
+        decode_state.cursor_byte_position = cursor_byte_position
 
         return value

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Tuple
+from typing import TYPE_CHECKING, Any, Dict
 
 from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
@@ -74,9 +74,7 @@ class ParamLengthInfoType(DiagCodedType):
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
 
-    def convert_bytes_to_internal(self,
-                                  decode_state: DecodeState,
-                                  bit_position: int = 0) -> Tuple[AtomicOdxType, int]:
+    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
         # Find length key with matching ID.
         bit_length = 0
 
@@ -91,7 +89,7 @@ class ParamLengthInfoType(DiagCodedType):
                 bit_length = 0
 
         # Extract the internal value and return.
-        return self._extract_internal_value(
+        value, cursor_position = self._extract_internal_value(
             decode_state.coded_message,
             decode_state.cursor_position,
             bit_position,
@@ -99,3 +97,7 @@ class ParamLengthInfoType(DiagCodedType):
             self.base_data_type,
             self.is_highlow_byte_order,
         )
+
+        decode_state.cursor_position = cursor_position
+
+        return value

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -94,13 +94,13 @@ class ParamLengthInfoType(DiagCodedType):
         value, cursor_byte_position = self._extract_internal_value(
             decode_state.coded_message,
             decode_state.cursor_byte_position,
-            decode_state.cursor_bit_position or 0,
+            decode_state.cursor_bit_position,
             bit_length,
             self.base_data_type,
             self.is_highlow_byte_order,
         )
 
-        decode_state.cursor_bit_position = None
+        decode_state.cursor_bit_position = 0
         decode_state.cursor_byte_position = cursor_byte_position
 
         return value

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -57,9 +57,9 @@ class StandardLengthType(DiagCodedType):
         )
 
     def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
-        internal_value, cursor_position = self._extract_internal_value(
+        internal_value, cursor_byte_position = self._extract_internal_value(
             decode_state.coded_message,
-            decode_state.cursor_position,
+            decode_state.cursor_byte_position,
             decode_state.cursor_bit_position or 0,
             self.bit_length,
             self.base_data_type,
@@ -67,7 +67,7 @@ class StandardLengthType(DiagCodedType):
         )
         internal_value = self.__apply_mask(internal_value)
 
-        decode_state.cursor_position = cursor_position
+        decode_state.cursor_byte_position = cursor_byte_position
         decode_state.cursor_bit_position = None
 
         return internal_value

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -60,7 +60,7 @@ class StandardLengthType(DiagCodedType):
         internal_value, cursor_position = self._extract_internal_value(
             decode_state.coded_message,
             decode_state.cursor_position,
-            bit_position,
+            decode_state.cursor_bit_position or 0,
             self.bit_length,
             self.base_data_type,
             self.is_highlow_byte_order,
@@ -68,5 +68,6 @@ class StandardLengthType(DiagCodedType):
         internal_value = self.__apply_mask(internal_value)
 
         decode_state.cursor_position = cursor_position
+        decode_state.cursor_bit_position = None
 
         return internal_value

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -60,7 +60,7 @@ class StandardLengthType(DiagCodedType):
         internal_value, cursor_byte_position = self._extract_internal_value(
             decode_state.coded_message,
             decode_state.cursor_byte_position,
-            decode_state.cursor_bit_position or 0,
+            decode_state.cursor_bit_position,
             self.bit_length,
             self.base_data_type,
             self.is_highlow_byte_order,
@@ -68,6 +68,6 @@ class StandardLengthType(DiagCodedType):
         internal_value = self.__apply_mask(internal_value)
 
         decode_state.cursor_byte_position = cursor_byte_position
-        decode_state.cursor_bit_position = None
+        decode_state.cursor_bit_position = 0
 
         return internal_value

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 
 from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
@@ -56,9 +56,7 @@ class StandardLengthType(DiagCodedType):
             is_highlow_byte_order=self.is_highlow_byte_order,
         )
 
-    def convert_bytes_to_internal(self,
-                                  decode_state: DecodeState,
-                                  bit_position: int = 0) -> Tuple[AtomicOdxType, int]:
+    def decode_from_pdu(self, decode_state: DecodeState, bit_position: int = 0) -> AtomicOdxType:
         internal_value, cursor_position = self._extract_internal_value(
             decode_state.coded_message,
             decode_state.cursor_position,
@@ -68,4 +66,7 @@ class StandardLengthType(DiagCodedType):
             self.is_highlow_byte_order,
         )
         internal_value = self.__apply_mask(internal_value)
-        return internal_value, cursor_position
+
+        decode_state.cursor_position = cursor_position
+
+        return internal_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 browse-tool = [
-     "PyInquirer >= 1.0",
+     "InquirerPy >= 0.3.4",
 ]
 
 test = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import unittest
 from argparse import Namespace
 from typing import List, Optional
+from unittest.mock import MagicMock, patch
 
 import odxtools.cli.compare as compare
 import odxtools.cli.decode as decode
@@ -131,7 +132,10 @@ class TestCommandLineTools(unittest.TestCase):
         UtilFunctions.run_compare_tool(ecu_variants=["somersault_lazy", "somersault_assiduous"])
 
     @unittest.skipIf(browse_import_failed, "importing the browse tool failed")
-    def test_browse_tool(self) -> None:
+    # browse is an interactive tool, so we need to mock a few
+    # functions to make PyInquirer reliably bail out
+    @patch("sys.stdout.isatty", return_value=False)
+    def test_browse_tool(self, pi_prompt: MagicMock) -> None:
         browse_args = Namespace(pdx_file="./examples/somersault.pdx")
         with self.assertRaises(SystemError):
             # browse can only be run interactively

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,12 @@ import odxtools.cli.decode as decode
 import odxtools.cli.find as find
 import odxtools.cli.list as list_tool
 
-import_failed = False
+browse_import_failed = False
 
 try:
     import odxtools.cli.browse as browse
 except ImportError:
-    import_failed = True
+    browse_import_failed = True
 
 
 class UtilFunctions:
@@ -130,10 +130,12 @@ class TestCommandLineTools(unittest.TestCase):
         ])
         UtilFunctions.run_compare_tool(ecu_variants=["somersault_lazy", "somersault_assiduous"])
 
-    @unittest.skipIf(import_failed, "import of PyInquirer failed")
+    @unittest.skipIf(browse_import_failed, "importing the browse tool failed")
     def test_browse_tool(self) -> None:
         browse_args = Namespace(pdx_file="./examples/somersault.pdx")
-        browse.run(browse_args)
+        with self.assertRaises(SystemError):
+            # browse can only be run interactively
+            browse.run(browse_args)
 
 
 if __name__ == "__main__":

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -41,8 +41,8 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x2, 0x34, 0x56]), cursor_position=0)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
-        self.assertEqual(internal, bytes([0x34, 0x56]))
+        internal_value = dct.decode_from_pdu(state, 0)
+        self.assertEqual(internal_value, bytes([0x34, 0x56]))
 
         dct = LeadingLengthInfoType(
             base_data_type=DataType.A_BYTEFIELD,
@@ -53,8 +53,8 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), cursor_position=1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
-        self.assertEqual(internal, bytes([0x3]))
+        internal_value = dct.decode_from_pdu(state, bit_position=1)
+        self.assertEqual(internal_value, bytes([0x3]))
 
     def test_decode_leading_length_info_type_zero_length(self) -> None:
         dct = LeadingLengthInfoType(
@@ -64,9 +64,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x0, 0x1]), cursor_position=0)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, 0)
-        self.assertEqual(internal, b'')
-        self.assertEqual(cursor_position, 1)
+        internal_value = dct.decode_from_pdu(state, 0)
+        self.assertEqual(internal_value, b'')
+        self.assertEqual(state.cursor_position, 1)
 
     def test_encode_leading_length_info_type_bytefield(self) -> None:
         dct = LeadingLengthInfoType(
@@ -111,9 +111,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), cursor_position=1)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-        self.assertEqual(internal, "a9")
-        self.assertEqual(cursor_position, 6)
+        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        self.assertEqual(internal_value, "a9")
+        self.assertEqual(state.cursor_position, 6)
 
         dct = LeadingLengthInfoType(
             base_data_type=DataType.A_UNICODE2STRING,
@@ -122,9 +122,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=False,
         )
         state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), cursor_position=1)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-        self.assertEqual(internal, "a9")
-        self.assertEqual(cursor_position, 6)
+        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        self.assertEqual(internal_value, "a9")
+        self.assertEqual(state.cursor_position, 6)
 
     def test_encode_leading_length_info_type_unicode2string(self) -> None:
         dct = LeadingLengthInfoType(
@@ -313,9 +313,9 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x1, 0x72, 0x3]), cursor_position=1)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=1)
-        self.assertEqual(internal, 25)
-        self.assertEqual(cursor_position, 2)
+        internal_value = dct.decode_from_pdu(state, bit_position=1)
+        self.assertEqual(internal_value, 25)
+        self.assertEqual(state.cursor_position, 2)
 
     def test_decode_standard_length_type_uint_byteorder(self) -> None:
         dct = StandardLengthType(
@@ -327,9 +327,9 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
         )
         state = DecodeState(bytes([0x1, 0x2, 0x3]), cursor_position=1)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-        self.assertEqual(internal, 0x0302)
-        self.assertEqual(cursor_position, 3)
+        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        self.assertEqual(internal_value, 0x0302)
+        self.assertEqual(state.cursor_position, 3)
 
     def test_decode_standard_length_type_bytes(self) -> None:
         dct = StandardLengthType(
@@ -341,9 +341,9 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), cursor_position=1)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-        self.assertEqual(internal, bytes([0x34, 0x56]))
-        self.assertEqual(cursor_position, 3)
+        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        self.assertEqual(internal_value, bytes([0x34, 0x56]))
+        self.assertEqual(state.cursor_position, 3)
 
 
 class TestParamLengthInfoType(unittest.TestCase):
@@ -377,9 +377,9 @@ class TestParamLengthInfoType(unittest.TestCase):
             length_keys={length_key.short_name: 16},
             cursor_position=1,
         )
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-        self.assertEqual(internal, 0x1234)
-        self.assertEqual(cursor_position, 3)
+        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        self.assertEqual(internal_value, 0x1234)
+        self.assertEqual(state.cursor_position, 3)
 
     def test_encode_param_info_length_type_uint(self) -> None:
         length_key_id = OdxLinkId("param.length_key", doc_frags)
@@ -614,9 +614,9 @@ class TestMinMaxLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), cursor_position=1)
-        internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-        self.assertEqual(internal, bytes([0xFF, 0x34, 0x56]))
-        self.assertEqual(cursor_position, 5)
+        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        self.assertEqual(internal_value, bytes([0xFF, 0x34, 0x56]))
+        self.assertEqual(state.cursor_position, 5)
 
     def test_decode_min_max_length_type_too_short_pdu(self) -> None:
         """If the PDU ends before min length is reached, an error must be raised."""
@@ -629,7 +629,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0xFF]), cursor_position=1)
-        self.assertRaises(DecodeError, dct.convert_bytes_to_internal, state)
+        self.assertRaises(DecodeError, dct.decode_from_pdu, state)
 
     def test_decode_min_max_length_type_end_of_pdu(self) -> None:
         """If the PDU ends before max length is reached, the extracted value ends at the end of the PDU."""
@@ -643,9 +643,9 @@ class TestMinMaxLengthType(unittest.TestCase):
                 is_highlow_byte_order_raw=None,
             )
             state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
-            internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-            self.assertEqual(internal, bytes([0x34, 0x56, 0x78, 0x9A]))
-            self.assertEqual(cursor_position, 5)
+            internal_value = dct.decode_from_pdu(state, bit_position=0)
+            self.assertEqual(internal_value, bytes([0x34, 0x56, 0x78, 0x9A]))
+            self.assertEqual(state.cursor_position, 5)
 
     def test_decode_min_max_length_type_max_length(self) -> None:
         """If the max length is smaller than the end of PDU, the extracted value ends after max length."""
@@ -659,9 +659,9 @@ class TestMinMaxLengthType(unittest.TestCase):
                 is_highlow_byte_order_raw=None,
             )
             state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
-            internal, cursor_position = dct.convert_bytes_to_internal(state, bit_position=0)
-            self.assertEqual(internal, bytes([0x34, 0x56, 0x78]))
-            self.assertEqual(cursor_position, 4)
+            internal_value = dct.decode_from_pdu(state, bit_position=0)
+            self.assertEqual(internal_value, bytes([0x34, 0x56, 0x78]))
+            self.assertEqual(state.cursor_position, 4)
 
     def test_encode_min_max_length_type_hex_ff(self) -> None:
         dct = MinMaxLengthType(

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -40,7 +40,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x2, 0x34, 0x56]), cursor_position=0)
+        state = DecodeState(bytes([0x2, 0x34, 0x56]), cursor_byte_position=0)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0x34, 0x56]))
 
@@ -50,7 +50,8 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), cursor_position=1, cursor_bit_position=1)
+        state = DecodeState(
+            bytes([0x1, 0xC2, 0x3, 0x4]), cursor_byte_position=1, cursor_bit_position=1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
         internal_value = dct.decode_from_pdu(state)
@@ -63,10 +64,10 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x0, 0x1]), cursor_position=0)
+        state = DecodeState(bytes([0x0, 0x1]), cursor_byte_position=0)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, b'')
-        self.assertEqual(state.cursor_position, 1)
+        self.assertEqual(state.cursor_byte_position, 1)
 
     def test_encode_leading_length_info_type_bytefield(self) -> None:
         dct = LeadingLengthInfoType(
@@ -110,10 +111,10 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), cursor_position=1)
+        state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), cursor_byte_position=1)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, "a9")
-        self.assertEqual(state.cursor_position, 6)
+        self.assertEqual(state.cursor_byte_position, 6)
 
         dct = LeadingLengthInfoType(
             base_data_type=DataType.A_UNICODE2STRING,
@@ -121,10 +122,10 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=False,
         )
-        state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), cursor_position=1)
+        state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), cursor_byte_position=1)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, "a9")
-        self.assertEqual(state.cursor_position, 6)
+        self.assertEqual(state.cursor_byte_position, 6)
 
     def test_encode_leading_length_info_type_unicode2string(self) -> None:
         dct = LeadingLengthInfoType(
@@ -312,10 +313,10 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x72, 0x3]), cursor_position=1, cursor_bit_position=1)
+        state = DecodeState(bytes([0x1, 0x72, 0x3]), cursor_byte_position=1, cursor_bit_position=1)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, 25)
-        self.assertEqual(state.cursor_position, 2)
+        self.assertEqual(state.cursor_byte_position, 2)
 
     def test_decode_standard_length_type_uint_byteorder(self) -> None:
         dct = StandardLengthType(
@@ -326,10 +327,10 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=False,
             is_condensed_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x2, 0x3]), cursor_position=1)
+        state = DecodeState(bytes([0x1, 0x2, 0x3]), cursor_byte_position=1)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, 0x0302)
-        self.assertEqual(state.cursor_position, 3)
+        self.assertEqual(state.cursor_byte_position, 3)
 
     def test_decode_standard_length_type_bytes(self) -> None:
         dct = StandardLengthType(
@@ -340,10 +341,10 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), cursor_position=1)
+        state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), cursor_byte_position=1)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0x34, 0x56]))
-        self.assertEqual(state.cursor_position, 3)
+        self.assertEqual(state.cursor_byte_position, 3)
 
 
 class TestParamLengthInfoType(unittest.TestCase):
@@ -375,11 +376,11 @@ class TestParamLengthInfoType(unittest.TestCase):
         state = DecodeState(
             coded_message=bytes([0x10, 0x12, 0x34, 0x56]),
             length_keys={length_key.short_name: 16},
-            cursor_position=1,
+            cursor_byte_position=1,
         )
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, 0x1234)
-        self.assertEqual(state.cursor_position, 3)
+        self.assertEqual(state.cursor_byte_position, 3)
 
     def test_encode_param_info_length_type_uint(self) -> None:
         length_key_id = OdxLinkId("param.length_key", doc_frags)
@@ -613,10 +614,10 @@ class TestMinMaxLengthType(unittest.TestCase):
             termination="HEX-FF",
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), cursor_position=1)
+        state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), cursor_byte_position=1)
         internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0xFF, 0x34, 0x56]))
-        self.assertEqual(state.cursor_position, 5)
+        self.assertEqual(state.cursor_byte_position, 5)
 
     def test_decode_min_max_length_type_too_short_pdu(self) -> None:
         """If the PDU ends before min length is reached, an error must be raised."""
@@ -628,7 +629,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             termination="HEX-FF",
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x12, 0xFF]), cursor_position=1)
+        state = DecodeState(bytes([0x12, 0xFF]), cursor_byte_position=1)
         self.assertRaises(DecodeError, dct.decode_from_pdu, state)
 
     def test_decode_min_max_length_type_end_of_pdu(self) -> None:
@@ -642,10 +643,10 @@ class TestMinMaxLengthType(unittest.TestCase):
                 termination=termination,
                 is_highlow_byte_order_raw=None,
             )
-            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
+            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_byte_position=1)
             internal_value = dct.decode_from_pdu(state, bit_position=0)
             self.assertEqual(internal_value, bytes([0x34, 0x56, 0x78, 0x9A]))
-            self.assertEqual(state.cursor_position, 5)
+            self.assertEqual(state.cursor_byte_position, 5)
 
     def test_decode_min_max_length_type_max_length(self) -> None:
         """If the max length is smaller than the end of PDU, the extracted value ends after max length."""
@@ -658,10 +659,10 @@ class TestMinMaxLengthType(unittest.TestCase):
                 termination=termination,
                 is_highlow_byte_order_raw=None,
             )
-            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
+            state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_byte_position=1)
             internal_value = dct.decode_from_pdu(state)
             self.assertEqual(internal_value, bytes([0x34, 0x56, 0x78]))
-            self.assertEqual(state.cursor_position, 4)
+            self.assertEqual(state.cursor_byte_position, 4)
 
     def test_encode_min_max_length_type_hex_ff(self) -> None:
         dct = MinMaxLengthType(

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -41,7 +41,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x2, 0x34, 0x56]), cursor_position=0)
-        internal_value = dct.decode_from_pdu(state, 0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0x34, 0x56]))
 
         dct = LeadingLengthInfoType(
@@ -50,10 +50,10 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             base_type_encoding=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), cursor_position=1)
+        state = DecodeState(bytes([0x1, 0xC2, 0x3, 0x4]), cursor_position=1, cursor_bit_position=1)
         # 0xC2 = 11000010, with bit_position=1 and bit_lenth=5, the extracted bits are 00001,
         # i.e. the leading length is 1, i.e. only the byte 0x3 should be extracted.
-        internal_value = dct.decode_from_pdu(state, bit_position=1)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0x3]))
 
     def test_decode_leading_length_info_type_zero_length(self) -> None:
@@ -64,7 +64,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x0, 0x1]), cursor_position=0)
-        internal_value = dct.decode_from_pdu(state, 0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, b'')
         self.assertEqual(state.cursor_position, 1)
 
@@ -111,7 +111,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0x4, 0x00, 0x61, 0x00, 0x39]), cursor_position=1)
-        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, "a9")
         self.assertEqual(state.cursor_position, 6)
 
@@ -122,7 +122,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             is_highlow_byte_order_raw=False,
         )
         state = DecodeState(bytes([0x12, 0x4, 0x61, 0x00, 0x39, 0x00]), cursor_position=1)
-        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, "a9")
         self.assertEqual(state.cursor_position, 6)
 
@@ -312,8 +312,8 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
             is_highlow_byte_order_raw=None,
         )
-        state = DecodeState(bytes([0x1, 0x72, 0x3]), cursor_position=1)
-        internal_value = dct.decode_from_pdu(state, bit_position=1)
+        state = DecodeState(bytes([0x1, 0x72, 0x3]), cursor_position=1, cursor_bit_position=1)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, 25)
         self.assertEqual(state.cursor_position, 2)
 
@@ -327,7 +327,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_condensed_raw=None,
         )
         state = DecodeState(bytes([0x1, 0x2, 0x3]), cursor_position=1)
-        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, 0x0302)
         self.assertEqual(state.cursor_position, 3)
 
@@ -341,7 +341,7 @@ class TestStandardLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78]), cursor_position=1)
-        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0x34, 0x56]))
         self.assertEqual(state.cursor_position, 3)
 
@@ -377,7 +377,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             length_keys={length_key.short_name: 16},
             cursor_position=1,
         )
-        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, 0x1234)
         self.assertEqual(state.cursor_position, 3)
 
@@ -614,7 +614,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), cursor_position=1)
-        internal_value = dct.decode_from_pdu(state, bit_position=0)
+        internal_value = dct.decode_from_pdu(state)
         self.assertEqual(internal_value, bytes([0xFF, 0x34, 0x56]))
         self.assertEqual(state.cursor_position, 5)
 
@@ -659,7 +659,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 is_highlow_byte_order_raw=None,
             )
             state = DecodeState(bytes([0x12, 0x34, 0x56, 0x78, 0x9A]), cursor_position=1)
-            internal_value = dct.decode_from_pdu(state, bit_position=0)
+            internal_value = dct.decode_from_pdu(state)
             self.assertEqual(internal_value, bytes([0x34, 0x56, 0x78]))
             self.assertEqual(state.cursor_position, 4)
 


### PR DESCRIPTION
The approach taken in this PR will serve as the template for all other objects which can be decoded (i.e., DOPs and parameters): decoding is done by a `decode_from_pdu()` method which takes a `DecodeState` object as their lone argument and returns the decoded physical value and the passed `DecodeState` is supposed to be changed so that it is set up to decode the next object after calling `decode_from_pdu()`.

IMO, this substantially reduces the mental load required to understand the decoding logic, because before this, parameters, diag coded types, and DOPs all used identical names for the decoding functions  but they behaved slightly different in terms of the parameters which they took and the types they returned...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
