### PR TITLE
fix the code computing value inheritance

### DIFF
--- a/odxtools/diaglayertype.py
+++ b/odxtools/diaglayertype.py
@@ -20,11 +20,23 @@ class DiagLayerType(Enum):
         """
 
         PRIORITY_OF_DIAG_LAYER_TYPE: Dict[DiagLayerType, int] = {
-            DiagLayerType.ECU_SHARED_DATA: 0,
-            DiagLayerType.PROTOCOL: 1,
-            DiagLayerType.FUNCTIONAL_GROUP: 2,
-            DiagLayerType.BASE_VARIANT: 3,
-            DiagLayerType.ECU_VARIANT: 4,
+            DiagLayerType.PROTOCOL:
+                1,
+            DiagLayerType.FUNCTIONAL_GROUP:
+                2,
+            DiagLayerType.BASE_VARIANT:
+                3,
+            DiagLayerType.ECU_VARIANT:
+                4,
+
+            # ECU shared data layers are a bit weird (see section
+            # 7.3.2.4.4 of the ASAM specification): they can be
+            # inherited from by any other layer but they will
+            # override any objects which are also provided by any of
+            # the other parent layers. tl;dr: When it comes to
+            # inheritance, they have the highest priority.
+            DiagLayerType.ECU_SHARED_DATA:
+                100,
         }
 
         return PRIORITY_OF_DIAG_LAYER_TYPE[self]


### PR DESCRIPTION
I recently noticed that the ODX specification for value inheritance slightly differed from the version which was implemented by odxtools:

 - objects directly inherited from ECU-SHARED-DATA parents did not override objects inherited from diagnostic layers of different type
 - the "not inherited" objects were not considered while populating the list, causing the function to produce undefined results if inheritance conflicts were solved using the NOT-INHERITED-* mechanism.
 - inheritance conflicts where generally not handled explicitly.

This PR fixes these issues and we now hopefully fully adhere to the specification. (I doubt that it did matter for many datasets, though. For the ones I have access to, it didn't.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
