### PR TITLE
Properly support decoding NRC-CONST parameters

### DIFF
--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -18,7 +18,6 @@ from .parameters.codedconstparameter import CodedConstParameter
 from .parameters.createanyparameter import create_any_parameter_from_et
 from .parameters.lengthkeyparameter import LengthKeyParameter
 from .parameters.matchingrequestparameter import MatchingRequestParameter
-from .parameters.nrcconstparameter import NrcConstParameter
 from .parameters.parameter import Parameter
 from .parameters.parameterwithdop import ParameterWithDOP
 from .parameters.physicalconstantparameter import PhysicalConstantParameter
@@ -75,7 +74,7 @@ class BasicStructure(ComplexDop):
 
         for param in self.parameters:
             if (isinstance(param, MatchingRequestParameter) and param.request_byte_position < len(request_prefix)) or \
-                isinstance(param, (CodedConstParameter, NrcConstParameter, PhysicalConstantParameter)):
+                isinstance(param, (CodedConstParameter, PhysicalConstantParameter)):
                 param.encode_into_pdu(physical_value=None, encode_state=encode_state)
             else:
                 break

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -181,8 +181,9 @@ class DiagService(DiagComm):
         for cpr in self.comparam_refs:
             cpr._resolve_snrefs(context)
 
-        # comparams named list is lazy loaded
-        # since ComparamInstance short_name is only valid after resolution
+        # The named item list of communication parameters is created
+        # here because ComparamInstance.short_name is only valid after
+        # reference resolution
         self._comparams = NamedItemList(self.comparam_refs)
 
         context.diag_service = None

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 
 from .comparaminstance import ComparamInstance
 from .diagcomm import DiagComm
-from .exceptions import DecodeError, odxassert, odxraise, odxrequire
+from .exceptions import DecodeError, DecodeMismatch, odxassert, odxraise, odxrequire
 from .message import Message
 from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -42,7 +42,7 @@ class DiagService(DiagComm):
     pos_response_refs: List[OdxLinkRef]
     neg_response_refs: List[OdxLinkRef]
 
-    # TODO: pos_response_suppressable: Optional[PosResponseSuppressable]
+    # TODO: pos_response_suppressable: Optional[PosResponseSuppressable] # (sic!)
 
     is_cyclic_raw: Optional[bool]
     is_multiple_raw: Optional[bool]
@@ -202,24 +202,36 @@ class DiagService(DiagComm):
             if len(raw_message) >= len(prefix) and prefix == raw_message[:len(prefix)]:
                 coding_objects.append(candidate_coding_object)
 
-        if len(coding_objects) != 1:
-            raise DecodeError(
-                f"The service {self.short_name} cannot decode the message {raw_message.hex()}")
-        coding_object = coding_objects[0]
-        param_dict = coding_object.decode(raw_message)
-        if not isinstance(param_dict, dict):
-            # if this happens, this is probably due to a bug in
-            # coding_object.decode()
-            raise RuntimeError(f"Expected a set of decoded parameters, got {type(param_dict)}")
-        return Message(
-            coded_message=raw_message,
-            service=self,
-            coding_object=coding_object,
-            param_dict=param_dict)
+        result_list: List[Message] = []
+        for coding_object in coding_objects:
+            try:
+                result_list.append(
+                    Message(
+                        coded_message=raw_message,
+                        service=self,
+                        coding_object=coding_object,
+                        param_dict=coding_object.decode(raw_message)))
+            except DecodeMismatch:
+                # An NRC-CONST or environment data parameter
+                # encountered a non-matching value -> coding object
+                # does not apply
+                pass
+
+        if len(result_list) < 1:
+            odxraise(f"The service {self.short_name} cannot decode the message {raw_message.hex()}",
+                     DecodeError)
+            return Message(
+                coded_message=raw_message, service=self, coding_object=None, param_dict={})
+        elif len(result_list) > 1:
+            odxraise(
+                f"The service {self.short_name} cannot uniquely decode the message {raw_message.hex()}",
+                DecodeError)
+
+        return result_list[0]
 
     def encode_request(self, **kwargs: ParameterValue) -> bytes:
