### PR TITLE
make descriptions conform to the specification

### DIFF
--- a/examples/mksomersaultmodifiedpdx.py
+++ b/examples/mksomersaultmodifiedpdx.py
@@ -11,6 +11,7 @@ from typing import List, TypeVar
 import odxtools
 import odxtools.uds as uds
 from examples import somersaultecu
+from odxtools.description import Description
 from odxtools.diaglayer import DiagLayer
 from odxtools.diagservice import DiagService
 from odxtools.nameditemlist import NamedItemList
@@ -80,13 +81,13 @@ somersault_young_dlr.short_name = "somersault_young"
 somersault_young_dlr.odx_id = OdxLinkId("ECU.somersault_young",
                                         somersault_young_dlr.odx_id.doc_fragments)
 somersault_young_dlr.description = \
-"""<p>A young version of the somersault ECU
+Description.from_string("""<p>A young version of the somersault ECU
 
 It is as grumpy as the lazy variant, but it is more agile, so it can do flic-flacs.
 
 On the flipside, it is unwilling to take any instructions, so no
 operational parameters can be set. Finally, it is unwilling to compete
-(i.e. it does not time its somersaults).</p>"""
+(i.e. it does not time its somersaults).</p>""")
 
 # remove the "sault_time" parameter from the positive response of the
 # "do_forward_flips" service.

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -25,6 +25,7 @@ from odxtools.compumethods.limit import Limit
 from odxtools.compumethods.texttablecompumethod import TexttableCompuMethod
 from odxtools.database import Database
 from odxtools.dataobjectproperty import DataObjectProperty
+from odxtools.description import Description
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 from odxtools.diaglayer import DiagLayer
 from odxtools.diaglayercontainer import DiagLayerContainer
