### PR TITLE
Improve the free parameter info messages

### DIFF
--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -67,8 +67,8 @@ class Multiplexer(ComplexDop):
 
     def _get_case_limits(self, case: MultiplexerCase) -> Tuple[AtomicOdxType, AtomicOdxType]:
         key_type = self.switch_key.dop.physical_type.base_data_type
-        lower_limit = key_type.make_from(case.lower_limit)
-        upper_limit = key_type.make_from(case.upper_limit)
+        lower_limit = key_type.make_from(case.lower_limit.value)
+        upper_limit = key_type.make_from(case.upper_limit.value)
         if not isinstance(lower_limit, type(upper_limit)) and not isinstance(
                 upper_limit, type(lower_limit)):
             odxraise("Upper and lower bounds of limits must compareable")

--- a/odxtools/parameterinfo.py
+++ b/odxtools/parameterinfo.py
@@ -1,105 +1,187 @@
 # SPDX-License-Identifier: MIT
-import re
-from typing import Iterable, Union
+import textwrap
+from io import StringIO
+from typing import Iterable
 
 from .compumethods.identicalcompumethod import IdenticalCompuMethod
 from .compumethods.limit import IntervalType
 from .compumethods.linearcompumethod import LinearCompuMethod
 from .compumethods.texttablecompumethod import TexttableCompuMethod
 from .dataobjectproperty import DataObjectProperty
+from .dtcdop import DtcDop
+from .dynamiclengthfield import DynamicLengthField
 from .endofpdufield import EndOfPduField
+from .exceptions import odxrequire
+from .multiplexer import Multiplexer
 from .odxtypes import DataType
 from .parameters.codedconstparameter import CodedConstParameter
 from .parameters.matchingrequestparameter import MatchingRequestParameter
 from .parameters.parameter import Parameter
 from .parameters.parameterwithdop import ParameterWithDOP
 from .parameters.reservedparameter import ReservedParameter
+from .parameters.tablekeyparameter import TableKeyParameter
+from .parameters.tablestructparameter import TableStructParameter
+from .paramlengthinfotype import ParamLengthInfoType
+from .staticfield import StaticField
 
 
-def parameter_info(param_list: Iterable[Union[Parameter, EndOfPduField]]) -> str:
-    result = ""
+def parameter_info(param_list: Iterable[Parameter], quoted_names: bool = False) -> str:
+    q = "'" if quoted_names else ""
+    of = StringIO()
     for param in param_list:
         if isinstance(param, CodedConstParameter):
-            result += f"{param.short_name} : const = {param._coded_value_str}\n"
+            of.write(f"{q}{param.short_name}{q}: const = {param._coded_value_str}\n")
             continue
         elif isinstance(param, MatchingRequestParameter):
-            result += f"{param.short_name} : <matches request>\n"
+            of.write(f"{q}{param.short_name}{q}: <matches request>\n")
             continue
         elif isinstance(param, ReservedParameter):
-            result += f"{param.short_name} : <reserved>\n"
+            of.write(f"{q}{param.short_name}{q}: <reserved>\n")
+            continue
+        elif isinstance(param, TableKeyParameter):
+            of.write(
+                f"{q}{param.short_name}{q}: <optional> table key; table = '{param.table.short_name}'; choices:\n"
+            )
+            for tr in param.table.table_rows:
+                of.write(f"  '{tr.short_name}',\n")
+
+            continue
+        elif isinstance(param, TableStructParameter):
+            of.write(
+                f"{q}{param.short_name}{q}: table struct; key = '{param.table_key.short_name}'; choices:\n"
+            )
+            for tr in param.table_key.table.table_rows:
+                of.write(f"  ('{tr.short_name}',\n")
+                of.write(f"   {{\n")
+                of.write(
+                    textwrap.indent(
+                        parameter_info(odxrequire(tr.structure).parameters, True), "    "))
+                of.write(f"   }}),\n")
+
             continue
         elif not isinstance(param, ParameterWithDOP):
-            result += f"{param.short_name} : <unhandled parameter type>\n"
+            of.write(
+                f"{q}{param.short_name}{q}: <unhandled parameter type '{type(param).__name__}'>\n")
             continue
 
         dop = param.dop
