### PR TITLE
Fix reserved encoding

### DIFF
--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -40,7 +40,7 @@ def odxraise(message: Optional[str] = None, error_type: Type[Exception] = OdxErr
         else:
             raise error_type(message)
     elif message is not None:
-        logger.warn(message)
+        logger.warning(message)
 
 
 def odxassert(condition: bool,

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -53,6 +53,7 @@ class ReservedParameter(Parameter):
                                     encode_state: EncodeState) -> None:
         encode_state.cursor_byte_position += (encode_state.cursor_bit_position + self.bit_length +
                                               7) // 8
+        encode_state.cursor_bit_position = 0
         encode_state.emplace_bytes(b'', self.short_name)
 
     @override


### PR DESCRIPTION
`encode_state.emplace_bytes()` only works if the bit position is zero. Besides this, #315 is also included because @radoering does not seem to be able to sign the CLA.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 