@@ -107,7 +108,7 @@ somersault_team_members = {
             odx_id=OdxLinkId("TM.Doggy", doc_frags),
             short_name="Doggy",
             long_name="Doggy the dog",
-            description="<p>Dog is man's best friend</p>",
+            description=Description.from_string("<p>Dog is man's best friend</p>"),
             roles=["gymnast", "tracker"],
             department="sniffers",
             address="Some road",
@@ -122,7 +123,7 @@ somersault_team_members = {
             odx_id=OdxLinkId("TM.Horsey", doc_frags),
             short_name="Horsey",
             long_name="Horsey the horse",
-            description="<p>Trustworthy worker</p>",
+            description=Description.from_string("<p>Trustworthy worker</p>"),
             roles=["gymnast"],
             department="haulers",
             address="Some road",
@@ -155,7 +156,7 @@ somersault_company_datas = {
             odx_id=OdxLinkId("CD.Suncus", doc_frags),
             short_name="Suncus",
             long_name="Circus of the sun",
-            description="<p>Prestigious group of performers</p>",
+            description=Description.from_string("<p>Prestigious group of performers</p>"),
             roles=["circus", "gym"],
             team_members=NamedItemList([
                 somersault_team_members["doggy"],
@@ -164,11 +165,11 @@ somersault_company_datas = {
             company_specific_info=CompanySpecificInfo(
                 related_docs=[
                     RelatedDoc(
-                        description="<p>We are the best!</p>",
+                        description=Description.from_string("<p>We are the best!</p>"),
                         xdoc=XDoc(
                             short_name="best",
                             long_name="suncus is the best",
-                            description="<p>great propaganda...</p>",
+                            description=Description.from_string("<p>great propaganda...</p>"),
                             number="1",
                             state="published",
                             date="2015-01-15T20:15:20+05:00",
@@ -362,7 +363,7 @@ somersault_units = {
             short_name="second",
             display_name="s",
             long_name="Second",
-            description="<p>SI unit for the time</p>",
+            description=Description.from_string("<p>SI unit for the time</p>"),
             factor_si_to_unit=1,
             offset_si_to_unit=0,
             physical_dimension_ref=OdxLinkRef.from_id(
@@ -407,7 +408,7 @@ somersault_unit_groups = {
                 OdxLinkRef.from_id(somersault_units["minute"].odx_id),
             ],
             long_name="Duration",
-            description="<p>Units for measuring a duration</p>",
+            description=Description.from_string("<p>Units for measuring a duration</p>"),
         ),
 }
 
@@ -1183,7 +1184,8 @@ somersault_tables = {
             odx_id=last_flip_details_table_id,
             short_name="last_flip_details",
             long_name="Flip Details",
-            description="<p>The details the last successfully executed request</p>",
+            description=Description.from_string(
+                "<p>The details the last successfully executed request</p>"),
             semantic="DETAILS",
             admin_data=None,
             key_label="key",
@@ -1198,7 +1200,7 @@ somersault_tables = {
                     key_raw="0",
                     structure_ref=None,
                     structure_snref=None,
-                    description="<p>We have not done any flips yet!</p>",
+                    description=Description.from_string("<p>We have not done any flips yet!</p>"),
                     semantic="DETAILS-KEY",
                     dop_ref=OdxLinkRef.from_id(somersault_dops["soberness_check"].odx_id),
                     dop_snref=None,
@@ -1214,7 +1216,8 @@ somersault_tables = {
                     structure_ref=OdxLinkRef.from_id(
                         somersault_positive_responses["forward_flips_grudgingly_done"].odx_id),
                     structure_snref=None,
-                    description="<p>The the last forward flip was grudgingly done</p>",
+                    description=Description.from_string(
+                        "<p>The the last forward flip was grudgingly done</p>"),
                     semantic="DETAILS-KEY",
                     dop_ref=None,
                     dop_snref=None,
@@ -1791,7 +1794,7 @@ somersault_services = {
             odx_id=OdxLinkId("somersault.service.do_forward_flips", doc_frags),
             short_name="do_forward_flips",
             long_name=None,
-            description="<p>Do a forward flip.</p>",
+            description=Description.from_string("<p>Do a forward flip.</p>"),
             admin_data=None,
             protocol_snrefs=[],
             related_diag_comm_refs=[],
@@ -1933,7 +1936,7 @@ somersault_single_ecu_jobs = {
             odx_id=OdxLinkId("somersault.service.compulsory_program", doc_frags),
             short_name="compulsory_program",
             long_name="Compulsory Program",
-            description="<p>Do several fancy moves.</p>",
+            description=Description.from_string("<p>Do several fancy moves.</p>"),
             admin_data=None,
             semantic=None,
             functional_class_refs=[],
@@ -2116,7 +2119,7 @@ somersault_diaglayer_raw = DiagLayerRaw(
     odx_id=OdxLinkId("somersault", doc_frags),
     short_name="somersault",
     long_name="Somersault base variant",
-    description="<p>Base variant of the somersault ECU &amp; cetera</p>",
+    description=Description.from_string("<p>Base variant of the somersault ECU &amp; cetera</p>"),
     admin_data=None,
     company_datas=NamedItemList(),
     functional_classes=NamedItemList(somersault_functional_classes.values()),
@@ -2147,7 +2150,8 @@ somersault_lazy_diaglayer_raw = DiagLayerRaw(
     odx_id=OdxLinkId("somersault_lazy", doc_frags),
     short_name="somersault_lazy",
     long_name="Somersault lazy ECU",
-    description="<p>Sloppy variant of the somersault ECU (lazy &lt; assiduous)</p>",
+    description=Description.from_string(
+        "<p>Sloppy variant of the somersault ECU (lazy &lt; assiduous)</p>"),
     admin_data=None,
     company_datas=NamedItemList(),
     functional_classes=NamedItemList(),
@@ -2358,7 +2362,8 @@ somersault_assiduous_diaglayer_raw = DiagLayerRaw(
     odx_id=OdxLinkId("somersault_assiduous", doc_frags),
     short_name="somersault_assiduous",
     long_name="Somersault assiduous ECU",
-    description="<p>Hard-working variant of the somersault ECU (lazy &lt; assiduous)</p>",
+    description=Description.from_string(
+        "<p>Hard-working variant of the somersault ECU (lazy &lt; assiduous)</p>"),
     admin_data=None,
     company_datas=NamedItemList(),
     functional_classes=NamedItemList(),
@@ -2414,7 +2419,8 @@ somersault_dlc = DiagLayerContainer(
     odx_id=OdxLinkId("DLC.somersault", doc_frags),
     short_name=dlc_short_name,
     long_name="Collect all saults in the summer",
-    description="<p>This contains ECUs which do somersaults &amp; cetera</p>",
+    description=Description.from_string(
+        "<p>This contains ECUs which do somersaults &amp; cetera</p>"),
     admin_data=somersault_admin_data,
     company_datas=NamedItemList([
         somersault_company_datas["suncus"],

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import markdownify
 from tabulate import tabulate  # TODO: switch to rich tables
 
+from ..description import Description
 from ..diaglayer import DiagLayer
 from ..diagservice import DiagService
 from ..parameters.codedconstparameter import CodedConstParameter
@@ -17,9 +18,9 @@ from ..parameters.valueparameter import ValueParameter
 from ..singleecujob import SingleEcuJob
 
 
-def format_desc(desc: str, indent: int = 0) -> str:
+def format_desc(description: Description, indent: int = 0) -> str:
     # Collapse whitespaces
-    desc = re.sub(r"\s+", " ", desc)
+    desc = re.sub(r"\s+", " ", str(description))
     # Covert XHTML to Markdown
     desc = markdownify.markdownify(desc)
     # Collapse blank lines

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -7,9 +7,9 @@ from xml.etree import ElementTree
 from .basecomparam import BaseComparam
 from .comparam import Comparam
 from .complexcomparam import ComplexComparam, ComplexValue, create_complex_value_from_et
+from .description import Description
 from .exceptions import OdxWarning, odxraise, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
-from .utils import create_description_from_et
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
@@ -23,7 +23,7 @@ class ComparamInstance:
     Be aware that the ODX specification calls this class COMPARAM-REF!
     """
     value: Union[str, ComplexValue]
-    description: Optional[str]
+    description: Optional[Description]
     protocol_snref: Optional[str]
     prot_stack_snref: Optional[str]
     spec_ref: OdxLinkRef
@@ -44,7 +44,7 @@ class ComparamInstance:
         else:
             value = create_complex_value_from_et(odxrequire(et_element.find("COMPLEX-VALUE")))
 
-        description = create_description_from_et(et_element.find("DESC"))
+        description = Description.from_et(et_element.find("DESC"), doc_frags)
 
         prot_stack_snref = None
         if (psnref_elem := et_element.find("PROT-STACK-SNREF")) is not None:

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 from typing import List, Optional
 from xml.etree import ElementTree
 
+from ..description import Description
 from ..odxlink import OdxDocFragment
 from ..odxtypes import AtomicOdxType, DataType
-from ..utils import create_description_from_et
 from .compuconst import CompuConst
 from .compuinversevalue import CompuInverseValue
 from .compurationalcoeffs import CompuRationalCoeffs
@@ -18,7 +18,7 @@ class CompuScale:
     """
 
     short_label: Optional[str]
-    description: Optional[str]
+    description: Optional[Description]
     lower_limit: Optional[Limit]
     upper_limit: Optional[Limit]
     compu_inverse_value: Optional[CompuInverseValue]
@@ -35,7 +35,7 @@ class CompuScale:
     def compuscale_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
                            internal_type: DataType, physical_type: DataType) -> "CompuScale":
         short_label = et_element.findtext("SHORT-LABEL")
-        description = create_description_from_et(et_element.find("DESC"))
+        description = Description.from_et(et_element.find("DESC"), doc_frags)
 
         lower_limit = Limit.limit_from_et(
             et_element.find("LOWER-LIMIT"), doc_frags, value_type=internal_type)

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import List, Optional
+from xml.etree import ElementTree
+
+from .exceptions import odxrequire
+from .odxlink import OdxDocFragment
+
+
+@dataclass
+class Description:
+    text: str
+    external_docs: List[str]
+    text_identifier: Optional[str]
+
+    @staticmethod
+    def from_et(et_element: Optional[ElementTree.Element],
+                doc_frags: List[OdxDocFragment]) -> Optional["Description"]:
+        if et_element is None:
+            return None
+
+        # Extract the contents of the tag as a XHTML string.
+        raw_string = et_element.text or ""
+        for e in et_element:
+            if e.tag == "EXTERNAL-DOCS":
+                break
+            raw_string += ElementTree.tostring(e, encoding="unicode")
+
+        # remove white spaces at the beginning and at the end of all
+        # extracted lines
+        stripped_lines = [x.strip() for x in raw_string.split("\n")]
+
+        text = "\n".join(stripped_lines).strip()
+
+        text_identifier = et_element.get("TI")
+
+        external_docs = \
+            [
+                odxrequire(ed.get("HREF")) for ed in et_element.iterfind("EXTERNAL-DOCS/EXTERNAL-DOC")
+            ]
+        return Description(text=text, text_identifier=text_identifier, external_docs=external_docs)
+
+    @staticmethod
+    def from_string(text: str) -> "Description":
+        return Description(text=text, external_docs=[], text_identifier=None)
+
+    def __str__(self) -> str:
+        return self.text

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -16,6 +16,7 @@ from .companydata import CompanyData
 from .comparaminstance import ComparamInstance
 from .comparamspec import ComparamSpec
 from .comparamsubset import ComparamSubset
+from .description import Description
 from .diagcomm import DiagComm
 from .diagdatadictionaryspec import DiagDataDictionarySpec
 from .diaglayerraw import DiagLayerRaw
@@ -309,7 +310,7 @@ class DiagLayer:
         return self.diag_layer_raw.long_name
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> Optional[Description]:
         return self.diag_layer_raw.description
 
     @property

--- a/odxtools/element.py
+++ b/odxtools/element.py
@@ -2,16 +2,17 @@ from dataclasses import dataclass
 from typing import List, Optional
 from xml.etree import ElementTree
 
+from .description import Description
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkId
-from .utils import create_description_from_et, dataclass_fields_asdict
+from .utils import dataclass_fields_asdict
 
 
 @dataclass
 class NamedElement:
     short_name: str
     long_name: Optional[str]
-    description: Optional[str]
+    description: Optional[Description]
 
     @staticmethod
     def from_et(
@@ -22,7 +23,7 @@ class NamedElement:
         return NamedElement(
             short_name=odxrequire(et_element.findtext("SHORT-NAME")),
             long_name=et_element.findtext("LONG-NAME"),
-            description=create_description_from_et(et_element.find("DESC")),
+            description=Description.from_et(et_element.find("DESC"), doc_frags),
         )
 
 

--- a/odxtools/relateddoc.py
+++ b/odxtools/relateddoc.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from xml.etree import ElementTree
 
+from .description import Description
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
-from .utils import create_description_from_et
 from .xdoc import XDoc
 
 if TYPE_CHECKING:
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
 
 @dataclass
 class RelatedDoc:
-    description: Optional[str]
+    description: Optional[Description]
     xdoc: Optional[XDoc]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "RelatedDoc":
-        description = create_description_from_et(et_element.find("DESC"))
+        description = Description.from_et(et_element.find("DESC"), doc_frags)
 
         xdoc: Optional[XDoc] = None
         if (xdoc_elem := et_element.find("XDOC")) is not None:

--- a/odxtools/scaleconstr.py
+++ b/odxtools/scaleconstr.py
@@ -5,10 +5,10 @@ from typing import List, Optional
 from xml.etree import ElementTree
 
 from .compumethods.limit import Limit
+from .description import Description
 from .exceptions import odxraise, odxrequire
 from .odxlink import OdxDocFragment
 from .odxtypes import DataType
-from .utils import create_description_from_et
 
 
 class ValidType(Enum):
@@ -24,7 +24,7 @@ class ScaleConstr:
     """
 
     short_label: Optional[str]
-    description: Optional[str]
+    description: Optional[Description]
     lower_limit: Optional[Limit]
     upper_limit: Optional[Limit]
     validity: ValidType
@@ -34,7 +34,7 @@ class ScaleConstr:
     def scale_constr_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
                              value_type: DataType) -> "ScaleConstr":
         short_label = et_element.findtext("SHORT-LABEL")
-        description = create_description_from_et(et_element.find("DESC"))
+        description = Description.from_et(et_element.find("DESC"), doc_frags)
 
         lower_limit = Limit.limit_from_et(
             et_element.find("LOWER-LIMIT"), doc_frags, value_type=value_type)

--- a/odxtools/templates/comparam-spec.odx-c.xml.jinja2
+++ b/odxtools/templates/comparam-spec.odx-c.xml.jinja2
@@ -8,6 +8,7 @@
 {%- import('macros/printAdminData.xml.jinja2') as pad -%}
 {%- import('macros/printCompanyData.xml.jinja2') as pcd -%}
 {%- import('macros/printProtStack.xml.jinja2') as pps %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 {#- -#}
 
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
@@ -18,11 +19,7 @@
    {%- if comparam_spec.long_name is not none %}
    <LONG-NAME>{{comparam_spec.long_name|e}}</LONG-NAME>
    {%- endif %}
-   {%- if comparam_spec.description and comparam_spec.description.strip() %}
-   <DESC>
-     {{comparam_spec.description}}
-   </DESC>
-   {%- endif %}
+   {{pd.printDescription(comparam_spec.description)}}
    {%- if comparam_spec.admin_data is not none %}
    {{- pad.printAdminData(comparam_spec.admin_data) | indent(3) }}
    {%- endif %}

--- a/odxtools/templates/comparam-subset.odx-cs.xml.jinja2
+++ b/odxtools/templates/comparam-subset.odx-cs.xml.jinja2
@@ -11,6 +11,7 @@
 {%- import('macros/printDOP.xml.jinja2') as pdop %}
 {%- import('macros/printUnitSpec.xml.jinja2') as pus %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 {#- -#}
 
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
@@ -22,11 +23,7 @@
    {%- if comparam_subset.long_name is not none %}
    <LONG-NAME>{{comparam_subset.long_name|e}}</LONG-NAME>
    {%- endif %}
-   {%- if comparam_subset.description and comparam_subset.description.strip() %}
-   <DESC>
-     {{comparam_subset.description}}
-   </DESC>
-   {%- endif %}
+   {{pd.printDescription(comparam_subset.description)}}
    {%- if comparam_subset.admin_data is not none %}
    {{- pad.printAdminData(comparam_subset.admin_data) | indent(3) }}
    {%- endif %}

--- a/odxtools/templates/macros/printCompanyData.xml.jinja2
+++ b/odxtools/templates/macros/printCompanyData.xml.jinja2
@@ -5,6 +5,7 @@
 
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 
 {%- macro printCompanyData(company_data) %}
 <COMPANY-DATA ID="{{company_data.odx_id.local_id}}">
@@ -81,11 +82,7 @@
      {%- endif %}
     </XDOC>
     {%- endif %}
-    {%- if rd.description is not none %}
-    <DESC>
-{{rd.description}}
-    </DESC>
-    {%- endif %}
+    {{pd.printDescription(rd.description)}}
    </RELATED-DOC>
   {%- endfor %}
   </RELATED-DOCS>

--- a/odxtools/templates/macros/printComparamRef.xml.jinja2
+++ b/odxtools/templates/macros/printComparamRef.xml.jinja2
@@ -3,6 +3,7 @@
  # SPDX-License-Identifier: MIT
 -#}
 {%- import('macros/printComparam.xml.jinja2') as pcp %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 {#- -#}
 
 {%- macro printComparamRef(cp) %}
@@ -11,27 +12,19 @@
               DOCTYPE="COMPARAM-SUBSET">
   {%- if cp.value is string %}
   <SIMPLE-VALUE>{{cp.value}}</SIMPLE-VALUE>
-  {%- if cp.description %}
-  <DESC>{{cp.description}}</DESC>
-  {%- endif %}
+  {{ pd.printDescription(cp.description) }}
   {%- elif cp.value is iterable %}
   {%- if hasattr(cp.value, "hex") %}
   {#- the value has a hex() method. assume that is a bytes or bytestring #}
   <SIMPLE-VALUE>{{cp.value.hex().upper()}}</SIMPLE-VALUE>
-  {%- if cp.description %}
-  <DESC>{{cp.description}}</DESC>
-  {%- endif %}
+  {{ pd.printDescription(cp.description) }}
   {%- else %}
   {{ pcp.printComplexValue(cp.value)|indent(1) }}
-  {%- if cp.description %}
-  <DESC>{{cp.description}}</DESC>
-  {%- endif %}
+  {{ pd.printDescription(cp.description) }}
   {%- endif %}
   {%- else %}
   <SIMPLE-VALUE>{{cp.value}}</SIMPLE-VALUE>
-  {%- if cp.description %}
-  <DESC>{{cp.description}}</DESC>
-  {%- endif %}
+  {{ pd.printDescription(cp.description) }}
   {%- endif %}
   {%- if cp.prot_stack_snref is not none %}
   <PROT-STACK-SNREF SHORT-NAME="{{cp.prot_stack_snref}}"/>

--- a/odxtools/templates/macros/printCompuMethod.xml.jinja2
+++ b/odxtools/templates/macros/printCompuMethod.xml.jinja2
@@ -6,6 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printAdminData.xml.jinja2') as pad %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 
 
 {%- macro printLimit(tag_name, limit_obj) -%}
@@ -59,13 +60,9 @@
   {%- if cs.short_label is not none %}
   <SHORT-LABEL>{{cs.short_label|e}}</SHORT-LABEL>
   {%- endif %}
-  {%- if cs.description and cs.description.strip() %}
-  <DESC>
-    {{cs.description}}
-  </DESC>
-  {%- endif %}
-  {{-printLimit("LOWER-LIMIT", cs.lower_limit)|indent(2, first=True) }}
-  {{-printLimit("UPPER-LIMIT", cs.upper_limit)|indent(2, first=True) }}
+  {{- pd.printDescription(cs.description)|indent(2, first=True) }}
+  {{- printLimit("LOWER-LIMIT", cs.lower_limit)|indent(2, first=True) }}
+  {{- printLimit("UPPER-LIMIT", cs.upper_limit)|indent(2, first=True) }}
   {%- if cs.compu_inverse_value is not none %}
   {{printCompuInverseValue(cs.compu_inverse_value)}}
   {%- endif %}

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -7,6 +7,7 @@
 {%- import('macros/printAdminData.xml.jinja2') as pad %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 {%- import('macros/printCompuMethod.xml.jinja2') as pcm %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 
 
 {%- macro printDiagCodedType(dct) -%}
@@ -49,11 +50,7 @@
   {%- if sc.short_label is not none %}
   <SHORT-LABEL>{{sc.short_label|e}}</SHORT-LABEL>
   {%- endif %}
-  {%- if sc.description and sc.description.strip() %}
-  <DESC>
-    {{sc.description}}
-  </DESC>
-  {%- endif %}
+  {{pd.printDescription(sc.description)}}
   {{pcm.printLimit("LOWER-LIMIT", sc.lower_limit) }}
   {{pcm.printLimit("UPPER-LIMIT", sc.upper_limit) }}
 </SCALE-CONSTR>
@@ -80,7 +77,6 @@
 </INTERNAL-CONSTR>
 {%- endif %}
 {%- endmacro -%}
-
 
 {%- macro printDopBaseAttribs(dop) %}
 {{- make_xml_attrib("ID", dop.odx_id.local_id) }}

--- a/odxtools/templates/macros/printDescription.xml.jinja2
+++ b/odxtools/templates/macros/printDescription.xml.jinja2
@@ -1,0 +1,18 @@
+{#- -*- mode: sgml; tab-width: 1; sgml-basic-offset: 1; indent-tabs-mode: nil -*-
+ #
+ # SPDX-License-Identifier: MIT
+-#}
+
+{%- macro printDescription(desc) %}
+{%- if desc is not none %}
+<DESC {{make_xml_attrib("TI", desc.text_identifier)}}>{{desc.text}}
+{%- if desc.external_docs %}
+<EXTERNAL-DOCS>
+ {%- for ed in desc.external_docs %}
+ <EXTERNAL-DOC HREF="{{ed}}" />
+ {%- endfor %}
+</EXTERNAL-DOCS>
+{%- endif -%}
+</DESC>
+{%- endif %}
+{%- endmacro %}

--- a/odxtools/templates/macros/printElementId.xml.jinja2
+++ b/odxtools/templates/macros/printElementId.xml.jinja2
@@ -3,12 +3,12 @@
  # SPDX-License-Identifier: MIT
 -#}
 
+{%- import('macros/printDescription.xml.jinja2') as pd %}
+
 {%- macro printElementIdSubtags(obj) -%}
 <SHORT-NAME>{{ obj.short_name }}</SHORT-NAME>
 {%- if obj.long_name %}
 <LONG-NAME>{{ obj.long_name|e }}</LONG-NAME>
 {%- endif %}
-{%- if obj.description %}
-<DESC>{{ obj.description }}</DESC>
-{%- endif %}
+{{- pd.printDescription(obj.description) }}
 {%- endmacro -%}

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -5,6 +5,7 @@
 
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
 
 {%- macro printTable(table) %}
 <TABLE ID="{{table.odx_id.local_id}}"
@@ -21,9 +22,7 @@
   {%- if table_row.long_name %}
   <LONG-NAME>{{table_row.long_name|e}}</LONG-NAME>
   {%- endif %}
-  {%- if table_row.description %}
-  <DESC>{{table_row.description}}</DESC>
-  {%- endif %}
+  {{ pd.printDescription(table_row.description) }}
   <KEY>{{table_row.key|e}}</KEY>
   {%- if table_row.dop_ref %}
   <DATA-OBJECT-PROP-REF ID-REF="{{ table_row.dop_ref.ref_id }}" />

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -1,32 +1,7 @@
 # SPDX-License-Identifier: MIT
 import dataclasses
 import re
-from typing import Any, Dict, Optional
-from xml.etree import ElementTree
-
-
-def create_description_from_et(et_element: Optional[ElementTree.Element],) -> Optional[str]:
-    """Read a description tag.
-
-    The description is located underneath the DESC tag of an an ODX
-    element."""
-
-    if et_element is None:
-        return None
-
-    if et_element.tag != "DESC":
-        raise TypeError(f"Attempted to extract an ODX description from a "
-                        f"'{et_element.tag}' XML node. (Must be a 'DESC' node!)")
-
-    # Extract the contents of the tag as a XHTML string.
-    raw_string = et_element.text or ""
-    for e in et_element:
-        raw_string += ElementTree.tostring(e, encoding="unicode")
-
-    # remove white spaces at the beginning and at the end of lines
-    stripped_lines = [x.strip() for x in raw_string.split("\n")]
-
-    return "\n".join(stripped_lines).strip()
+from typing import Any, Dict
 
 
 def dataclass_fields_asdict(obj: Any) -> Dict[str, Any]:

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -12,6 +12,7 @@ from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.createanydiagcodedtype import create_any_diag_coded_type_from_et
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.decodestate import DecodeState
+from odxtools.description import Description
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 from odxtools.diaglayer import DiagLayer
 from odxtools.diaglayerraw import DiagLayerRaw
@@ -238,7 +239,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                 ValueParameter(
                     short_name="certificateClient",
                     long_name=None,
-                    description="The certificate to verify.",
+                    description=Description.from_string("The certificate to verify."),
                     semantic=None,
                     byte_position=1,
                     bit_position=None,
@@ -546,7 +547,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                 LengthKeyParameter(
                     short_name="lengthOfCertificateClient",
                     long_name=None,
-                    description="Length parameter for certificateClient.",
+                    description=Description.from_string("Length parameter for certificateClient."),
                     semantic=None,
                     # LengthKeyParams have an ID to be referenced by a ParamLengthInfoType (which is a diag coded type)
                     odx_id=OdxLinkId("param.dummy_length_key", doc_frags),
@@ -560,7 +561,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                 ValueParameter(
                     short_name="certificateClient",
                     long_name=None,
-                    description="The certificate to verify.",
+                    description=Description.from_string("The certificate to verify."),
                     semantic=None,
                     byte_position=2,
                     bit_position=None,
@@ -885,7 +886,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 ValueParameter(
                     short_name="certificateClient",
                     long_name=None,
-                    description=("The certificate to verify."),
+                    description=Description.from_string("The certificate to verify."),
                     semantic=None,
                     byte_position=1,
                     bit_position=None,

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -19,6 +19,7 @@ from odxtools.compumethods.limit import Limit
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.compumethods.texttablecompumethod import TexttableCompuMethod
 from odxtools.dataobjectproperty import DataObjectProperty
+from odxtools.description import Description
 from odxtools.diaglayer import DiagLayer
 from odxtools.diaglayerraw import DiagLayerRaw
 from odxtools.diaglayertype import DiagLayerType
@@ -239,7 +240,7 @@ class TestSingleEcuJob(unittest.TestCase):
                 semantic="DATA",
                 short_name="outputParam",
                 long_name="The Output Param",
-                description="<p>The one and only output of this job.</p>",
+                description=Description.from_string("<p>The one and only output of this job.</p>"),
                 dop_base_ref=OdxLinkRef.from_id(self.context.outputDOP.odx_id),
             )
         ])
@@ -247,7 +248,7 @@ class TestSingleEcuJob(unittest.TestCase):
             NegOutputParam(
                 short_name="NegativeOutputParam",
                 long_name=None,
-                description="<p>The one and only output of this job.</p>",
+                description=Description.from_string("<p>The one and only output of this job.</p>"),
                 dop_base_ref=OdxLinkRef.from_id(self.context.negOutputDOP.odx_id),
             )
         ])
@@ -376,6 +377,7 @@ class TestSingleEcuJob(unittest.TestCase):
         expected = self.singleecujob_odx.replace(" ", "")
 
         # Assert equality of outputted string
+        self.maxDiff = None
         self.assertEqual(expected, actual)
 
         # Assert equality of objects

--- a/tests/test_somersault.py
+++ b/tests/test_somersault.py
@@ -3,6 +3,7 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
+from odxtools.description import Description
 from odxtools.exceptions import OdxError, odxrequire
 from odxtools.loadfile import load_pdx_file
 from odxtools.parameters.nrcconstparameter import NrcConstParameter
@@ -67,7 +68,8 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(cd.odx_id.local_id, "CD.Suncus")
         self.assertEqual(cd.short_name, "Suncus")
         self.assertEqual(cd.long_name, "Circus of the sun")
-        self.assertEqual(cd.description, "<p>Prestigious group of performers</p>")
+        self.assertEqual(cd.description,
+                         Description.from_string("<p>Prestigious group of performers</p>"))
         self.assertEqual(cd.roles, ["circus", "gym"])
 
         self.assertEqual([x.short_name for x in cd.team_members], ["Doggy", "Horsey"])
@@ -76,7 +78,8 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(doggy.odx_id.local_id, "TM.Doggy")
         self.assertEqual(doggy.short_name, "Doggy")
         self.assertEqual(doggy.long_name, "Doggy the dog")
-        self.assertEqual(doggy.description, "<p>Dog is man's best friend</p>")
+        self.assertEqual(doggy.description,
+                         Description.from_string("<p>Dog is man's best friend</p>"))
         self.assertEqual(doggy.roles, ["gymnast", "tracker"])
         self.assertEqual(doggy.department, "sniffers")
         self.assertEqual(doggy.address, "Some road")
@@ -91,13 +94,13 @@ class TestDatabase(unittest.TestCase):
 
         rd = odxrequire(cd.company_specific_info).related_docs[0]
 
-        self.assertEqual(rd.description, "<p>We are the best!</p>")
+        self.assertEqual(rd.description, Description.from_string("<p>We are the best!</p>"))
         self.assertTrue(rd.xdoc is not None)
 
         xdoc = odxrequire(rd.xdoc)
         self.assertEqual(xdoc.short_name, "best")
         self.assertEqual(xdoc.long_name, "suncus is the best")
-        self.assertEqual(xdoc.description, "<p>great propaganda...</p>")
+        self.assertEqual(xdoc.description, Description.from_string("<p>great propaganda...</p>"))
         self.assertEqual(xdoc.number, "1")
         self.assertEqual(xdoc.state, "published")
         self.assertEqual(xdoc.date, "2015-01-15T20:15:20+05:00")


### PR DESCRIPTION
even though I never saw DESC tags containing anything other than a subset of HTML, the specification allows them to provide a list of URLs to auxiliary external documents and a text identifier (the TI attribute).

To make working with these objects as easy as possible and in order to simplify backwards compatibility, the `__str__()` method of these `Description` objects returns only the content of the tag.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 