### PR TITLE
Make more linters happy

### DIFF
--- a/odxtools/__init__.py
+++ b/odxtools/__init__.py
@@ -62,11 +62,11 @@ References
 - _`[ISO22901]` The ISO 22901 Standard: https://www.iso.org/standard/41207.html
 
 """
-from .load_file import load_file as load_file
-from .load_odx_d_file import load_odx_d_file as load_odx_d_file
-from .load_pdx_file import load_pdx_file as load_pdx_file
-from .version import __version__ as __version__
-from .write_pdx_file import write_pdx_file as write_pdx_file
+from .load_file import load_file as load_file  # noqa: F401
+from .load_odx_d_file import load_odx_d_file as load_odx_d_file  # noqa: F401
+from .load_pdx_file import load_pdx_file as load_pdx_file  # noqa: F401
+from .version import __version__ as __version__  # noqa: F401
+from .write_pdx_file import write_pdx_file as write_pdx_file  # noqa: F401
 
 __author__ = "Katrin Bauer"
 

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -210,18 +210,18 @@ class BasicStructure(ComplexDop):
                 stacklevel=1)
 
     def convert_physical_to_bytes(self,
-                                  param_values: ParameterValue,
+                                  physical_value: ParameterValue,
                                   encode_state: EncodeState,
                                   bit_position: int = 0) -> bytes:
-        if not isinstance(param_values, dict):
+        if not isinstance(physical_value, dict):
             raise EncodeError(
                 f"Expected a dictionary for the values of structure {self.short_name}, "
-                f"got {type(param_values)}")
+                f"got {type(physical_value)}")
         if bit_position != 0:
             raise EncodeError("Structures must be aligned, i.e. bit_position=0, but "
                               f"{self.short_name} was passed the bit position {bit_position}")
         return self.convert_physical_to_internal(
-            param_values,
+            physical_value,
             triggering_coded_request=encode_state.triggering_request,
             is_end_of_pdu=encode_state.is_end_of_pdu,
         )

--- a/odxtools/cli/_parser_utils.py
+++ b/odxtools/cli/_parser_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import argparse
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from ..database import Database
 from ..load_file import load_file as _load_file
@@ -20,9 +20,6 @@ class SubparsersList(Protocol):
 
     def add_parser(self, name: str, **kwargs: Any) -> "argparse.ArgumentParser":
         ...
-
-
-TSubparsersAction = TypeVar("TSubparsersAction", bound=SubparsersList)
 
 
 def add_pdx_argument(parser: argparse.ArgumentParser, is_optional: bool = False) -> None:

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -156,6 +156,7 @@ def extract_parameter_tabulation_data(parameters: List[Parameter]) -> Dict[str, 
         byte.append(param.byte_position)
         semantic.append(param.semantic)
         param_type.append(param.parameter_type)
+        length = 0
         if param.get_static_bit_length() is not None:
             bit_length.append(param.get_static_bit_length())
             length = (param.get_static_bit_length() or 0) // 4

--- a/odxtools/cli/compare.py
+++ b/odxtools/cli/compare.py
@@ -19,7 +19,7 @@ from ..parameters.parameter import Parameter
 from ..parameters.physicalconstantparameter import PhysicalConstantParameter
 from ..parameters.valueparameter import ValueParameter
 from . import _parser_utils
-from ._parser_utils import TSubparsersAction
+from ._parser_utils import SubparsersList
 from ._print_utils import (extract_service_tabulation_data, print_dl_metrics,
                            print_service_parameters)
 
@@ -482,11 +482,13 @@ class Comparison(Display):
 
                 # check for deleted diagnostic services
                 if service2.short_name not in dl1_service_names and dl2_request_prefixes[
-                        service2_idx] not in dl1_request_prefixes and service2 not in service_dict[
-                            "deleted_services"]:
+                        service2_idx] not in dl1_request_prefixes:
 
-                    service_dict["deleted_services"].append(  # type: ignore[union-attr]
-                        service2)  # type: ignore[arg-type]
+                    deleted_list = service_dict["deleted_services"]
+                    assert isinstance(deleted_list, list)
+                    if service2 not in deleted_list:
+                        service_dict["deleted_services"].append(  # type: ignore[union-attr]
+                            service2)  # type: ignore[arg-type]
 
                 if service1.short_name == service2.short_name:
                     # compare request, pos. response and neg. response parameters of both diagnostic services
@@ -545,7 +547,7 @@ class Comparison(Display):
         return changes_variants
 
 
-def add_subparser(subparsers: TSubparsersAction) -> None:
+def add_subparser(subparsers: SubparsersList) -> None:
     parser = subparsers.add_parser(
         "compare",
         description="\n".join([

--- a/odxtools/cli/decode.py
+++ b/odxtools/cli/decode.py
@@ -9,7 +9,7 @@ from ..exceptions import odxraise
 from ..odxtypes import ParameterValue
 from ..singleecujob import SingleEcuJob
 from . import _parser_utils
-from ._parser_utils import TSubparsersAction
+from ._parser_utils import SubparsersList
 
 # name of the tool
 _odxtools_tool_name_ = "decode"
@@ -71,7 +71,7 @@ def print_summary(
                 print(f"  {param_name}={get_display_value(param_value)}")
 
 
-def add_subparser(subparsers: TSubparsersAction) -> None:
+def add_subparser(subparsers: SubparsersList) -> None:
     parser = subparsers.add_parser(
         "decode",
         description="\n".join([

--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 from io import StringIO
 
-from ._parser_utils import TSubparsersAction
+from ._parser_utils import SubparsersList
 
 
 class DummyTool:
@@ -22,7 +22,7 @@ class DummyTool:
         self._odxtools_tool_name_ = tool_name
         self._error = error
 
-    def add_subparser(self, subparser_list: TSubparsersAction) -> None:
+    def add_subparser(self, subparser_list: SubparsersList) -> None:
         desc = StringIO()
 
         print(f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}", file=desc)

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -7,7 +7,7 @@ from ..diagservice import DiagService
 from ..odxtypes import ParameterValue
 from ..singleecujob import SingleEcuJob
 from . import _parser_utils
-from ._parser_utils import TSubparsersAction
+from ._parser_utils import SubparsersList
 from ._print_utils import print_diagnostic_service
 
 # name of the tool
@@ -67,7 +67,7 @@ def print_summary(odxdb: Database,
             print(f"Unknown service: {service}")
 
 
-def add_subparser(subparsers: TSubparsersAction) -> None:
+def add_subparser(subparsers: SubparsersList) -> None:
     parser = subparsers.add_parser(
         "find",
         description="\n".join([

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -10,7 +10,7 @@ from ..diaglayer import DiagLayer
 from ..diagservice import DiagService
 from ..singleecujob import SingleEcuJob
 from . import _parser_utils
-from ._parser_utils import TSubparsersAction
+from ._parser_utils import SubparsersList
 from ._print_utils import format_desc, print_diagnostic_service, print_dl_metrics
 
 # name of the tool
@@ -112,7 +112,7 @@ def print_summary(odxdb: Database,
                 rich.print(f"  {com_param.short_name}: {com_param.value}")
 
 
-def add_subparser(subparsers: TSubparsersAction) -> None:
+def add_subparser(subparsers: SubparsersList) -> None:
     parser = subparsers.add_parser(
         "list",
         description="\n".join([

--- a/odxtools/cli/main.py
+++ b/odxtools/cli/main.py
@@ -4,6 +4,7 @@ import importlib
 from typing import Any, List
 
 import odxtools
+import odxtools.exceptions
 
 from ..version import __version__ as odxtools_version
 from .dummy_sub_parser import DummyTool

--- a/odxtools/cli/snoop.py
+++ b/odxtools/cli/snoop.py
@@ -15,7 +15,7 @@ from odxtools.isotp_state_machine import IsoTpStateMachine
 from odxtools.response import Response, ResponseType
 
 from . import _parser_utils
-from ._parser_utils import TSubparsersAction
+from ._parser_utils import SubparsersList
 
 # name of the tool
 _odxtools_tool_name_ = "snoop"
@@ -30,6 +30,8 @@ ecu_tx_id = None
 def handle_telegram(telegram_id: int, payload: bytes) -> None:
     global odx_diag_layer
     global last_request
+
+    assert odx_diag_layer is not None
 
     if telegram_id == ecu_tx_id:
         if uds.is_response_pending(payload):
@@ -210,7 +212,7 @@ def add_cli_arguments(parser: argparse.ArgumentParser) -> None:
     _parser_utils.add_pdx_argument(parser)
 
 
-def add_subparser(subparsers: TSubparsersAction) -> None:
+def add_subparser(subparsers: SubparsersList) -> None:
     parser = subparsers.add_parser(
         "snoop",
         description="Live decoding of a diagnostic session.",

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -131,7 +131,7 @@ class ComparamInstance:
 
         result = value_list[idx]
         if result is None:
-            result = comparam_spec.subparams[idx].physical_default_value
+            result = getattr(comparam_spec.subparams[idx], "physical_default_value", None)
         if not isinstance(result, str):
             odxraise()
 

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -120,6 +120,7 @@ class ComparamInstance:
         name_list = [cp.short_name for cp in comparam_spec.subparams]
         try:
             idx = name_list.index(subparam_name)
+            subparam = comparam_spec.subparams[idx]
         except ValueError:
             warnings.warn(
                 f"Communication parameter '{self.short_name}' "
@@ -130,8 +131,8 @@ class ComparamInstance:
             return None
 
         result = value_list[idx]
-        if result is None:
-            result = getattr(comparam_spec.subparams[idx], "physical_default_value", None)
+        if result is None and isinstance(subparam, (Comparam, ComplexComparam)):
+            result = subparam.physical_default_value
         if not isinstance(result, str):
             odxraise()
 

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import abc
 from dataclasses import dataclass
 from typing import Literal
 
@@ -15,14 +14,13 @@ CompuMethodCategory = Literal[
 
 
 @dataclass
-class CompuMethod(abc.ABC):
+class CompuMethod:
     internal_type: DataType
     physical_type: DataType
 
     @property
-    @abc.abstractmethod
     def category(self) -> CompuMethodCategory:
-        pass
+        raise NotImplementedError()
 
     def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
         raise NotImplementedError()

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -88,7 +88,7 @@ class CompuScale:
             # which is allowed (cf section 7.3.6.6.1)
             assert self.lower_limit is not None
 
-            return internal_value == self.lower_limit._value
+            return internal_value == self.lower_limit.value
         elif self.lower_limit is None:
             # only the upper limit has been specified. the spec is
             # ambiguous: it only says that if no upper limit is
@@ -101,7 +101,7 @@ class CompuScale:
             # specified.
             assert self.upper_limit is not None
 
-            return internal_value == self.upper_limit._value
+            return internal_value == self.upper_limit.value
 
         return self.lower_limit.complies_to_lower(internal_value) and \
             self.upper_limit.complies_to_upper(internal_value)

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: MIT
-import warnings
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree
 
-from ..exceptions import OdxWarning, odxassert, odxraise, odxrequire
-from ..globals import logger
+from ..exceptions import odxassert, odxraise, odxrequire
 from ..odxlink import OdxDocFragment
 from ..odxtypes import DataType
 from .compumethod import CompuMethod
@@ -58,10 +56,8 @@ def _parse_compu_scale_to_linear_compu_method(
     if (string := coeffs.findtext("COMPU-DENOMINATOR/V")) is not None:
         denominator = float(string)
         if denominator == 0:
-            warnings.warn(
-                "CompuMethod: A denominator of zero will lead to divisions by zero.",
-                OdxWarning,
-                stacklevel=1)
+            odxraise("CompuMethod: A denominator of zero will lead to divisions by zero.")
+
     # Read lower limit
     internal_lower_limit = Limit.limit_from_et(
         et_element.find("LOWER-LIMIT"),
@@ -184,6 +180,7 @@ def create_any_compu_method_from_et(et_element: ElementTree.Element,
         return TabIntpCompuMethod(
             internal_points=internal_points, physical_points=physical_points, **kwargs)
 
-    # TODO: Implement other categories (never instantiate CompuMethod)
-    logger.warning(f"Warning: Computation category {compu_category} is not implemented!")
+    # TODO: Implement all categories (never instantiate the CompuMethod base class!)
+    odxraise(f"Warning: Computation category {compu_category} is not implemented!")
+
     return IdenticalCompuMethod(internal_type=DataType.A_UINT32, physical_type=DataType.A_UINT32)

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -62,6 +62,10 @@ class Limit:
         if self.value_raw is not None:
             self._value = value_type.from_string(self.value_raw)
 
+    @property
+    def value(self) -> Optional[AtomicOdxType]:
+        return self._value
+
     def complies_to_upper(self, value: AtomicOdxType) -> bool:
         """Checks if the value is in the range w.r.t. the upper limit.
 

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -120,8 +120,10 @@ class DataObjectProperty(DopBase):
 
         return self.compu_method.convert_physical_to_internal(physical_value)
 