-
         if isinstance(dop, EndOfPduField):
-            result += f"{param.short_name} : <optional> list({{\n"
-            tmp = parameter_info(dop.structure.parameters).strip()
-            tmp = re.sub("^", "  ", tmp)
-            result += tmp + "\n"
-            result += f"}})\n"
+            of.write(f"{q}{param.short_name}{q}: list({{\n")
+            of.write(textwrap.indent(parameter_info(dop.structure.parameters, True), "  "))
+            of.write(f"}})\n")
+            continue
+        elif isinstance(dop, StaticField):
+            of.write(f"{q}{param.short_name}{q}: length={dop.fixed_number_of_items}; list({{\n")
+            of.write(textwrap.indent(parameter_info(dop.structure.parameters, True), "  "))
+            of.write(f"}})\n")
+            continue
+        elif isinstance(dop, DynamicLengthField):
+            of.write(f"{q}{param.short_name}{q}: list({{\n")
+            of.write(textwrap.indent(parameter_info(dop.structure.parameters, True), "  "))
+            of.write(f"}})\n")
+            continue
+        elif isinstance(dop, ParamLengthInfoType):
+            of.write(f"{q}{param.short_name}{q}: ")
+            of.write("<optional> ")
+            of.write(f"int; length_key='{dop.length_key.short_name}'\n")
+            continue
+        elif isinstance(dop, DtcDop):
+            of.write(f"{q}{param.short_name}{q}: ")
+            of.write(f"DTC; choices:\n")
+            for dtc in dop.dtcs:
+                if dtc.display_trouble_code is not None:
+                    dtc_desc = dtc.text and f"; \"{dtc.text}\""
+                    of.write(
+                        f"  '{dtc.display_trouble_code}' (0x{dtc.trouble_code:06x}{dtc_desc})\n")
+                else:
+                    dtc_desc = dtc.text and f" (\"{dtc.text}\")"
+                    of.write(f"  0x{dtc.trouble_code:06x}{dtc_desc}\n")
+            continue
+        elif isinstance(dop, Multiplexer):
+            of.write(f"{q}{param.short_name}{q}: ")
+            if dop.default_case is not None:
+                of.write(f"<optional>")
+            of.write(f"multiplexer; choices:\n")
+            for mux_case in dop.cases:
+                of.write(f"  ({repr(mux_case.short_name)}, {{\n")
+                of.write(
+                    textwrap.indent(parameter_info(mux_case.structure.parameters, True), "    "))
+                of.write(f"   }})\n")
             continue
 
-        result += f"{param.short_name}"
+        of.write(f"{q}{param.short_name}{q}")
 
         if dop is None:
-            result += ": <no DOP>\n"
+            of.write(": <no DOP>\n")
             continue
         elif not isinstance(dop, DataObjectProperty):
-            result += ": <unhandled DOP>\n"
+            of.write(f": <unhandled DOP '{type(dop).__name__}'>\n")
             continue
 
         if (cm := dop.compu_method) is None:
-            result += ": <no compu method>\n"
+            of.write(": <no compu method>\n")
             continue
 
         if isinstance(cm, TexttableCompuMethod):
-            result += f": enum; choices:\n"
+            of.write(f": enum; choices:\n")
             for scale in cm.internal_to_phys:
-                result += f"  '{str(scale.compu_const)}'\n"
+                val_str = ""
+                if scale.lower_limit is not None:
+                    val_str = f"({repr(scale.lower_limit.value)})"
+                of.write(f"  {repr(scale.compu_const)}{val_str}\n")
 
         elif isinstance(cm, IdenticalCompuMethod):
             bdt = dop.physical_type.base_data_type
             if bdt in (DataType.A_UTF8STRING, DataType.A_UNICODE2STRING, DataType.A_ASCIISTRING):
-                result += f": str"
-            elif bdt in (DataType.A_BYTEFIELD,):
-                result += f": bytes"
+                of.write(f": str")
+            elif bdt == DataType.A_BYTEFIELD:
+                of.write(f": bytes")
             elif bdt.name.startswith("A_FLOAT"):
