### PR TITLE
Add `PositionableParam`

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -68,7 +68,8 @@ class BasicStructure(ComplexDop):
             cursor += param_bit_length
             length = max(length, cursor)
 
-        # Round up to account for padding bits
+        # Round up to account for padding bits (all structures are
+        # byte aligned)
         return ((length + 7) // 8) * 8
 
     def coded_const_prefix(self, request_prefix: bytes = b'') -> bytes:

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -3,6 +3,8 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
@@ -62,13 +64,8 @@ class CodedConstParameter(Parameter):
         return self.diag_coded_type.convert_internal_to_bytes(
             self.coded_value, encode_state=encode_state, bit_position=bit_position_int)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
-        # Extract coded values
-        orig_cursor_pos = decode_state.cursor_byte_position
-        if self.byte_position is not None:
-            decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
-
-        decode_state.cursor_bit_position = self.bit_position or 0
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
         coded_val = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.
@@ -82,8 +79,6 @@ class CodedConstParameter(Parameter):
                 DecodeError,
                 stacklevel=1,
             )
-
-        decode_state.cursor_byte_position = max(orig_cursor_pos, decode_state.cursor_byte_position)
 
         return coded_val
 

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..odxtypes import ParameterValue
@@ -25,5 +27,6 @@ class DynamicParameter(Parameter):
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         raise NotImplementedError("Encoding a DynamicParameter is not implemented yet.")
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         raise NotImplementedError("Decoding a DynamicParameter is not implemented yet.")

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import odxraise, odxrequire
@@ -66,8 +68,9 @@ class LengthKeyParameter(ParameterWithDOP):
     def encode_into_pdu(self, encode_state: EncodeState) -> bytes:
         return super().encode_into_pdu(encode_state)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
-        phys_val = super().decode_from_pdu(decode_state)
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
+        phys_val = super()._decode_positioned_from_pdu(decode_state)
 
         if not isinstance(phys_val, int):
             odxraise(f"The pysical type of length keys must be an integer, "

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import EncodeError
@@ -37,16 +39,11 @@ class MatchingRequestParameter(Parameter):
                                                .request_byte_position:self.request_byte_position +
                                                self.byte_length]
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
-        orig_cursor = decode_state.cursor_byte_position
-        if self.byte_position is not None:
-            decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
-
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         result = decode_state.extract_atomic_value(
             bit_length=self.byte_length * 8,
             base_data_type=DataType.A_UINT32,
             is_highlow_byte_order=False)
-
-        decode_state.cursor_byte_position = max(decode_state.cursor_byte_position, orig_cursor)
 
         return result

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -3,6 +3,8 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
@@ -77,14 +79,9 @@ class NrcConstParameter(Parameter):
         return self.diag_coded_type.convert_internal_to_bytes(
             coded_value, encode_state, bit_position=bit_position_int)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
-        orig_cursor = decode_state.cursor_byte_position
-        if self.byte_position is not None:
-            # Update cursor position
-            decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
-
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
         # Extract coded values
-        decode_state.cursor_bit_position = self.bit_position or 0
         coded_value = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.
@@ -98,8 +95,6 @@ class NrcConstParameter(Parameter):
                 DecodeError,
                 stacklevel=1,
             )
-
-        decode_state.cursor_byte_position = max(decode_state.cursor_byte_position, orig_cursor)
 
         return coded_value
 

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -31,6 +31,13 @@ ParameterType = Literal[
 
 @dataclass
 class Parameter(NamedElement, abc.ABC):
+    """This class corresponds to the POSITIONABLE-PARAMETER type of
+    the ODX specification.
+
+    Be aware that, even though the ODX specification seems to make the
+    distinction of "positionable" and "normal" parameters, it does not
+    define any non-positionable parameter types.
+    """
     byte_position: Optional[int]
     bit_position: Optional[int]
     semantic: Optional[str]

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from typing_extensions import override
+
 from ..dataobjectproperty import DataObjectProperty
 from ..decodestate import DecodeState
 from ..dopbase import DopBase
@@ -75,16 +77,6 @@ class ParameterWithDOP(Parameter):
         return dop.convert_physical_to_bytes(
             physical_value, encode_state, bit_position=bit_position_int)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
-        orig_cursor = decode_state.cursor_byte_position
-        if self.byte_position is not None:
-            decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
-
-        decode_state.cursor_bit_position = self.bit_position or 0
-
-        # Use DOP to decode
-        phys_val = self.dop.decode_from_pdu(decode_state)
-
-        decode_state.cursor_byte_position = max(orig_cursor, decode_state.cursor_byte_position)
-
-        return phys_val
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
+        return self.dop.decode_from_pdu(decode_state)

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict
 
+from typing_extensions import override
+
 from ..dataobjectproperty import DataObjectProperty
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
@@ -63,9 +65,10 @@ class PhysicalConstantParameter(ParameterWithDOP):
         return dop.convert_physical_to_bytes(
             self.physical_constant_value, encode_state, bit_position=bit_position_int)
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         # Decode value
-        phys_val = super().decode_from_pdu(decode_state)
+        phys_val = super()._decode_positioned_from_pdu(decode_state)
 
         # Check if decoded value matches expected value
         if phys_val != self.physical_constant_value:

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..odxtypes import ParameterValue
@@ -27,5 +29,6 @@ class SystemParameter(ParameterWithDOP):
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         raise NotImplementedError("Encoding a SystemParameter is not implemented yet.")
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
-        raise NotImplementedError("Decoding a SystemParameter is not implemented yet.")
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
+        raise NotImplementedError("Decoding SystemParameter is not implemented yet.")

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -21,15 +21,15 @@ class TableEntryParameter(Parameter):
 
     @property
     def is_required(self) -> bool:
-        raise NotImplementedError("TableKeyParameter.is_required is not implemented yet.")
+        raise NotImplementedError("TableEntryParameter.is_required is not implemented yet.")
 
     @property
     def is_settable(self) -> bool:
-        raise NotImplementedError("TableKeyParameter.is_settable is not implemented yet.")
+        raise NotImplementedError("TableEntryParameter.is_settable is not implemented yet.")
 
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
-        raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")
+        raise NotImplementedError("Encoding a TableEntryParameter is not implemented yet.")
 
     @override
     def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
-        raise NotImplementedError("Decoding a TableKeyParameter is not implemented yet.")
+        raise NotImplementedError("Decoding a TableEntryParameter is not implemented yet.")

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..odxlink import OdxLinkRef
@@ -28,5 +30,6 @@ class TableEntryParameter(Parameter):
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
         raise NotImplementedError("Encoding a TableKeyParameter is not implemented yet.")
 
-    def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
+    @override
+    def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         raise NotImplementedError("Decoding a TableKeyParameter is not implemented yet.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,9 @@ dependencies = [
     "markdownify >= 0.11",
     "deprecation >= 2.1",
     "packaging",
-    "tabulate >= 0.9.0",
-    "rich >= 13.7.0",
+    "tabulate >= 0.9",
+    "rich >= 13.7",
+    "typing_extensions >= 4.9",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This is the base class of all parameters for which a position within the PDU can be defined. Interestingly, the XSD does not seem to feature *any* parameters that are not positionable, but let's reflect the class hierarchy implied by the ODX specification...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