-    def convert_physical_to_bytes(self, physical_value: Any, encode_state: EncodeState,
-                                  bit_position: int) -> bytes:
+    def convert_physical_to_bytes(self,
+                                  physical_value: Any,
+                                  encode_state: EncodeState,
+                                  bit_position: int = 0) -> bytes:
         """
         Convert a physical representation of a parameter to a string bytes that can be send over the wire
         """

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -100,6 +100,7 @@ class DecodeState:
 
         text_errors = 'strict' if exceptions.strict_mode else 'replace'
         if base_data_type == DataType.A_ASCIISTRING:
+            assert isinstance(internal_value, (bytes, bytearray))
             # The spec says ASCII, meaning only byte values 0-127.
             # But in practice, vendors use iso-8859-1, aka latin-1
             # reason being iso-8859-1 never fails since it has a valid
@@ -107,9 +108,11 @@ class DecodeState:
             text_encoding = 'iso-8859-1'
             internal_value = internal_value.decode(encoding=text_encoding, errors=text_errors)
         elif base_data_type == DataType.A_UTF8STRING:
+            assert isinstance(internal_value, (bytes, bytearray))
             text_encoding = "utf-8"
             internal_value = internal_value.decode(encoding=text_encoding, errors=text_errors)
         elif base_data_type == DataType.A_UNICODE2STRING:
