### PR TITLE
fix: COMPU-DEFAULT-VALUE parsing issue by modifying its hierarchical …

### DIFF
--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -137,7 +137,7 @@ def create_any_compu_method_from_et(et_element: ElementTree.Element,
                     scale_elem, doc_frags, internal_type=internal_type,
                     physical_type=physical_type))
         compu_default_value = create_compu_default_value(
-            et_element.find("COMPU-DEFAULT-VALUE"), doc_frags, **kwargs)
+            et_element.find("COMPU-INTERNAL-TO-PHYS/COMPU-DEFAULT-VALUE"), doc_frags, **kwargs)
 
         return TexttableCompuMethod(
             internal_to_phys=internal_to_phys,


### PR DESCRIPTION
During my usage of this tool, I encountered an issue where the `COMPU-DEFAULT-VALUE` within my `COMPU-METHOD` was always returned as None, despite the presence of `COMPU-DEFAULT-VALUE` entries in my ODX files. Upon inspecting the code, I discovered that the hierarchical level of `COMPU-DEFAULT-VALUE` was incorrectly placed under `COMPU-METHOD`. However, according to the actual structure, `COMPU-DEFAULT-VALUE` should be located under `COMPU-INTERNAL-TO-PHYS`.

I proceeded to adjust the hierarchical level of the element accordingly, and after this modification, the `COMPU-DEFAULT-VALUE` was successfully parsed. This fix addresses a parsing issue and ensures that `COMPU-DEFAULT-VALUE` is correctly interpreted from the ODX files, adhering to the expected structure.

I hope this modification can be reviewed and integrated to improve the tool's reliability and usefulness for all users facing similar issues.

Thank you for considering this pull request.