### PR TITLE
Refactor encoding, part 2 (diag coded types)

### DIFF
--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -133,8 +133,22 @@ class DataObjectProperty(DopBase):
                 f" is not a valid.")
 
         internal_val = self.convert_physical_to_internal(physical_value)
-        return self.diag_coded_type.convert_internal_to_bytes(
-            internal_val, encode_state, bit_position=bit_position)
+
+        tmp_state = EncodeState(
+            bytearray(),
+            encode_state.parameter_values,
+            triggering_request=encode_state.triggering_request,
+            is_end_of_pdu=encode_state.is_end_of_pdu,
+            cursor_byte_position=0,
+            cursor_bit_position=bit_position,
+            origin_byte_position=0)
+
+        self.diag_coded_type.encode_into_pdu(internal_val, tmp_state)
+
+        encode_state.length_keys.update(tmp_state.length_keys)
+        encode_state.table_keys.update(tmp_state.table_keys)
+
+        return tmp_state.coded_message
 
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         """

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -147,9 +147,21 @@ class DtcDop(DopBase):
                               f" DiagnosticTroubleCode but got {physical_value!r}.")
 
         internal_trouble_code = self.compu_method.convert_physical_to_internal(trouble_code)
+        tmp_state = EncodeState(
+            bytearray(),
+            encode_state.parameter_values,
+            triggering_request=encode_state.triggering_request,
+            is_end_of_pdu=False,
+            cursor_byte_position=0,
+            cursor_bit_position=0,
+            origin_byte_position=0)
+        encode_state.cursor_bit_position = encode_state.cursor_bit_position
+        self.diag_coded_type.encode_into_pdu(internal_trouble_code, encode_state=tmp_state)
 
-        return self.diag_coded_type.convert_internal_to_bytes(
-            internal_trouble_code, encode_state=encode_state, bit_position=bit_position)
+        encode_state.length_keys.update(tmp_state.length_keys)
+        encode_state.table_keys.update(tmp_state.table_keys)
+
+        return tmp_state.coded_message
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -78,7 +78,9 @@ class LengthKeyParameter(ParameterWithDOP):
 
     @override
     def get_coded_value_as_bytes(self, encode_state: EncodeState) -> bytes:
-        physical_value = encode_state.parameter_values.get(self.short_name, 0)
+        physical_value = encode_state.length_keys.get(self.short_name)
+        if physical_value is None:
+            physical_value = encode_state.parameter_values.get(self.short_name, 0)
 
         bit_pos = self.bit_position or 0
         dop = odxrequire(super().dop,

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -103,9 +103,18 @@ class NrcConstParameter(Parameter):
             # I think it does not matter ...
             coded_value = self.coded_values[0]
 
-        bit_position_int = self.bit_position if self.bit_position is not None else 0
-        return self.diag_coded_type.convert_internal_to_bytes(
-            coded_value, encode_state, bit_position=bit_position_int)
+        tmp_state = EncodeState(
+            bytearray(),
+            encode_state.parameter_values,
+            triggering_request=encode_state.triggering_request,
+            is_end_of_pdu=False,
+            cursor_byte_position=0,
+            cursor_bit_position=0,
+            origin_byte_position=0)
+        encode_state.cursor_bit_position = self.bit_position or 0
+        self.diag_coded_type.encode_into_pdu(coded_value, encode_state=tmp_state)
+
+        return tmp_state.coded_message
 
     @override
     def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -416,6 +416,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             coded_message=bytearray([0xcc]), parameter_values={}, cursor_byte_position=2)
         dct.encode_into_pdu(0x12345, state)
         self.assertEqual(state.coded_message.hex(), "cc00012345")
+        self.assertEqual(state.length_keys.get("length_key"), 24)
 
     def test_end_to_end(self) -> None:
         # diag coded types

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -287,7 +287,7 @@ class TestEncodeRequest(unittest.TestCase):
             parameters=NamedItemList([param1, param2, param3]),
             byte_size=None,
         )
-        self.assertEqual(req.encode(), bytearray([0x12, 0x34, 0x56]))
+        self.assertEqual(req.encode(), bytearray([0x33, 0x75, 0x56]))
         self.assertEqual(req.get_static_bit_length(), 24)
 
     def _create_request(self, parameters: List[Parameter]) -> Request:


### PR DESCRIPTION
This converts the diag coded types to the new and shiny encoding infrastructure. Note that doing this as a stand-alone change requires some kludges like creating temporary `EncodeState` objects. These will be removed by later PRs in the series...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)