### PR TITLE
dop_snref Temporary plan

### DIFF
--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -128,7 +128,7 @@ class Database:
         # let the diaglayers sort out the inherited objects and the
         # short name references
         for dlc in self.diag_layer_containers:
-            dlc._finalize_init(self._odxlinks)
+            dlc._finalize_init(self._odxlinks, self._ecu_shared_datas)
 
     @property
     def odxlinks(self) -> OdxLinkDatabase:

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -92,6 +92,9 @@ class Database:
 
     def refresh(self) -> None:
         # Create wrapper objects
+        self._ecu_shared_datas = NamedItemList(chain(*[dlc.ecu_shared_datas
+            for dlc in self.diag_layer_containers if dlc.ecu_shared_datas]))
+
         self._diag_layers = NamedItemList(
             chain(*[dlc.diag_layers for dlc in self.diag_layer_containers]))
 
@@ -131,6 +134,13 @@ class Database:
     def odxlinks(self) -> OdxLinkDatabase:
         """A map from odx_id to object"""
         return self._odxlinks
+
+    @property
+    def ecu_shared_datas(self) -> OdxLinkDatabase:
+        """
+        All ecu_shared_datas defined by this database
+        """
+        return self._ecu_shared_datas
 
     @property
     def protocols(self) -> NamedItemList[DiagLayer]:

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -124,17 +124,18 @@ class DiagLayerContainer(IdentifiableElement):
         for ecu_variant in self.ecu_variants:
             ecu_variant._resolve_odxlinks(odxlinks)
 
-    def _finalize_init(self, odxlinks: OdxLinkDatabase) -> None:
+    def _finalize_init(self, odxlinks: OdxLinkDatabase,
+            ecu_shared_datas: NamedItemList[DiagLayer]) -> None:
         for ecu_shared_data in self.ecu_shared_datas:
-            ecu_shared_data._finalize_init(odxlinks)
+            ecu_shared_data._finalize_init(odxlinks, ecu_shared_datas)
         for protocol in self.protocols:
-            protocol._finalize_init(odxlinks)
+            protocol._finalize_init(odxlinks, ecu_shared_datas)
         for functional_group in self.functional_groups:
-            functional_group._finalize_init(odxlinks)
+            functional_group._finalize_init(odxlinks, ecu_shared_datas)
         for base_variant in self.base_variants:
-            base_variant._finalize_init(odxlinks)
+            base_variant._finalize_init(odxlinks, ecu_shared_datas)
         for ecu_variant in self.ecu_variants:
-            ecu_variant._finalize_init(odxlinks)
+            ecu_variant._finalize_init(odxlinks, ecu_shared_datas)
 
     @property
     def diag_layers(self) -> NamedItemList[DiagLayer]:

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -55,6 +55,14 @@ class ItemAttributeList(List[T]):
 
         super().append(item)
 
+    def append_list(self, item_list) -> None:
+        if item_list:
+            for item in item_list:
+                item_name = self._get_item_key(item)
+                if item_name not in self._item_dict:
+                    self._item_dict[item_name] = item
+                    super().append()
+
     def _add_attribute_item(self, item: T) -> None:
         item_name = self._get_item_key(item)
 
@@ -151,6 +159,9 @@ class ItemAttributeList(List[T]):
             raise AttributeError(f"ItemAttributeList does not contain an item named '{key}'")
 
         return self._item_dict[key]
+
+    def __contains__(self, key) -> bool:
+        return key in self._item_dict
 
     def get(self, key: Union[int, str], default: Optional[T] = None) -> Optional[T]:
         if isinstance(key, int):

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -56,12 +56,17 @@ class ItemAttributeList(List[T]):
         super().append(item)
 
     def append_list(self, item_list) -> None:
+        """
+        An instance of a itemAttributeList class,add another instance
+
+        \return The name under which item is accessible
+        """
         if item_list:
             for item in item_list:
                 item_name = self._get_item_key(item)
                 if item_name not in self._item_dict:
                     self._item_dict[item_name] = item
-                    super().append()
+                    super().append(item)
 
     def _add_attribute_item(self, item: T) -> None:
         item_name = self._get_item_key(item)

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -66,7 +66,13 @@ class ParameterWithDOP(Parameter):
 
         if self.dop_snref:
             ddds = diag_layer.diag_data_dictionary_spec
-            self._dop = odxrequire(ddds.all_data_object_properties.get(self.dop_snref))
+            if snref_shortname := ddds.all_data_object_properties.get(self.dop_snref):
+                self._dop = odxrequire(snref_shortname)
+            else:
+                # TODO: In section 7.3.2.5 "Importing and referencing of cobjects",
+                # the ability to cross-reference shortnames using "dop_snref" is
+                # odefined.
+                ...
 
     @property
     def dop(self) -> DopBase:

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -10,7 +10,7 @@ from ..decodestate import DecodeState
 from ..dopbase import DopBase
 from ..dtcdop import DtcDop
 from ..encodestate import EncodeState
-from ..exceptions import odxassert, odxrequire
+from ..exceptions import odxassert, odxrequire, odxraise
 from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..odxtypes import ParameterValue
 from ..physicaltype import PhysicalType
@@ -69,10 +69,7 @@ class ParameterWithDOP(Parameter):
             if snref_shortname := ddds.all_data_object_properties.get(self.dop_snref):
                 self._dop = odxrequire(snref_shortname)
             else:
-                # TODO: In section 7.3.2.5 "Importing and referencing of cobjects",
-                # the ability to cross-reference shortnames using "dop_snref" is
-                # odefined.
-                ...
+                odxraise(f"{self.dop_snref} in not found in {diag_layer.short_name}")
 
     @property
     def dop(self) -> DopBase:


### PR DESCRIPTION
In section 7.3.2.5 "Importing and referencing of cobjects",the ability to cross-reference shortnames using "dop_snref" is
odefined.
dop_snref can reference the content of other files, but the all_data_object_properties here do not define the entire content, which may lead to errors. 
The change here temporarily solves this problem (skipping the use of dop_snref that references other files). This is necessary, otherwise it will trigger odxraise.
Long term change direction: I tend to add the content of the import file when generating all_data_object_properties, rather than processing it in the resolve_snrefs section.