### PR TITLE
Implement the IMPORT-REF mechanism

### DIFF
--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -111,10 +111,14 @@ class DiagLayer:
                     link_id = OdxLinkId(link_id.local_id, self.odx_id.doc_fragments)
                     imported_links[link_id] = obj
 
-            odxlinks = copy(odxlinks)
-            odxlinks.update(imported_links)
+            # We need to copy the odxlink database here since this
+            # function must not modify its argument because the
+            # imported references only apply within this specific
+            # diagnostic layer
+            extended_odxlinks = copy(odxlinks)
+            extended_odxlinks.update(imported_links)
 
-            self.diag_layer_raw._resolve_odxlinks(odxlinks)
+            self.diag_layer_raw._resolve_odxlinks(extended_odxlinks)
             return
 
         self.diag_layer_raw._resolve_odxlinks(odxlinks)


### PR DESCRIPTION
If I understood the spec correctly, this simply extends the pool of objects that are locally referenceable via ODXLINK (i.e., without having to explicitly specify the DOCREF attribute in the reference), and can thus be seen as a kind of "poor man's inheritance" mechanism.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