-        """
-        Composes an UDS request an array of bytes for this service.
+        """Prepare an array of bytes ready to be send over the wire
+        for the request of this service.
         """
         # make sure that all parameters which are required for
         # encoding are specified (parameters which have a default are

--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -12,15 +12,6 @@ class EncodeError(Warning, OdxError):
     """Encoding of a message to raw data failed"""
 
 
-class EncodeMismatch(EncodeError):
-    """Encoding failed because some parameters exhibit an incorrect value
-
-    This is can happen if NRC-CONST or environment data descriptions
-    are present.
-
-    """
-
-
 class DecodeError(Warning, OdxError):
     """Decoding raw data failed."""
 

--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -9,11 +9,29 @@ class OdxError(Exception):
 
 
 class EncodeError(Warning, OdxError):
-    """Encoding of a message to raw data failed."""
+    """Encoding of a message to raw data failed"""
+
+
+class EncodeMismatch(EncodeError):
+    """Encoding failed because some parameters exhibit an incorrect value
+
+    This is can happen if NRC-CONST or environment data descriptions
+    are present.
+
+    """
 
 
 class DecodeError(Warning, OdxError):
     """Decoding raw data failed."""
+
+
+class DecodeMismatch(DecodeError):
+    """Decoding failed because some parameters exhibit an incorrect value
+
+    This is can happen if NRC-CONST or environment data descriptions
+    are present.
+
+    """
 
 
 class OdxWarning(Warning):

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
-import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -10,7 +9,7 @@ from ..createanydiagcodedtype import create_any_diag_coded_type_from_et
 from ..decodestate import DecodeState
 from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
-from ..exceptions import DecodeError, EncodeError, odxraise, odxrequire
+from ..exceptions import DecodeMismatch, EncodeError, odxraise, odxrequire
 from ..odxlink import OdxDocFragment, OdxLinkId
 from ..odxtypes import AtomicOdxType, DataType, ParameterValue
 from ..utils import dataclass_fields_asdict
@@ -19,7 +18,8 @@ from .parameter import Parameter, ParameterType
 
 @dataclass
 class NrcConstParameter(Parameter):
-    """A param of type NRC-CONST defines a set of values to be matched for a negative response to apply.
+    """A parameter of type NRC-CONST defines a set of values to be
+    matched for a negative response object to apply
 
     The behaviour of NRC-CONST parameters is similar to CODED-CONST
     parameters in that they allow to specify which coding objects
@@ -88,49 +88,40 @@ class NrcConstParameter(Parameter):
     @override
     def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
                                     encode_state: EncodeState) -> None:
-        coded_value: ParameterValue
+        # NRC-CONST parameters are not encoding any value on its
+        # own. instead, it is supposed to overlap with a value
+        # parameter.
         if physical_value is not None:
-            if physical_value not in self.coded_values:
-                odxraise(
-                    f"The value of parameter '{self.short_name}' must "
-                    f" be one of {self.coded_values} (is: {physical_value!r})", EncodeError)
-                coded_value = self.coded_values[0]
-            else:
-                coded_value = physical_value
-        else:
-            # If the user did not select a value, the value of the
-            # this parameter is set by another parameter which
-            # overlaps with it. We thus just move the cursor.
-            bit_pos = encode_state.cursor_bit_position
-            bit_len = self.diag_coded_type.get_static_bit_length()
+            odxraise("The value of NRC-CONST parameters cannot be set directly!", EncodeError)
 
-            if bit_len is None:
-                odxraise("The diag coded type of NRC-CONST parameters must "
-                         "exhibit a static size")
-                return
+        # TODO (?): extract the parameter and check if it is one of
+        # the values of self.coded_values. if not, throw an
+        # EncodeMismatch exception! This is probably a bad idea
+        # because the parameter which determines the value of the
+        # NRC-CONST might possibly be specified after the NRC-CONST.
 
-            encode_state.cursor_byte_position += (bit_pos + bit_len + 7) // 8
-            encode_state.cursor_bit_position = 0
+        # move the cursor forward by the size of the parameter
+        bit_pos = encode_state.cursor_bit_position
+        bit_len = self.diag_coded_type.get_static_bit_length()
+
+        if bit_len is None:
+            odxraise("The diag coded type of NRC-CONST parameters must "
+                     "exhibit a static size")
             return
 
-        self.diag_coded_type.encode_into_pdu(cast(AtomicOdxType, coded_value), encode_state)
+        encode_state.cursor_byte_position += (bit_pos + bit_len + 7) // 8
+        encode_state.cursor_bit_position = 0
+
+        encode_state.emplace_bytes(b'', self.short_name)
 
     @override
     def _decode_positioned_from_pdu(self, decode_state: DecodeState) -> AtomicOdxType:
-        # Extract coded values
+        # Extract coded value
         coded_value = self.diag_coded_type.decode_from_pdu(decode_state)
 
         # Check if the coded value in the message is correct.
         if coded_value not in self.coded_values:
-            warnings.warn(
-                f"Coded constant parameter does not match! "
-                f"The parameter {self.short_name} expected a coded "
-                f"value in {str(self.coded_values)} but got {str(coded_value)} "
-                f"at byte position {decode_state.cursor_byte_position} "
-                f"in coded message {decode_state.coded_message.hex()}.",
-                DecodeError,
-                stacklevel=1,
-            )
+            raise DecodeMismatch(f"NRC-CONST parameter {self.short_name} does not apply")
 
         return coded_value
 


### PR DESCRIPTION
if a negative response contains an NRC-CONST parameter, where the parameter's value is not in the list of expected values, the response is not applicable and decoding should be stopped at this point. (Thus, NRC-CONST parameters are a multiplexer mechanism which filters responses based on the value of some other parameter.)

This patch implements this by introducing a new `DecodeMismatch` exception which is raised whenever a NRC-CONST parameter which exhibits an unexpected value is encountered. The higher-level routines for decoding responses then ignore these exceptions when appropriate. IMO, this solution is a bit sub-optimal because it uses exceptions for flow control in normal operation, but alternative implementations would be far more complex.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 