### PR TITLE
Change interpretation of "last parameter"

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -10,7 +10,7 @@ from .complexdop import ComplexDop
 from .dataobjectproperty import DataObjectProperty
 from .decodestate import DecodeState
 from .encodestate import EncodeState
-from .exceptions import DecodeError, EncodeError, OdxWarning, odxassert, odxraise, strict_mode
+from .exceptions import EncodeError, OdxWarning, odxassert, odxraise, strict_mode
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterDict, ParameterValue, ParameterValueDict
@@ -156,7 +156,6 @@ class BasicStructure(ComplexDop):
                 f"{encode_state.cursor_bit_position}", EncodeError)
             encode_state.bit_position = 0
 
-        orig_cursor = encode_state.cursor_byte_position
         orig_origin = encode_state.origin_byte_position
         encode_state.origin_byte_position = encode_state.cursor_byte_position
 
@@ -227,7 +226,6 @@ class BasicStructure(ComplexDop):
                                           encode_state.origin_byte_position)
 
         encode_state.origin_byte_position = orig_origin
-        encode_state.cursor_byte_position = max(orig_cursor, encode_state.cursor_byte_position)
 
     @override
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
@@ -250,13 +248,6 @@ class BasicStructure(ComplexDop):
     def decode(self, message: bytes) -> ParameterValueDict:
         decode_state = DecodeState(coded_message=message)
         param_values = self.decode_from_pdu(decode_state)
-
-        if len(message) != decode_state.cursor_byte_position:
-            odxraise(
-                f"The message {message.hex()} probably could not be completely parsed:"
-                f" Expected length of {decode_state.cursor_byte_position} but got {len(message)}.",
-                DecodeError)
-            return {}
 
         if not isinstance(param_values, dict):
             odxraise("Decoding structures must result in a dictionary")

--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -100,7 +100,6 @@ class DynamicEndmarkerField(Field):
                   "No bit position can be specified for dynamic endmarker fields!")
 
         orig_origin = decode_state.origin_byte_position
-        orig_cursor = decode_state.cursor_byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
 
         result: List[ParameterValue] = []
@@ -131,6 +130,5 @@ class DynamicEndmarkerField(Field):
             result.append(self.structure.decode_from_pdu(decode_state))
 
         decode_state.origin_byte_position = orig_origin
-        decode_state.cursor_byte_position = max(orig_cursor, decode_state.cursor_byte_position)
 
         return result

--- a/odxtools/dynamiclengthfield.py
+++ b/odxtools/dynamiclengthfield.py
@@ -61,7 +61,6 @@ class DynamicLengthField(Field):
                 f"got {type(physical_value)}", EncodeError)
 
         # move the origin to the cursor position
-        orig_cursor = encode_state.cursor_byte_position
         orig_origin = encode_state.origin_byte_position
         encode_state.origin_byte_position = encode_state.cursor_byte_position
 
@@ -92,7 +91,6 @@ class DynamicLengthField(Field):
 
         # move cursor and origin positions
         encode_state.origin_byte_position = orig_origin
-        encode_state.cursor_byte_position = max(orig_cursor, encode_state.cursor_byte_position)
 
     @override
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
@@ -101,7 +99,6 @@ class DynamicLengthField(Field):
                   "No bit position can be specified for dynamic length fields!")
 
         orig_origin = decode_state.origin_byte_position
-        orig_cursor = decode_state.cursor_byte_position
 
         det_num_items = self.determine_number_of_items
         decode_state.origin_byte_position = decode_state.cursor_byte_position
@@ -125,6 +122,5 @@ class DynamicLengthField(Field):
             result.append(self.structure.decode_from_pdu(decode_state))
 
         decode_state.origin_byte_position = orig_origin
-        decode_state.cursor_byte_position = max(orig_cursor, decode_state.cursor_byte_position)
 
         return result

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -72,7 +72,6 @@ class EndOfPduField(Field):
                   "No bit position can be specified for end-of-pdu fields!")
 
         orig_origin = decode_state.origin_byte_position
-        orig_cursor = decode_state.cursor_byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
 
         result: List[ParameterValue] = []
@@ -84,6 +83,5 @@ class EndOfPduField(Field):
             result.append(self.structure.decode_from_pdu(decode_state))
 
         decode_state.origin_byte_position = orig_origin
