### PR TITLE
fix deprecation warning

### DIFF
--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -40,7 +40,7 @@ def odxraise(message: Optional[str] = None, error_type: Type[Exception] = OdxErr
         else:
             raise error_type(message)
     elif message is not None:
-        logger.warn(message)
+        logger.warning(message)
 
 
 def odxassert(condition: bool,


### PR DESCRIPTION
Fixes the following warning: `DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead`

(This seems to be the only location in the code where the deprecated method is used.)

Edit: Feel free to close this PR and do the fix for yourself if signing the CLA is mandatory.