+            assert isinstance(internal_value, (bytes, bytearray))
             # For UTF-16, we need to manually decode the extracted
             # bytes to a string
             text_encoding = "utf-16-be" if is_highlow_byte_order else "utf-16-le"

--- a/odxtools/determinenumberofitems.py
+++ b/odxtools/determinenumberofitems.py
@@ -7,7 +7,7 @@ from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 
 if TYPE_CHECKING:
-    from ..diaglayer import DiagLayer
+    from .diaglayer import DiagLayer
 
 
 @dataclass

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -142,6 +142,7 @@ class DiagCodedType(abc.ABC):
         """Helper method to get the minimal byte length.
         (needed for LeadingLength- and MinMaxLengthType)
         """
+        byte_length: int = -1
         # A_BYTEFIELD, A_ASCIISTRING, A_UNICODE2STRING, A_UTF8STRING
         if self.base_data_type == DataType.A_BYTEFIELD:
             byte_length = len(internal_value)

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -53,6 +53,9 @@ class DiagLayer:
 
     diag_layer_raw: DiagLayerRaw
 
+    def __post_init__(self) -> None:
+        self._global_negative_responses: NamedItemList[Response]
+
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagLayer":
         diag_layer_raw = DiagLayerRaw.from_et(et_element, doc_frags)
