### PR TITLE
Avoid incompatible overrides

### DIFF
--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -49,14 +49,14 @@ class CompuScale:
     physical_type: DataType
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
-                internal_type: DataType, physical_type: DataType) -> "CompuScale":
+    def compuscale_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+                           internal_type: DataType, physical_type: DataType) -> "CompuScale":
         short_label = et_element.findtext("SHORT-LABEL")
         description = create_description_from_et(et_element.find("DESC"))
 
-        lower_limit = Limit.from_et(
+        lower_limit = Limit.limit_from_et(
             et_element.find("LOWER-LIMIT"), doc_frags, value_type=internal_type)
-        upper_limit = Limit.from_et(
+        upper_limit = Limit.limit_from_et(
             et_element.find("UPPER-LIMIT"), doc_frags, value_type=internal_type)
 
         compu_inverse_value = internal_type.create_from_et(et_element.find("COMPU-INVERSE-VALUE"))

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -63,7 +63,7 @@ def _parse_compu_scale_to_linear_compu_method(
                 OdxWarning,
                 stacklevel=1)
     # Read lower limit
-    internal_lower_limit = Limit.from_et(
+    internal_lower_limit = Limit.limit_from_et(
         et_element.find("LOWER-LIMIT"),
         doc_frags,
         value_type=internal_type,
@@ -72,7 +72,7 @@ def _parse_compu_scale_to_linear_compu_method(
     kwargs["internal_lower_limit"] = internal_lower_limit
 
     # Read upper limit
-    internal_upper_limit = Limit.from_et(
+    internal_upper_limit = Limit.limit_from_et(
         et_element.find("UPPER-LIMIT"),
         doc_frags,
         value_type=internal_type,
@@ -92,7 +92,7 @@ def create_compu_default_value(et_element: Optional[ElementTree.Element],
     if et_element is None:
         return None
     compu_const = physical_type.create_from_et(et_element)
-    scale = CompuScale.from_et(
+    scale = CompuScale.compuscale_from_et(
         et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
     scale.compu_const = compu_const
     return scale
@@ -137,7 +137,7 @@ def create_any_compu_method_from_et(et_element: ElementTree.Element,
         internal_to_phys: List[CompuScale] = []
         for scale_elem in compu_internal_to_phys.iterfind("COMPU-SCALES/COMPU-SCALE"):
             internal_to_phys.append(
-                CompuScale.from_et(
+                CompuScale.compuscale_from_et(
                     scale_elem, doc_frags, internal_type=internal_type,
                     physical_type=physical_type))
         compu_default_value = create_compu_default_value(

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -29,19 +29,19 @@ class Limit:
 
     @staticmethod
     @overload
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment],
-                value_type: Optional[DataType]) -> "Limit":
+    def limit_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment],
+                      value_type: Optional[DataType]) -> "Limit":
         ...
 
     @staticmethod
     @overload
-    def from_et(et_element: None, doc_frags: List[OdxDocFragment],
-                value_type: Optional[DataType]) -> None:
+    def limit_from_et(et_element: None, doc_frags: List[OdxDocFragment],
+                      value_type: Optional[DataType]) -> None:
         ...
 
     @staticmethod
-    def from_et(et_element: Optional[ElementTree.Element], doc_frags: List[OdxDocFragment],
-                value_type: Optional[DataType]) -> Optional["Limit"]:
+    def limit_from_et(et_element: Optional[ElementTree.Element], doc_frags: List[OdxDocFragment],
+                      value_type: Optional[DataType]) -> Optional["Limit"]:
 
         if et_element is None:
             return None

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -66,12 +66,12 @@ class DataObjectProperty(DopBase):
 
         internal_constr = None
         if (internal_constr_elem := et_element.find("INTERNAL-CONSTR")) is not None:
-            internal_constr = InternalConstr.from_et(
+            internal_constr = InternalConstr.constr_from_et(
                 internal_constr_elem, doc_frags, value_type=diag_coded_type.base_data_type)
 
         physical_constr = None
         if (physical_constr_elem := et_element.find("PHYS-CONSTR")) is not None:
-            physical_constr = InternalConstr.from_et(
+            physical_constr = InternalConstr.constr_from_et(
                 physical_constr_elem, doc_frags, value_type=physical_type.base_data_type)
 
         return DataObjectProperty(

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -1139,7 +1139,7 @@ class DiagLayer:
 
         if len(decoded_messages) == 0:
             raise DecodeError(
-                f"None of the services {candidate_services} could parse {message.hex()}.")
+                f"None of the services {[x.short_name for x in candidate_services]} could parse {message.hex()}.")
 
         return decoded_messages
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -1139,7 +1139,8 @@ class DiagLayer:
 
         if len(decoded_messages) == 0:
             raise DecodeError(
-                f"None of the services {[x.short_name for x in candidate_services]} could parse {message.hex()}.")
+                f"None of the services {[x.short_name for x in candidate_services]} could parse {message.hex()}."
+            )
 
         return decoded_messages
 

--- a/odxtools/internalconstr.py
+++ b/odxtools/internalconstr.py
@@ -23,16 +23,16 @@ class InternalConstr:
     value_type: DataType
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
-                value_type: DataType) -> "InternalConstr":
+    def constr_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+                       value_type: DataType) -> "InternalConstr":
 
-        lower_limit = Limit.from_et(
+        lower_limit = Limit.limit_from_et(
             et_element.find("LOWER-LIMIT"), doc_frags, value_type=value_type)
-        upper_limit = Limit.from_et(
+        upper_limit = Limit.limit_from_et(
             et_element.find("UPPER-LIMIT"), doc_frags, value_type=value_type)
 
         scale_constrs = [
-            ScaleConstr.from_et(sc_el, doc_frags, value_type=value_type)
+            ScaleConstr.scale_constr_from_et(sc_el, doc_frags, value_type=value_type)
             for sc_el in et_element.iterfind("SCALE-CONSTRS/SCALE-CONSTR")
         ]
 

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -37,12 +37,12 @@ class MultiplexerCase(NamedElement):
         if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:
             structure_snref = odxrequire(structure_snref_elem.get("SHORT-NAME"))
 
-        lower_limit = Limit.from_et(
+        lower_limit = Limit.limit_from_et(
             odxrequire(et_element.find("LOWER-LIMIT")),
             doc_frags,
             value_type=None,
         )
-        upper_limit = Limit.from_et(
+        upper_limit = Limit.limit_from_et(
             odxrequire(et_element.find("UPPER-LIMIT")),
             doc_frags,
             value_type=None,

--- a/odxtools/scaleconstr.py
+++ b/odxtools/scaleconstr.py
@@ -31,14 +31,14 @@ class ScaleConstr:
     value_type: DataType
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
-                value_type: DataType) -> "ScaleConstr":
+    def scale_constr_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+                             value_type: DataType) -> "ScaleConstr":
         short_label = et_element.findtext("SHORT-LABEL")
         description = create_description_from_et(et_element.find("DESC"))
 
-        lower_limit = Limit.from_et(
+        lower_limit = Limit.limit_from_et(
             et_element.find("LOWER-LIMIT"), doc_frags, value_type=value_type)
-        upper_limit = Limit.from_et(
+        upper_limit = Limit.limit_from_et(
             et_element.find("UPPER-LIMIT"), doc_frags, value_type=value_type)
 
         validity_str = odxrequire(et_element.get("VALIDITY"))

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -45,7 +45,8 @@ class Table(IdentifiableElement):
         for sub_elem in et_element:
             if sub_elem.tag == "TABLE-ROW":
                 table_rows_raw.append(
-                    TableRow.from_et(sub_elem, doc_frags, table_ref=OdxLinkRef.from_id(odx_id)))
+                    TableRow.tablerow_from_et(
+                        sub_elem, doc_frags, table_ref=OdxLinkRef.from_id(odx_id)))
             elif sub_elem.tag == "TABLE-ROW-REF":
                 table_rows_raw.append(OdxLinkRef.from_et(sub_elem, doc_frags))
 

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -51,9 +51,13 @@ class TableRow(IdentifiableElement):
         )
 
     @staticmethod
-    def from_et(  # type: ignore[override]
-            et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
-            table_ref: OdxLinkRef) -> "TableRow":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> Any:
+        raise RuntimeError(
+            "Calling TableRow.from_et() is not allowed. Use TableRow.tablerow_from_et().")
+
+    @staticmethod
+    def tablerow_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+                         table_ref: OdxLinkRef) -> "TableRow":
         """Reads a TABLE-ROW."""
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
         semantic = et_element.get("SEMANTIC")


### PR DESCRIPTION
This PR fixes the incompatible overrides of `from_et()` methods which require additional arguments by renaming them to `.{foo}_from_et()` (e.g. `Limit.limit_from_et()`). Some type checkers complain about this, IMO rightfully so.

Besides this, as a drive-by I've updated the `README` so that the snippets outlined there work with the latest odxtools version. (I don't think that this changelet merrits its own PR.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
