### PR TITLE
DiagLayer: remember the database

### DIFF
--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -131,7 +131,7 @@ class Database:
         # let the diaglayers sort out the inherited objects and the
         # short name references
         for dlc in self.diag_layer_containers:
-            dlc._finalize_init(self._odxlinks)
+            dlc._finalize_init(self, self._odxlinks)
 
     @property
     def odxlinks(self) -> OdxLinkDatabase:

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -160,6 +160,9 @@ class DiagLayer:
         excessive memory consumption for large databases...
         """
 
+        # this attribute may be removed later. it is currently
+        # required to properly deal with auxiliary files within the
+        # diagnostic layer.
         self._database = database
 
         #####
@@ -306,10 +309,6 @@ class DiagLayer:
     @cached_property
     def service_groups(self) -> ServiceBinner:
         return ServiceBinner(self.services)
-
-    @property
-    def database(self) -> "Database":
-        return self._database
 
     #####
     # </convenience functionality>

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -13,6 +13,9 @@ from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .specialdatagroup import SpecialDataGroup
 from .utils import dataclass_fields_asdict
+
+if TYPE_CHECKING:
+    from .database import Database
 
 
 @dataclass
@@ -127,17 +130,17 @@ class DiagLayerContainer(IdentifiableElement):
         for ecu_variant in self.ecu_variants:
             ecu_variant._resolve_odxlinks(odxlinks)
 
-    def _finalize_init(self, odxlinks: OdxLinkDatabase) -> None:
+    def _finalize_init(self, database: "Database", odxlinks: OdxLinkDatabase) -> None:
         for ecu_shared_data in self.ecu_shared_datas:
-            ecu_shared_data._finalize_init(odxlinks)
+            ecu_shared_data._finalize_init(database, odxlinks)
         for protocol in self.protocols:
-            protocol._finalize_init(odxlinks)
+            protocol._finalize_init(database, odxlinks)
         for functional_group in self.functional_groups:
-            functional_group._finalize_init(odxlinks)
+            functional_group._finalize_init(database, odxlinks)
         for base_variant in self.base_variants:
-            base_variant._finalize_init(odxlinks)
+            base_variant._finalize_init(database, odxlinks)
         for ecu_variant in self.ecu_variants:
-            ecu_variant._finalize_init(odxlinks)
+            ecu_variant._finalize_init(database, odxlinks)
 
     @property
     def diag_layers(self) -> NamedItemList[DiagLayer]:

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: MIT
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .utils import dataclass_fields_asdict
 
 if TYPE_CHECKING:
     from .diaglayer import DiagLayer
@@ -78,3 +80,14 @@ class ParentRef:
 
     def _resolve_snrefs(self, diag_layer: "DiagLayer") -> None:
         pass
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        fields = dataclass_fields_asdict(self)
+        for name, value in fields.items():
+            setattr(result, name, deepcopy(value))
+
+        return result

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -8,6 +8,7 @@ from odxtools.compumethods.compurationalcoeffs import CompuRationalCoeffs
 from odxtools.compumethods.compuscale import CompuScale
 from odxtools.compumethods.identicalcompumethod import IdenticalCompuMethod
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
+from odxtools.database import Database
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.determinenumberofitems import DetermineNumberOfItems
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
@@ -224,8 +225,9 @@ class TestIdentifyingService(unittest.TestCase):
             prot_stack_snref=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         self.assertEqual(
             diag_layer._prefix_tree,
@@ -344,8 +346,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         coded_message = bytes([0x7D, 0xAB])
         expected_message = Message(
@@ -486,8 +489,9 @@ class TestDecoding(unittest.TestCase):
             prot_stack_snref=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         self.assertDictEqual(diag_layer._prefix_tree,
                              {0x12: {
@@ -695,8 +699,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         coded_message = bytes([0x12, 0x34])
         expected_message = Message(
@@ -902,8 +907,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         expected_message = Message(
             coded_message=bytes([0x12, 0x34, 0x56, 0x00, 0x78, 0x9a, 0x00]),
@@ -1235,8 +1241,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         ######
         ## test with endmarker termination
@@ -1508,8 +1515,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         expected_message = Message(
             coded_message=bytes([0x12, 0x00, 0x18, 0x00, 0x34, 0x44, 0x54]),
@@ -1738,8 +1746,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         coded_message = bytes([0x12, 0x34, 0x54])
         expected_message = Message(
@@ -1917,8 +1926,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         coded_message = bytes([0x7D, 0x12])
         # The physical value of the second parameter is decode(0x12) = decode(18) = 5 * 18 + 1 = 91
@@ -2102,8 +2112,9 @@ class TestDecoding(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         for sid, message in [(0x34, pos_response), (0x56, neg_response)]:
             coded_message = bytes([sid, 0xAB])

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -10,6 +10,7 @@ from odxtools.compumethods.compuscale import CompuScale
 from odxtools.compumethods.identicalcompumethod import IdenticalCompuMethod
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.createanydiagcodedtype import create_any_diag_coded_type_from_et
+from odxtools.database import Database
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.decodestate import DecodeState
 from odxtools.description import Description
@@ -297,8 +298,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         # Test decoding.
         coded_request = bytes([
@@ -619,8 +621,9 @@ class TestParamLengthInfoType(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         # Test decoding.
         coded_request = bytes([
@@ -955,8 +958,9 @@ class TestMinMaxLengthType(unittest.TestCase):
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(diag_layer._build_odxlinks())
+        db = Database()
         diag_layer._resolve_odxlinks(odxlinks)
-        diag_layer._finalize_init(odxlinks)
+        diag_layer._finalize_init(db, odxlinks)
 
         # Test decoding.
         coded_request = bytes([

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 
 import pytest
 
+from odxtools.database import Database
 from odxtools.diaglayer import DiagLayer
 from odxtools.diaglayerraw import DiagLayerRaw
 from odxtools.diaglayertype import DiagLayerType
@@ -221,8 +222,9 @@ def ecu_variant_1(
     )
     result = DiagLayer(diag_layer_raw=raw_layer)
     odxlinks.update(result._build_odxlinks())
+    db = Database()
     result._resolve_odxlinks(odxlinks)
-    result._finalize_init(odxlinks)
+    result._finalize_init(db, odxlinks)
     return result
 
 
@@ -259,8 +261,9 @@ def ecu_variant_2(
     )
     result = DiagLayer(diag_layer_raw=raw_layer)
     odxlinks.update(result._build_odxlinks())
+    db = Database()
     result._resolve_odxlinks(odxlinks)
-    result._finalize_init(odxlinks)
+    result._finalize_init(db, odxlinks)
     return result
 
 
@@ -298,8 +301,9 @@ def ecu_variant_3(
     )
     result = DiagLayer(diag_layer_raw=raw_layer)
     odxlinks.update(result._build_odxlinks())
+    db = Database()
     result._resolve_odxlinks(odxlinks)
-    result._finalize_init(odxlinks)
+    result._finalize_init(db, odxlinks)
     return result
 
 

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -18,6 +18,7 @@ from odxtools.compumethods.compuscale import CompuScale
 from odxtools.compumethods.limit import Limit
 from odxtools.compumethods.linearcompumethod import LinearCompuMethod
 from odxtools.compumethods.texttablecompumethod import TexttableCompuMethod
+from odxtools.database import Database
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.description import Description
 from odxtools.diaglayer import DiagLayer
@@ -465,8 +466,12 @@ class TestSingleEcuJob(unittest.TestCase):
             self.context.negOutputDOP.odx_id: self.context.negOutputDOP,
         })
 
+        db = Database()
+        db.add_auxiliary_file("abc.jar",
+                              b"this is supposed to be a JAR archive, but it isn't (HARR)")
+
         dl._resolve_odxlinks(odxlinks)
-        dl._finalize_init(odxlinks)
+        dl._finalize_init(db, odxlinks)
 
         self.assertEqual(self.context.extensiveTask,
                          self.singleecujob_object.functional_classes.extensiveTask)

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 
 from odxtools.compumethods.compumethod import CompuCategory
 from odxtools.compumethods.identicalcompumethod import IdenticalCompuMethod
+from odxtools.database import Database
 from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 from odxtools.diaglayer import DiagLayer
@@ -210,8 +211,9 @@ class TestUnitSpec(unittest.TestCase):
         dl = DiagLayer(diag_layer_raw=dl_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(dl._build_odxlinks())
+        db = Database()
         dl._resolve_odxlinks(odxlinks)
-        dl._finalize_init(odxlinks)
+        dl._finalize_init(db, odxlinks)
 
         param = dl.requests[0].parameters[1]
         assert isinstance(param, ValueParameter)


### PR DESCRIPTION
this is a spin-off of #310: We provide a backlink from the diagnostic layer to the database which contains the layer in question (this is necessary to access the contents of auxiliary files from objects contained by the diag layer). Note that this seemingly trivial change is surprisingly difficult to implement, as it requires some custom `__deepcopy__()` methods, or else the whole database would be copied if some relatively trivial objects like `ParentRef` are copied...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 