@@ -1149,14 +1152,8 @@ class DiagLayer:
 
         return self._decode(message, candidate_services)
 
-    def decode_response(self, response: bytes, request: Union[bytes, Message]) -> List[Message]:
-        if isinstance(request, Message):
-            candidate_services = [request.service]
-        else:
-            if not isinstance(request, (bytes, bytearray)):
-                raise TypeError(f"Request parameter must have type "
-                                f"Message, bytes or bytearray but was {type(request)}")
-            candidate_services = self._find_services_for_uds(request)
+    def decode_response(self, response: bytes, request: bytes) -> List[Message]:
+        candidate_services = self._find_services_for_uds(request)
         if candidate_services is None:
             raise DecodeError(f"Couldn't find corresponding service for request {request.hex()}.")
 

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -64,8 +64,10 @@ class DopBase(IdentifiableElement):
         """
         raise NotImplementedError
 
-    def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
-                                  bit_position: int) -> bytes:
+    def convert_physical_to_bytes(self,
+                                  physical_value: ParameterValue,
+                                  encode_state: EncodeState,
+                                  bit_position: int = 0) -> bytes:
         """Convert the physical value into bytes."""
         raise NotImplementedError
 

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -128,8 +128,10 @@ class DtcDop(DopBase):
 
         return dtc
 
-    def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
-                                  bit_position: int) -> bytes:
+    def convert_physical_to_bytes(self,
+                                  physical_value: ParameterValue,
+                                  encode_state: EncodeState,
+                                  bit_position: int = 0) -> bytes:
         if isinstance(physical_value, DiagnosticTroubleCode):
             trouble_code = physical_value.trouble_code
         elif isinstance(physical_value, int):

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -41,7 +41,7 @@ class EndOfPduField(Field):
 
     def convert_physical_to_bytes(
         self,
-        physical_values: ParameterValue,
+        physical_value: ParameterValue,
         encode_state: EncodeState,
         bit_position: int = 0,
     ) -> bytes:
@@ -49,13 +49,13 @@ class EndOfPduField(Field):
         odxassert(
             bit_position == 0, "End of PDU field must be byte aligned. "
             "Is there an error in reading the .odx?", EncodeError)
-        if not isinstance(physical_values, list):
+        if not isinstance(physical_value, list):
             odxraise(
                 f"Expected a list of values for end-of-pdu field {self.short_name}, "
-                f"got {type(physical_values)}", EncodeError)
+                f"got {type(physical_value)}", EncodeError)
 
         coded_message = b''
-        for value in physical_values:
+        for value in physical_value:
             coded_message += self.structure.convert_physical_to_bytes(value, encode_state)
         return coded_message
 

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -86,8 +86,10 @@ class EnvironmentDataDescription(ComplexDop):
             for ed in self.env_datas:
                 ed._resolve_snrefs(diag_layer)
 
-    def convert_physical_to_bytes(self, physical_value: ParameterValue, encode_state: EncodeState,
-                                  bit_position: int) -> bytes:
+    def convert_physical_to_bytes(self,
+                                  physical_value: ParameterValue,
+                                  encode_state: EncodeState,
+                                  bit_position: int = 0) -> bytes:
         """Convert the physical value into bytes.
 
         Since environmental data is supposed to never appear on the

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -139,7 +139,7 @@ class IsoTpStateMachine:
                     return
 
                 if m := self.can_normal_frame_re.match(cur_line.strip()):