-        decode_state.cursor_byte_position = max(orig_cursor, decode_state.cursor_byte_position)
 
         return result

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -90,7 +90,6 @@ class Multiplexer(ComplexDop):
             with only one key equal to the desired case""")
 
         orig_origin = encode_state.origin_byte_position
-        orig_cursor = encode_state.cursor_byte_position
 
         encode_state.origin_byte_position = encode_state.cursor_byte_position
 
@@ -120,8 +119,6 @@ class Multiplexer(ComplexDop):
                     physical_value=key_value, encode_state=encode_state)
 
                 encode_state.origin_byte_position = orig_origin
-                encode_state.cursor_byte_position = max(orig_cursor,
-                                                        encode_state.cursor_byte_position)
                 return
 
         raise EncodeError(f"The case {case_name} is not found in Multiplexer {self.short_name}")
@@ -132,7 +129,6 @@ class Multiplexer(ComplexDop):
         # multiplexers are structures and thus the origin position
         # must be moved to the start of the multiplexer
         orig_origin = decode_state.origin_byte_position
-        orig_cursor = decode_state.cursor_byte_position
         if self.byte_position is not None:
             decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
@@ -164,7 +160,6 @@ class Multiplexer(ComplexDop):
 
         # go back to the original origin
         decode_state.origin_byte_position = orig_origin
-        decode_state.cursor_byte_position = max(orig_cursor, decode_state.cursor_byte_position)
 
         return mux_value
 

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -107,7 +107,6 @@ class LengthKeyParameter(ParameterWithDOP):
 
             encode_state.length_keys[self.short_name] = physical_value
 
-        orig_cursor = encode_state.cursor_byte_position
         pos = encode_state.cursor_byte_position
         if self.byte_position is not None:
             pos = encode_state.origin_byte_position + self.byte_position
@@ -120,7 +119,6 @@ class LengthKeyParameter(ParameterWithDOP):
         tmp_val = b'\x00' * ((n + 7) // 8)
         encode_state.emplace_bytes(tmp_val, obj_used_mask=tmp_val)
 
-        encode_state.cursor_byte_position = max(encode_state.cursor_byte_position, orig_cursor)
         encode_state.cursor_bit_position = 0
 
     def encode_value_into_pdu(self, encode_state: EncodeState) -> None:

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -127,14 +127,15 @@ class Parameter(NamedElement):
     @final
     def encode_into_pdu(self, physical_value: Optional[ParameterValue],
                         encode_state: EncodeState) -> None:
-        """Convert a physical value into its encoded form and place it into the PDU
+        """Convert a physical value into its encoded form and place it
+        into the PDU
 
-        Also, adapt the `encode_state` so that it points to where the next
-        parameter is located (if the parameter does not explicitly specify a
-        position)
+        Also, adapt the `encode_state` so that it points to where the
+        next parameter is located (if the next parameter does not
+        explicitly specify a position)
+
         """
 
-        orig_cursor = encode_state.cursor_byte_position
         if self.byte_position is not None:
             encode_state.cursor_byte_position = encode_state.origin_byte_position + self.byte_position
 
@@ -142,7 +143,6 @@ class Parameter(NamedElement):
 
         self._encode_positioned_into_pdu(physical_value, encode_state)
 
-        encode_state.cursor_byte_position = max(encode_state.cursor_byte_position, orig_cursor)
         encode_state.cursor_bit_position = 0
 
     def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
@@ -156,7 +156,15 @@ class Parameter(NamedElement):
 
     @final
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
-        orig_cursor = decode_state.cursor_byte_position
+        """Retrieve the raw data for the parameter from the PDU and
+        convert it to its physical interpretation
+
+        Also, adapt the `encode_state` so that it points to where the
+        next parameter is located (if the next parameter does not
+        explicitly specify a position)
+
+        """
+
         if self.byte_position is not None:
             decode_state.cursor_byte_position = decode_state.origin_byte_position + self.byte_position
 
@@ -164,7 +172,6 @@ class Parameter(NamedElement):
 
         result = self._decode_positioned_from_pdu(decode_state)
 
-        decode_state.cursor_byte_position = max(decode_state.cursor_byte_position, orig_cursor)
         decode_state.cursor_bit_position = 0
 
         return result

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -51,9 +51,9 @@ class ReservedParameter(Parameter):
     @override
     def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
                                     encode_state: EncodeState) -> None:
-        raw_data = (0).to_bytes((encode_state.cursor_bit_position + self.bit_length + 7) // 8,
-                                "big")
-        encode_state.emplace_bytes(raw_data, self.short_name)
+        encode_state.cursor_byte_position += (encode_state.cursor_bit_position + self.bit_length +
+                                              7) // 8
+        encode_state.emplace_bytes(b'', self.short_name)
 
     @override
     def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> ParameterValue:

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -165,7 +165,6 @@ class TableKeyParameter(Parameter):
 
             encode_state.table_keys[self.short_name] = physical_value
 
