### PR TITLE
make the continuous integration work again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Lint code quality (ruff)
         run: |
-          ruff .
+          ruff check .
 
   test:
     strategy:

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -235,7 +235,7 @@ class DataType(Enum):
         expected_type = self.python_type
         if isinstance(value, expected_type):
             return True
-        elif expected_type == float and isinstance(value, (int, float)):
+        elif expected_type is float and isinstance(value, (int, float)):
             return True
         elif self == DataType.A_BYTEFIELD and isinstance(value, (bytearray, bytes)):
             return True

--- a/tests/test_odxtypes.py
+++ b/tests/test_odxtypes.py
@@ -20,14 +20,14 @@ class TestDataType(unittest.TestCase):
         self.assertTrue(DataType.A_BYTEFIELD.from_string("12") == b"\x12")
 
     def test_python_types(self) -> None:
-        self.assertTrue(DataType.A_UINT32.python_type == int)
-        self.assertTrue(DataType.A_INT32.python_type == int)
-        self.assertTrue(DataType.A_FLOAT32.python_type == float)
-        self.assertTrue(DataType.A_FLOAT64.python_type == float)
-        self.assertTrue(DataType.A_BYTEFIELD.python_type == bytearray)
-        self.assertTrue(DataType.A_UNICODE2STRING.python_type == str)
-        self.assertTrue(DataType.A_UTF8STRING.python_type == str)
-        self.assertTrue(DataType.A_ASCIISTRING.python_type == str)
+        self.assertTrue(DataType.A_UINT32.python_type is int)
+        self.assertTrue(DataType.A_INT32.python_type is int)
+        self.assertTrue(DataType.A_FLOAT32.python_type is float)
+        self.assertTrue(DataType.A_FLOAT64.python_type is float)
+        self.assertTrue(DataType.A_BYTEFIELD.python_type is bytearray)
+        self.assertTrue(DataType.A_UNICODE2STRING.python_type is str)
+        self.assertTrue(DataType.A_UTF8STRING.python_type is str)
+        self.assertTrue(DataType.A_ASCIISTRING.python_type is str)
 
     def test_isinstance(self) -> None:
         self.assertTrue(DataType.A_ASCIISTRING.isinstance("123"))


### PR DESCRIPTION
the latest version of `ruff` must be called using `ruff check <path>` instead of via `ruff <path>`.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 