-                    #frame_interface = m.group(1)
+                    # frame_interface = m.group(1)
                     frame_id = int(m.group(2), 16)
 
                     frame_data_formatted = m.group(3).strip()
@@ -151,7 +151,7 @@ class IsoTpStateMachine:
                 elif (m := self.can_log_frame_re.match(
                         cur_line.strip())) or (m := self.can_fd_log_frame_re.match(
                             cur_line.strip())):
-                    #frame_interface = m.group(2)
+                    # frame_interface = m.group(2)
                     frame_id = int(m.group(2), 16)
 
                     frame_data_formatted = m.group(3).strip()
@@ -257,7 +257,7 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
 
     def on_single_frame(self, telegram_idx: int, frame_payload: bytes) -> None:
         # send ACK
-        #rx_id = self.can_rx_id(telegram_idx)
+        # rx_id = self.can_rx_id(telegram_idx)
         tx_id = self.can_tx_id(telegram_idx)
         block_size = 0xFF
         min_separation_time = 0  # ms
@@ -276,7 +276,7 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
 
     def on_first_frame(self, telegram_idx: int, frame_payload: bytes) -> None:
         # send ACK
-        #rx_id = self.can_rx_id(telegram_idx)
+        # rx_id = self.can_rx_id(telegram_idx)
         tx_id = self.can_tx_id(telegram_idx)
         block_size = 0xFF  # default value, can be overwritten later
         min_separation_time = 0  # ms