-        orig_pos = encode_state.cursor_byte_position
         pos = encode_state.cursor_byte_position
         if self.byte_position is not None:
             pos = encode_state.origin_byte_position + self.byte_position
@@ -189,7 +188,6 @@ class TableKeyParameter(Parameter):
         tmp_val = b'\x00' * ((n + 7) // 8)
         encode_state.emplace_bytes(tmp_val, obj_used_mask=tmp_val)
 
-        encode_state.cursor_byte_position = max(orig_pos, encode_state.cursor_byte_position)
         encode_state.cursor_bit_position = 0
 
     def encode_value_into_pdu(self, encode_state: EncodeState) -> None:

--- a/odxtools/staticfield.py
+++ b/odxtools/staticfield.py
@@ -89,7 +89,6 @@ class StaticField(Field):
                   "No bit position can be specified for static length fields!")
 
         orig_origin = decode_state.origin_byte_position
-        orig_cursor = decode_state.cursor_byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
 
         result: List[ParameterValue] = []
@@ -106,6 +105,5 @@ class StaticField(Field):
             decode_state.cursor_byte_position = orig_cursor + self.item_byte_size
 
         decode_state.origin_byte_position = orig_origin
-        decode_state.cursor_byte_position = max(orig_cursor, decode_state.cursor_byte_position)
 
         return result

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -30,6 +30,7 @@ from odxtools.odxtypes import DataType, ParameterValueDict
 from odxtools.parameters.codedconstparameter import CodedConstParameter
 from odxtools.parameters.matchingrequestparameter import MatchingRequestParameter
 from odxtools.parameters.physicalconstantparameter import PhysicalConstantParameter
+from odxtools.parameters.reservedparameter import ReservedParameter
 from odxtools.parameters.valueparameter import ValueParameter
 from odxtools.physicaltype import PhysicalType
 from odxtools.request import Request
@@ -1091,6 +1092,16 @@ class TestDecoding(unittest.TestCase):
             bit_position=None,
             sdgs=[],
         )
+        req_demf_endmarker_param = ReservedParameter(
+            short_name="demf_endmarker",
+            long_name=None,
+            description=None,
+            semantic=None,
+            bit_length=24,
+            byte_position=None,
+            bit_position=None,
+            sdgs=[],
+        )
         req_param3 = CodedConstParameter(
             short_name="demf_post_param",
             long_name=None,
@@ -1110,7 +1121,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             sdgs=[],
-            parameters=NamedItemList([req_param1, req_param2, req_param3]),
+            parameters=NamedItemList([req_param1, req_param2, req_demf_endmarker_param,
+                                      req_param3]),
             byte_size=None,
         )
 
@@ -1248,6 +1260,7 @@ class TestDecoding(unittest.TestCase):
                         "struct_param_2": 5
                     },
                 ],
+                "demf_endmarker": 0xffffff,
                 "demf_post_param": 0xcc,
             },
         )

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -393,8 +393,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             semantic=None,
             diag_coded_type=diag_coded_type,
-            coded_value=0x56,
-            byte_position=2,
+            coded_value=0x78,
+            byte_position=3,
             bit_position=None,
             sdgs=[],
         )
@@ -415,7 +415,7 @@ class TestDecoding(unittest.TestCase):
             description=None,
             semantic=None,
             diag_coded_type=diag_coded_type,
-            coded_value=0x78,
+            coded_value=0x56,
             byte_position=None,
             bit_position=None,
             sdgs=[],
@@ -507,9 +507,9 @@ class TestDecoding(unittest.TestCase):
             coding_object=req,
             param_dict={
                 "SID": 0x12,
-                "coded_const_parameter_2": 0x56,
+                "coded_const_parameter_2": 0x78,
                 "coded_const_parameter_3": 0x34,
-                "coded_const_parameter_4": 0x78,
+                "coded_const_parameter_4": 0x56,
             },
         )
         decoded_message = diag_layer.decode(coded_message)[0]


### PR DESCRIPTION
The specification states that if the position of a parameter is not explicitly specified using BYTE-POSITION, "The parameter starts then at the byte edge next to the end of the last parameter". This PR changes the interpretation of "last parameter" from "parameter currently closest to the end of the PDU" to "most recently handled parameter". The reason is that IMO it is more likely that this is what is meant by the specification, and that it is slightly simpler to implement. That said, I consider it to be likely that no data set encountered in the wild is affected by this.

Besides this, a bug in dynamic endmarker fields is fixed by this PR: it turns out that the data occupied by the endmarker of these fields ought not to be considered consumed (why???), i.e., one needs to explicitly add a `ReservedParameter` after `DynamicEndmarker` fields...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 