-                result += f": float"
+                of.write(f": float")
             elif bdt.name.startswith("A_UINT"):
-                result += f": uint"
+                of.write(f": uint")
             elif bdt.name.startswith("A_INT"):
-                result += f": int"
+                of.write(f": int")
             else:
-                result += f": <unknown type>"
+                of.write(f": <unknown type {{ bdt.name }}>")
 
-            if (bl := dop.get_static_bit_length()) is not None:
-                result += f"{bl}"
-
-            result += "\n"
+            of.write("\n")
 
         elif isinstance(cm, LinearCompuMethod):
-            result += f": float\n"
+            bdt = dop.physical_type.base_data_type
+            if bdt in (DataType.A_UTF8STRING, DataType.A_UNICODE2STRING, DataType.A_ASCIISTRING):
+                of.write(f": str")
+            elif bdt in (DataType.A_BYTEFIELD,):
+                of.write(f": bytes")
+            elif bdt.name.startswith("A_FLOAT"):
+                of.write(f": float")
+            elif bdt.name.startswith("A_UINT"):
+                of.write(f": uint")
+            elif bdt.name.startswith("A_INT"):
+                of.write(f": int")
+            else:
+                of.write(f": <unknown type>")
+
             ll = cm.physical_lower_limit
             ul = cm.physical_upper_limit
-            if ll is None:
-                ll_str = "(inf"
+            if ll is None or ll.interval_type == IntervalType.INFINITE:
+                ll_str = "(-inf"
             else:
-                ll_delim = '[' if ll.interval_type == IntervalType.CLOSED else '('
+                ll_delim = '(' if ll.interval_type == IntervalType.OPEN else '['
                 ll_str = f"{ll_delim}{ll._value!r}"
 
-            if ul is None:
+            if ul is None or ul.interval_type == IntervalType.INFINITE:
                 ul_str = "inf)"
             else:
-                ul_delim = ']' if ul.interval_type == IntervalType.CLOSED else ')'
+                ul_delim = ')' if ul.interval_type == IntervalType.OPEN else ']'
                 ul_str = f"{ul._value!r}{ul_delim}"
-            result += f" range: {ll_str}, {ul_str}\n"
+            of.write(f"; range: {ll_str}, {ul_str}")
 
             unit = dop.unit
             unit_str = unit.display_name if unit is not None else None
             if unit_str is not None:
-                result += f" unit: {unit_str}\n"
+                of.write(f"; unit: {unit_str}")
 
-    return result
+            of.write("\n")
+
+    return of.getvalue()

--- a/tests/test_somersault.py
+++ b/tests/test_somersault.py
@@ -305,20 +305,20 @@ class TestEnDecode(unittest.TestCase):
         stdout = StringIO()
         with patch("sys.stdout", stdout):
             request.print_free_parameters_info()
-            expected_output = "forward_soberness_check: uint8\nnum_flips: uint8\n"
+            expected_output = "forward_soberness_check: uint\nnum_flips: uint\n"
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)
 
         with patch("sys.stdout", stdout):
             pos_response.print_free_parameters_info()
-            expected_output = "forward_soberness_check: uint8\nnum_flips: uint8\nsault_time: uint8\n"
+            expected_output = "forward_soberness_check: uint\nnum_flips: uint\nsault_time: uint\n"
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)
 
         with patch("sys.stdout", stdout):
             neg_response.print_free_parameters_info()
             expected_output = (
-                "forward_soberness_check: uint8\nnum_flips: uint8\nsault_time: uint8\nflips_successfully_done: uint8\n"
+                "forward_soberness_check: uint\nnum_flips: uint\nsault_time: uint\nflips_successfully_done: uint\n"
             )
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)


### PR DESCRIPTION
With this, the `parameter_info()` function handles more parameter types, deals with more DOP types and handles complex DOPs (structures) properly. Also, I tried to make the results more consistent, but IMO this is not too important, because the result of this function is intended to be informal and for human consumption.

Besides this I found a fixed a small mistake in the handling of case limits in the multiplexer code.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