@@ -308,7 +308,7 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
         # send new ACK if necessary
         block_size = self._block_size[telegram_idx]
         if block_size is not None and num_received >= block_size:
-            #rx_id = self.can_rx_id(telegram_idx)
+            # rx_id = self.can_rx_id(telegram_idx)
             tx_id = self.can_tx_id(telegram_idx)
             min_separation_time = 0  # ms
             fc_payload = bitstruct.pack(

--- a/odxtools/multiplexerswitchkey.py
+++ b/odxtools/multiplexerswitchkey.py
@@ -7,7 +7,7 @@ from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 
 if TYPE_CHECKING:
-    from ..diaglayer import DiagLayer
+    from .diaglayer import DiagLayer
 
 
 @dataclass

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -12,7 +12,7 @@ class OdxNamed(Protocol):
 
     @property
     def short_name(self) -> str:
-        pass
+        ...
 
 
 T = TypeVar("T")
@@ -139,7 +139,8 @@ class ItemAttributeList(List[T]):
     def __getitem__(self, key: slice) -> List[T]:
         ...
 
-    def __getitem__(self, key: Union[SupportsIndex, str, slice]) -> Union[T, List[T]]:
+    def __getitem__(  # type: ignore
+            self, key: Union[SupportsIndex, str, slice]) -> Union[T, List[T]]:
         if isinstance(key, (SupportsIndex, slice)):
             return super().__getitem__(key)
         else:
@@ -177,7 +178,7 @@ class ItemAttributeList(List[T]):
 
 class NamedItemList(ItemAttributeList[T]):
 
-    def _get_item_key(self, obj: T) -> str:
+    def _get_item_key(self, item: T) -> str:
         """Transform an object's `short_name` attribute into a valid
         python identifier
 
@@ -187,9 +188,9 @@ class NamedItemList(ItemAttributeList[T]):
         such short names.
 
         """
-        if not isinstance(obj, OdxNamed):
+        if not isinstance(item, OdxNamed):
             odxraise()
-        sn = obj.short_name
+        sn = item.short_name
         if not isinstance(sn, str):
             odxraise()
 

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -181,7 +181,7 @@ class OdxLinkDatabase:
     def resolve(self, ref: OdxLinkRef, expected_type: Type[T]) -> T:
         ...
 
-    def resolve(self, ref: OdxLinkRef, expected_type: Optional[Type[T]] = None) -> Any:
+    def resolve(self, ref: OdxLinkRef, expected_type: Optional[Any] = None) -> Any:
         """
         Resolve a reference to an object
 
@@ -223,7 +223,7 @@ class OdxLinkDatabase:
 
     def resolve_lenient(self,
                         ref: OdxLinkRef,
-                        expected_type: Optional[Type[T]] = None) -> Optional[Any]:
+                        expected_type: Optional[Any] = None) -> Optional[Any]:
         """
         Resolve a reference to an object
 

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -40,6 +40,8 @@ def create_any_parameter_from_et(et_element: ElementTree.Element,
     sdgs = create_sdgs_from_et(et_element.find("SDGS"), doc_frags)
 
     # Which attributes are set depends on the type of the parameter.
+    dop_ref = None
+    dop_snref = None
     if parameter_type in ["VALUE", "PHYS-CONST", "SYSTEM", "LENGTH-KEY"]:
         dop_ref = OdxLinkRef.from_et(et_element.find("DOP-REF"), doc_frags)
         dop_snref = None

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
-from ..exceptions import EncodeError, OdxWarning, odxraise
+from ..exceptions import DecodeError, EncodeError, OdxWarning, odxraise
 from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..odxtypes import ParameterValue
 from .parameter import Parameter, ParameterType
@@ -136,8 +136,9 @@ class TableStructParameter(Parameter):
         decode_state.table_keys[key_name]
         table_row = decode_state.table_keys.get(key_name)
         if table_row is None:
-            raise odxraise(f"No table key '{key_name}' found when decoding "
-                           f"table struct parameter '{str(self.short_name)}'")
+            odxraise(
+                f"No table key '{key_name}' found when decoding "
+                f"table struct parameter '{str(self.short_name)}'", DecodeError)
             dummy_val = cast(str, None), cast(int, None)
             return dummy_val
 

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -20,7 +20,7 @@ class StateTransition(IdentifiableElement):
     """
     source_snref: str
     target_snref: str
-    #external_access_method: Optional[ExternalAccessMethod] # TODO
+    # external_access_method: Optional[ExternalAccessMethod] # TODO
 
     @property
     def source_state(self) -> State:

--- a/odxtools/write_pdx_file.py
+++ b/odxtools/write_pdx_file.py
@@ -120,9 +120,9 @@ def write_pdx_file(
             creation_date = file_cdate.strftime("%Y-%m-%dT%H:%M:%S")
 
             mime_type = "text/plain"
-            if template_file_name.endswith(".odx-cs"):
+            if output_file_name.endswith(".odx-cs"):
                 mime_type = "application/x-asam.odx.odx-cs"
-            elif template_file_name.endswith(".odx-d"):
+            elif output_file_name.endswith(".odx-d"):
                 mime_type = "application/x-asam.odx.odx-d"
 
             zf_name = os.path.basename(output_file_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import unittest
 from argparse import Namespace
+from types import ModuleType
 from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
@@ -10,12 +11,11 @@ import odxtools.cli.decode as decode
 import odxtools.cli.find as find
 import odxtools.cli.list as list_tool
 
-browse_import_failed = False
-
+browse: Optional[ModuleType]
 try:
     import odxtools.cli.browse as browse
 except ImportError:
-    browse_import_failed = True
+    browse = None
 
 
 class UtilFunctions:
@@ -131,11 +131,12 @@ class TestCommandLineTools(unittest.TestCase):
         ])
         UtilFunctions.run_compare_tool(ecu_variants=["somersault_lazy", "somersault_assiduous"])
 
-    @unittest.skipIf(browse_import_failed, "importing the browse tool failed")
+    @unittest.skipIf(browse is None, "importing the browse tool failed")
     # browse is an interactive tool, so we need to mock a few
     # functions to make PyInquirer reliably bail out
     @patch("sys.stdout.isatty", return_value=False)
     def test_browse_tool(self, pi_prompt: MagicMock) -> None:
+        assert browse is not None
         browse_args = Namespace(pdx_file="./examples/somersault.pdx")
         with self.assertRaises(SystemError):
             # browse can only be run interactively

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List
 
 import odxtools
+import odxtools.exceptions
 from odxtools.exceptions import OdxError
 from odxtools.load_pdx_file import load_pdx_file
 from odxtools.nameditemlist import NamedItemList


### PR DESCRIPTION
This fixes some complaints brought up by `flake8`, `pytype` and `pyright`. Note that I don't intend to run these linters as part of the CI, because it would make contributing even harder than it already is and there are some issues with `flake8` and `pytype`:

- `flake8` likes to play "style police" and thus requires *a ton* of parameters (`--ignore E124,E125,E126,E131,E501,F541,W503,W504`), which together with the fact that it cannot (easily) be configured via `pyproject.toml`  makes it quite cumbersome.
- `pytype` is glacially slow and produces a few false positives which I could not fix
- `pyright` fights with `mypy` about the import of `InquirerPy.prompt` in the browse tool, so it draws the shorter stick...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
