### PR TITLE
Some miscellaneous fixes

### DIFF
--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -161,11 +161,6 @@ class DiagLayer:
         excessive memory consumption for large databases...
         """
 
-        # this attribute may be removed later. it is currently
-        # required to properly deal with auxiliary files within the
-        # diagnostic layer.
-        self._database = database
-
         #####
         # fill in all applicable objects that use value inheritance
         #####

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -1200,16 +1200,19 @@ class DiagLayer:
         for service in candidate_services:
             try:
                 decoded_messages.append(service.decode_message(message))
-            except DecodeError:
+            except DecodeError as e:
                 # check if the message can be decoded as a global
                 # negative response for the service
+                gnr_found = False
                 for gnr in self.global_negative_responses:
                     try:
                         decoded_gnr = gnr.decode(message)
+                        gnr_found = True
                         if not isinstance(decoded_gnr, dict):
-                            raise DecodeError(f"Expected the decoded value of a global "
-                                              f"negative response to be a dictionary, "
-                                              f"got {type(decoded_gnr)} for {self.short_name}")
+                            odxraise(
+                                f"Expected the decoded value of a global "
+                                f"negative response to be a dictionary, "
+                                f"got {type(decoded_gnr)} for {self.short_name}", DecodeError)
 
                         decoded_messages.append(
                             Message(
@@ -1219,6 +1222,9 @@ class DiagLayer:
                                 param_dict=decoded_gnr))
                     except DecodeError:
                         pass
+
+                if not gnr_found:
+                    raise e
 
         if len(decoded_messages) == 0:
             raise DecodeError(

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -147,7 +147,19 @@ class DtcDop(DopBase):
             raise EncodeError(f"The DTC-DOP {self.short_name} expected a"
                               f" DiagnosticTroubleCode but got {physical_value!r}.")
 
-        internal_trouble_code = self.compu_method.convert_physical_to_internal(trouble_code)
+        internal_trouble_code = int(self.compu_method.convert_physical_to_internal(trouble_code))
+
+        found = False
+        for dtc in self.dtcs:
+            if internal_trouble_code == dtc.trouble_code:
+                found = True
+                break
+
+        if not found:
+            odxraise(
+                f"Unknown diagnostic trouble code {physical_value!r} "
+                f"(0x{internal_trouble_code: 06x}) specified", EncodeError)
+
         self.diag_coded_type.encode_into_pdu(internal_trouble_code, encode_state)
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:


### PR DESCRIPTION
Since #318 became quite a bit too off topic, I figured it was a good idea to spin off all changes not directly related to multiplexer coding, so this PR contains:

- `DiagLayer.decode()` now re-raises encountered `DecodeError`s if the binary data is also not decodable as a global negative response. The old behavior accidentally was to never raise  `DecodeError`.
- a `DecodeError` exception is raised if unknown DTC numbers are passed to DtcDop parameters.
- the ODXLINK reference machinery is fixed for the case where multiple document fragments provided objects featuring the same local ID
- The `._database` object of diagnostic layers is removed again. (this became unnecessary because of SNREF context objects...)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
