### PR TITLE
some fixes for files using ODX 2.0

### DIFF
--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -15,6 +15,7 @@ from .admindata import AdminData
 from .companydata import CompanyData
 from .comparaminstance import ComparamInstance
 from .comparamspec import ComparamSpec
+from .comparamsubset import ComparamSubset
 from .diagcomm import DiagComm
 from .diagdatadictionaryspec import DiagDataDictionarySpec
 from .diaglayerraw import DiagLayerRaw
@@ -356,7 +357,7 @@ class DiagLayer:
         return self.diag_layer_raw.prot_stack_snref
 
     @property
-    def comparam_spec(self) -> Optional[ComparamSpec]:
+    def comparam_spec(self) -> Optional[Union[ComparamSpec, ComparamSubset]]:
         return self.diag_layer_raw.comparam_spec
 
     @property


### PR DESCRIPTION
In ODX 2.0, `ComparamSpec` does not exist, so `ComparamSubset` seems to be used as target for `COMPARAM-SPEC-REF` instead. This commit takes care of that and thus hopefully fixes #301.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 