### PR TITLE
Implement diagnostic variables

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -2037,6 +2037,9 @@ somersault_diaglayer_raw = DiagLayerRaw(
     ecu_variant_patterns=[],
     comparam_spec_ref=None,
     prot_stack_snref=None,
+    diag_variables_raw=[],
+    variable_groups=NamedItemList(),
+    dyn_defined_spec=None,
 )
 somersault_diaglayer = DiagLayer(diag_layer_raw=somersault_diaglayer_raw)
 
@@ -2082,6 +2085,9 @@ somersault_lazy_diaglayer_raw = DiagLayerRaw(
     ecu_variant_patterns=[],
     comparam_spec_ref=None,
     prot_stack_snref=None,
+    diag_variables_raw=[],
+    variable_groups=NamedItemList(),
+    dyn_defined_spec=None,
 )
 somersault_lazy_diaglayer = DiagLayer(diag_layer_raw=somersault_lazy_diaglayer_raw)
 
@@ -2306,6 +2312,9 @@ somersault_assiduous_diaglayer_raw = DiagLayerRaw(
     ecu_variant_patterns=[],
     comparam_spec_ref=None,
     prot_stack_snref=None,
+    diag_variables_raw=[],
+    variable_groups=NamedItemList(),
+    dyn_defined_spec=None,
 )
 somersault_assiduous_diaglayer = DiagLayer(diag_layer_raw=somersault_assiduous_diaglayer_raw)
 

--- a/odxtools/commrelation.py
+++ b/odxtools/commrelation.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree
+
+from .description import Description
+from .diagcomm import DiagComm
+from .diagservice import DiagService
+from .exceptions import odxraise, odxrequire
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .parameters.parameter import Parameter
+from .snrefcontext import SnRefContext
+
+
+class CommRelationValueType(Enum):
+    CURRENT = "CURRENT"
+    STORED = "STORED"
+    STATIC = "STATIC"
+    SUBSTITUTED = "SUBSTITUTED"
+
+
+@dataclass
+class CommRelation:
+    description: Optional[Description]
+    relation_type: str
+    diag_comm_ref: Optional[OdxLinkRef]
+    diag_comm_snref: Optional[str]
+    in_param_if_snref: Optional[str]
+    in_param_if_snpathref: Optional[str]
+    out_param_if_snref: Optional[str]
+    out_param_if_snpathref: Optional[str]
+    value_type_raw: Optional[CommRelationValueType]
+
+    @property
+    def diag_comm(self) -> DiagComm:
+        return self._diag_comm
+
+    @property
+    def in_param_if(self) -> Optional[Parameter]:
+        return self._in_param_if
+
+    @property
+    def out_param_if(self) -> Optional[Parameter]:
+        return self._out_param_if
+
+    @property
+    def value_type(self) -> CommRelationValueType:
+        if self.value_type_raw is None:
+            return CommRelationValueType.CURRENT
+
+        return self.value_type_raw
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "CommRelation":
+        description = Description.from_et(et_element.find("DESC"), doc_frags)
+        relation_type = odxrequire(et_element.findtext("RELATION-TYPE"))
+
+        diag_comm_ref = OdxLinkRef.from_et(et_element.find("DIAG-COMM-REF"), doc_frags)
+        diag_comm_snref = None
+        if (diag_comm_snref_elem := et_element.find("DIAG-COMM-SNREF")) is not None:
+            diag_comm_snref = odxrequire(diag_comm_snref_elem.get("SHORT-NAME"))
+
+        in_param_if_snref = None
+        if (in_param_if_snref_elem := et_element.find("IN-PARAM-IF-SNREF")) is not None:
+            in_param_if_snref = odxrequire(in_param_if_snref_elem.get("SHORT-NAME"))
+
+        in_param_if_snpathref = None
+        if (in_param_if_snpathref_elem := et_element.find("IN-PARAM-IF-SNPATHREF")) is not None:
+            in_param_if_snpathref = odxrequire(in_param_if_snpathref_elem.get("SHORT-NAME-PATH"))
+
+        out_param_if_snref = None
+        if (out_param_if_snref_elem := et_element.find("OUT-PARAM-IF-SNREF")) is not None:
+            out_param_if_snref = odxrequire(out_param_if_snref_elem.get("SHORT-NAME"))
+
+        out_param_if_snpathref = None
+        if (out_param_if_snpathref_elem := et_element.find("OUT-PARAM-IF-SNPATHREF")) is not None:
+            out_param_if_snpathref = odxrequire(out_param_if_snpathref_elem.get("SHORT-NAME-PATH"))
+
+        value_type_raw = None
+        if (value_type_str := et_element.get("VALUE-TYPE")) is not None:
+            try:
+                value_type_raw = CommRelationValueType(value_type_str)
+            except ValueError:
+                odxraise(f"Encountered unknown comm relation value type '{value_type_str}'")
+
+        return CommRelation(
+            description=description,
+            relation_type=relation_type,
+            diag_comm_ref=diag_comm_ref,
+            diag_comm_snref=diag_comm_snref,
+            in_param_if_snref=in_param_if_snref,
+            in_param_if_snpathref=in_param_if_snpathref,
+            out_param_if_snref=out_param_if_snref,
+            out_param_if_snpathref=out_param_if_snpathref,
+            value_type_raw=value_type_raw)
+
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+        return {}
+
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
+        if self.diag_comm_ref is not None:
+            self._diag_comm = odxlinks.resolve(self.diag_comm_ref, DiagComm)
+
+    def _resolve_snrefs(self, context: SnRefContext) -> None:
+        diag_layer = odxrequire(context.diag_layer)
+
+        if self.diag_comm_snref is not None:
+            self._diag_comm = resolve_snref(self.diag_comm_snref, diag_layer.diag_comms, DiagComm)
+
+        service = self.diag_comm
+        if not isinstance(service, DiagService):
+            odxraise(f"DIAG-VARIABLE references non-service {type(service).__name__} "
+                     f"diagnostic communication")
+
+        self._in_param_if = None
+        if self.in_param_if_snref is not None:
+            self._in_param_if = resolve_snref(self.in_param_if_snref,
+                                              odxrequire(service.request).parameters, Parameter)
+        elif self.in_param_if_snpathref is not None:
+            odxraise("Resolving SNPATHREFS", NotImplementedError)
+        else:
+            odxraise(f"No IN-PARAM-IF referenced")
+
+        self._out_param_if = None
+        if self.out_param_if_snref is not None:
+            self._out_param_if = resolve_snref(self.out_param_if_snref,
+                                               odxrequire(service.positive_responses[0]).parameters,
+                                               Parameter)
+        elif self.out_param_if_snpathref is not None:
+            odxraise("Resolving SNPATHREFS", NotImplementedError)
+        else:
+            odxraise(f"No OUT-PARAM-IF referenced")

--- a/odxtools/diaglayerraw.py
+++ b/odxtools/diaglayerraw.py
@@ -194,7 +194,8 @@ class DiagLayerRaw(IdentifiableElement):
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
                     dv_proxy = DiagVariable.from_et(dv_proxy_elem, doc_frags)
                 else:
-                    odxraise()
+                    odxraise("DIAG-VARIABLES tags may only contain "
+                             "DIAG-VARIABLE and DIAG-VARIABLE-REF subtags")
 
                 diag_variables_raw.append(dv_proxy)
 

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -13,7 +13,6 @@ from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
 from .swvariable import SwVariable
-from .tablerow import TableRow
 from .utils import dataclass_fields_asdict
 from .variablegroup import VariableGroup
 
@@ -27,17 +26,13 @@ class DiagVariable(IdentifiableElement):
     variable_group_ref: OdxLinkRef
     sw_variables: List[SwVariable]
     comm_relations: List[CommRelation]
-    #snref_to_tablerow: Optional[SnrefToTableRow]
+    #snref_to_tablerow: Optional[SnrefToTableRow] # TODO
     sdgs: List[SpecialDataGroup]
     is_read_before_write_raw: Optional[bool]
 
     @property
     def variable_group(self) -> VariableGroup:
         return self._variable_group
-
-    @property
-    def table_row(self) -> Optional[TableRow]:
-        raise NotImplementedError
 
     @property
     def is_read_before_write(self) -> bool:

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree
+
+from .admindata import AdminData
+from .commrelation import CommRelation
+from .element import IdentifiableElement
+from .exceptions import odxrequire
+from .nameditemlist import NamedItemList
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxtypes import odxstr_to_bool
+from .snrefcontext import SnRefContext
+from .specialdatagroup import SpecialDataGroup
+from .swvariable import SwVariable
+from .tablerow import TableRow
+from .utils import dataclass_fields_asdict
+from .variablegroup import VariableGroup
+
+
+@dataclass
+class DiagVariable(IdentifiableElement):
+    """Representation of a diagnostic variable
+    """
+
+    admin_data: Optional[AdminData]
+    variable_group_ref: OdxLinkRef
+    sw_variables: List[SwVariable]
+    comm_relations: List[CommRelation]
+    #snref_to_tablerow: Optional[SnrefToTableRow]
+    sdgs: List[SpecialDataGroup]
+    is_read_before_write_raw: Optional[bool]
+
+    @property
+    def variable_group(self) -> VariableGroup:
+        return self._variable_group
+
+    @property
+    def table_row(self) -> Optional[TableRow]:
+        raise NotImplementedError
+
+    @property
+    def is_read_before_write(self) -> bool:
+        return self.is_read_before_write_raw is True
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagVariable":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        variable_group_ref = odxrequire(
+            OdxLinkRef.from_et(et_element.find("VARIABLE-GROUP-REF"), doc_frags))
+        sw_variables = NamedItemList([
+            SwVariable.from_et(swv_elem, doc_frags)
+            for swv_elem in et_element.iterfind("SW-VARIABLES/SW-VARIABLE")
+        ])
+        comm_relations = [
+            CommRelation.from_et(cr_elem, doc_frags)
+            for cr_elem in et_element.iterfind("COMM-RELATIONS/COMM-RELATION")
+        ]
+        sdgs = [
+            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
+        ]
+        is_read_before_write_raw = odxstr_to_bool(et_element.get("IS-READ-BEFORE-WRITE"))
+
+        return DiagVariable(
+            admin_data=admin_data,
+            variable_group_ref=variable_group_ref,
+            sw_variables=sw_variables,
+            comm_relations=comm_relations,
+            sdgs=sdgs,
+            is_read_before_write_raw=is_read_before_write_raw,
+            **kwargs)
+
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+        result = {self.odx_id: self}
+
+        if self.admin_data is not None:
+            result.update(self.admin_data._build_odxlinks())
+
+        for sdg in self.sdgs:
+            result.update(sdg._build_odxlinks())
+
+        for cr in self.comm_relations:
+            result.update(cr._build_odxlinks())
+
+        return result
+
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
+        self._variable_group = odxlinks.resolve(self.variable_group_ref, VariableGroup)
+
+        if self.admin_data is not None:
+            self.admin_data._resolve_odxlinks(odxlinks)
+
+        for sdg in self.sdgs:
+            sdg._resolve_odxlinks(odxlinks)
+
+        for cr in self.comm_relations:
+            cr._resolve_odxlinks(odxlinks)
+
+    def _resolve_snrefs(self, context: SnRefContext) -> None:
+        if self.admin_data is not None:
+            self.admin_data._resolve_snrefs(context)
+
+        for sdg in self.sdgs:
+            sdg._resolve_snrefs(context)
+
+        for cr in self.comm_relations:
+            cr._resolve_snrefs(context)

--- a/odxtools/dyndefinedspec.py
+++ b/odxtools/dyndefinedspec.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+from xml.etree import ElementTree
+
+from .diagcomm import DiagClassType, DiagComm
+from .exceptions import odxraise, odxrequire
+from .nameditemlist import NamedItemList
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .snrefcontext import SnRefContext
+from .table import Table
+
+
+@dataclass
+class DynIdDefModeInfo:
+    def_mode: str
+
+    clear_dyn_def_message_ref: Optional[OdxLinkRef]
+    clear_dyn_def_message_snref: Optional[str]
+
+    read_dyn_def_message_ref: Optional[OdxLinkRef]
+    read_dyn_def_message_snref: Optional[str]
+
+    dyn_def_message_ref: Optional[OdxLinkRef]
+    dyn_def_message_snref: Optional[str]
+
+    supported_dyn_ids: List[bytes]
+    selection_table_refs: List[Union[OdxLinkRef, str]]
+
+    @property
+    def clear_dyn_def_message(self) -> DiagComm:
+        return self._clear_dyn_def_message
+
+    @property
+    def read_dyn_def_message(self) -> DiagComm:
+        return self._read_dyn_def_message
+
+    @property
+    def dyn_def_message(self) -> DiagComm:
+        return self._dyn_def_message
+
+    @property
+    def selection_tables(self) -> NamedItemList[Table]:
+        return self._selection_tables
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "DynIdDefModeInfo":
+        def_mode = odxrequire(et_element.findtext("DEF-MODE"))
+
+        clear_dyn_def_message_ref = OdxLinkRef.from_et(
+            et_element.find("CLEAR-DYN-DEF-MESSAGE-REF"), doc_frags)
+        if (snref_elem := et_element.find("CLEAR-DYN-DEF-MESSAGE-SNREF")) is not None:
+            clear_dyn_def_message_snref = snref_elem.attrib["SHORT-NAME"]
+
+        read_dyn_def_message_ref = OdxLinkRef.from_et(
+            et_element.find("READ-DYN-DEF-MESSAGE-REF"), doc_frags)
+        if (snref_elem := et_element.find("READ-DYN-DEF-MESSAGE-SNREF")) is not None:
+            read_dyn_def_message_snref = snref_elem.attrib["SHORT-NAME"]
+
+        dyn_def_message_ref = OdxLinkRef.from_et(et_element.find("DYN-DEF-MESSAGE-REF"), doc_frags)
+        if (snref_elem := et_element.find("DYN-DEF-MESSAGE-SNREF")) is not None:
+            dyn_def_message_snref = snref_elem.attrib["SHORT-NAME"]
+
+        supported_dyn_ids = [
+            bytes.fromhex(odxrequire(x.text))
+            for x in et_element.iterfind("SUPPORTED-DYN-IDS/SUPPORTED-DYN-ID")
+        ]
+
+        selection_table_refs: List[Union[OdxLinkRef, str]] = []
+        if (st_elems := et_element.find("SELECTION-TABLE-REFS")) is not None:
+            for st_elem in st_elems:
+                if st_elem.tag == "SELECTION-TABLE-REF":
+                    selection_table_refs.append(OdxLinkRef.from_et(st_elem, doc_frags))
+                elif st_elem.tag == "SELECTION-TABLE-SNREF":
+                    selection_table_refs.append(odxrequire(st_elem.get("SHORT-NAME")))
+                else:
+                    odxraise()
+
+        return DynIdDefModeInfo(
+            def_mode=def_mode,
+            clear_dyn_def_message_ref=clear_dyn_def_message_ref,
+            clear_dyn_def_message_snref=clear_dyn_def_message_snref,
+            read_dyn_def_message_ref=read_dyn_def_message_ref,
+            read_dyn_def_message_snref=read_dyn_def_message_snref,
+            dyn_def_message_ref=dyn_def_message_ref,
+            dyn_def_message_snref=dyn_def_message_snref,
+            supported_dyn_ids=supported_dyn_ids,
+            selection_table_refs=selection_table_refs,
+        )
+
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+        result: Dict[OdxLinkId, Any] = {}
+
+        return result
+
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
+        self._selection_tables = NamedItemList[Table]()
+
+        if self.clear_dyn_def_message_ref is not None:
+            self._clear_dyn_def_message = odxlinks.resolve(self.clear_dyn_def_message_ref, DiagComm)
+
+        if self.read_dyn_def_message_ref is not None:
+            self._read_dyn_def_message = odxlinks.resolve(self.read_dyn_def_message_ref, DiagComm)
+
+        if self.dyn_def_message_ref is not None:
+            self._dyn_def_message = odxlinks.resolve(self.dyn_def_message_ref, DiagComm)
+
+        # resolve the selection tables referenced using ODXLINK
+        for x in self.selection_table_refs:
+            if isinstance(x, OdxLinkRef):
+                self._selection_tables.append(odxlinks.resolve(x, Table))
+
+    def _resolve_snrefs(self, context: SnRefContext) -> None:
+        diag_layer = odxrequire(context.diag_layer)
+
+        if self.clear_dyn_def_message_snref is not None:
+            self._clear_dyn_def_message = resolve_snref(self.clear_dyn_def_message_snref,
+                                                        diag_layer.diag_comms, DiagComm)
+
+        if self.read_dyn_def_message_snref is not None:
+            self._read_dyn_def_message = resolve_snref(self.read_dyn_def_message_snref,
+                                                       diag_layer.diag_comms, DiagComm)
+
+        if self.dyn_def_message_snref is not None:
+            self._dyn_def_message = resolve_snref(self.dyn_def_message_snref, diag_layer.diag_comms,
+                                                  DiagComm)
+
+        if self._clear_dyn_def_message.diagnostic_class != DiagClassType.CLEAR_DYN_DEF_MESSAGE:
+            odxraise(
+                f"Diagnostic communication object of wrong type referenced: "
+                f"({odxrequire(self._clear_dyn_def_message.diagnostic_class).value} instead of "
+                f"CLEAR-DYN-DEF-MESSAGE)")
+        if self._read_dyn_def_message.diagnostic_class != DiagClassType.READ_DYN_DEFINED_MESSAGE:
+            odxraise(f"Diagnostic communication object of wrong type referenced: "
+                     f"({odxrequire(self._read_dyn_def_message.diagnostic_class).value} instead of "
+                     f"READ-DYN-DEFINED-MESSAGE)")
+        if self._dyn_def_message.diagnostic_class != DiagClassType.DYN_DEF_MESSAGE:
+            odxraise(f"Diagnostic communication object of wrong type referenced: "
+                     f"({odxrequire(self._dyn_def_message.diagnostic_class).value} instead of "
+                     f"DYN-DEF-MESSAGE)")
+
+        # resolve the remaining selection tables that are referenced via SNREF
+        for i, x in enumerate(self.selection_table_refs):
+            if isinstance(x, str):
+                ddd_spec = odxrequire(diag_layer.diag_data_dictionary_spec)
+                self._selection_tables.insert(i, resolve_snref(x, ddd_spec.tables, Table))
+
+
+@dataclass
+class DynDefinedSpec:
+    dyn_id_def_mode_infos: List[DynIdDefModeInfo]
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "DynDefinedSpec":
+        dyn_id_def_mode_infos = [
+            DynIdDefModeInfo.from_et(x, doc_frags)
+            for x in et_element.iterfind("DYN-ID-DEF-MODE-INFOS/DYN-ID-DEF-MODE-INFO")
+        ]
+        return DynDefinedSpec(dyn_id_def_mode_infos=dyn_id_def_mode_infos)
+
+    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+        result: Dict[OdxLinkId, Any] = {}
+
+        result.update(self._build_odxlinks())
+
+        for didmi in self.dyn_id_def_mode_infos:
+            result.update(didmi._build_odxlinks())
+
+        return result
+
+    def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
+        for didmi in self.dyn_id_def_mode_infos:
+            didmi._resolve_odxlinks(odxlinks)
+
+    def _resolve_snrefs(self, context: SnRefContext) -> None:
+        for didmi in self.dyn_id_def_mode_infos:
+            didmi._resolve_snrefs(context)

--- a/odxtools/swvariable.py
+++ b/odxtools/swvariable.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+from typing import List, Optional
+from xml.etree import ElementTree
+
+from .element import NamedElement
+from .odxlink import OdxDocFragment
+from .utils import dataclass_fields_asdict
+
+
+@dataclass
+class SwVariable(NamedElement):
+    origin: Optional[str]
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "SwVariable":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+
+        origin = et_element.findtext("ORIGIN")
+
+        return SwVariable(origin=origin, **kwargs)

--- a/odxtools/templates/macros/printDiagVariable.xml.jinja2
+++ b/odxtools/templates/macros/printDiagVariable.xml.jinja2
@@ -1,0 +1,66 @@
+{#- -*- mode: sgml; tab-width: 2; indent-tabs-mode: nil -*-
+ #
+ # SPDX-License-Identifier: MIT
+-#}
+{%- import('macros/printElementId.xml.jinja2') as peid %}
+{%- import('macros/printAdminData.xml.jinja2') as pad %}
+{%- import('macros/printDescription.xml.jinja2') as pd %}
+
+{%- macro printDiagVariable(diag_var) -%}
+<DIAG-VARIABLE>
+  {{ peid.printElementIdSubtags(diag_variable)|indent(2) }}
+  {%- if diag_variable.admin_data is not none %}
+  {{ pad.printAdminData(diag_variable.admin_data)|indent(2) }}
+  {%- endif %}
+  <VARIABLE-GROUP-REF ID-REF="{{ diag_var.ref_id }}" />
+  {%- if diag_variable.sw_variables %}
+  <SW-VARIABLES>
+    {%- for sw_var in diag_variable.sw_variables %}
+    <SW-VARIABLE>
+      {{ peid.printElementIdSubtags(sw_var)|indent(6) }}
+      {%- if sw_var.origin is not none %}
+      <ORIGIN>{{ sw_var.origin }}</ORIGIN>
+      {%- endif %}
+    </SW-VARIABLE>
+    {%- endfor %}
+  </SW-VARIABLES>
+  {%- endif %}
+  {%- if diag_variable.comm_relations %}
+  <COMM-RELATIONS>
+    {%- for comm_relation in diag_variable.comm_relations %}
+    <COMM-RELATION>
+      {{ pd.printDescription(comm_relation.description) }}
+      <RELATION-TYPE>{{comm_relation.relation_type}}</RELATION-TYPE>
+      {%- if comm_relation.diag_comm_ref is not none %}
+      <DIAG-COMM-REF ID-REF="{{comm_relation.diag_comm_ref.ref_id}}" />
+      {%- endif %}
+      {%- if comm_relation.diag_comm_snref is not none %}
+      <DIAG-COMM-SNREF SHORT-NAME="{{comm_relation.diag_comm_snref}}" />
+      {%- endif %}
+      {%- if comm_relation.in_param_if_ref is not none %}
+      <IN-PARAM-IF-REF ID-REF="{{comm_relation.in_param_if_ref.ref_id}}" />
+      {%- endif %}
+      {%- if comm_relation.in_param_if_snref is not none %}
+      <IN-PARAM-IF-SNREF SHORT-NAME="{{comm_relation.in_param_if_snref}}" />
+      {%- endif %}
+      {%- if comm_relation.out_param_if_ref is not none %}
+      <OUT-PARAM-IF-REF ID-REF="{{comm_relation.out_param_if_ref.ref_id}}" />
+      {%- endif %}
+      {%- if comm_relation.out_param_if_snref is not none %}
+      <OUT-PARAM-IF-SNREF SHORT-NAME="{{comm_relation.out_param_if_snref}}" />
+      {%- endif %}
+      {%- if comm_relation.value_type_raw is not none %}
+      <VALUE-TYPE>{{comm_relation.value_type_raw.value}}</VALUE-TYPE>
+      {%- endif %}
+    <COMM-RELATION>
+    {%- endfor %}
+  </COMM-RELATIONS>
+  {%- endif %}
+</DIAG-VARIABLE>
+{%- endmacro -%}
+
+{%- macro printVariableGroup(var_group) -%}
+<VARIABLE-GROUP>
+  {{ peid.printElementIdSubtags(diag_variable)|indent(2) }}
+</VARIABLE-GROUP>
+{%- endmacro -%}

--- a/odxtools/templates/macros/printDynDefinedSpec.xml.jinja2
+++ b/odxtools/templates/macros/printDynDefinedSpec.xml.jinja2
@@ -1,0 +1,48 @@
+{#- -*- mode: sgml; tab-width: 2; indent-tabs-mode: nil -*-
+ #
+ # SPDX-License-Identifier: MIT
+-#}
+
+{%- macro printDynDefinedSpec(dd_spec) -%}
+<DYN-DEFINED-SPEC>
+{%- if dd_spec.dyn_id_def_mode_infos %}
+<DYN-ID-DEF-MODE-INFOS>
+  {%- for diddmi in dd_spec.dyn_id_def_mode_infos %}
+  <DYN-ID-DEF-MODE-INFO>
+    <DEF-MODE>{{ diddmi.def_mode }}</DEF-MODE>
+    {%- if diddmi.clear_dyn_def_message_ref is not none %}
+    <CLEAR-DYN-DEF-MESSAGE-REF ID-REF="{{diddmi.clear_dyn_def_message_ref.ref_id}}" />
+    {%- endif %}
+    {%- if diddmi.clear_dyn_def_message_snref is not none %}
+    <CLEAR-DYN-DEF-MESSAGE-SNREF SHORT-NAME="{{diddmi.clear_dyn_def_message_snref}}" />
+    {%- endif %}
+    {%- if diddmi.read_dyn_def_message_ref is not none %}
+    <READ-DYN-DEF-MESSAGE-REF ID-REF="{{diddmi.read_dyn_def_message_ref.ref_id}}" />
+    {%- endif %}
+    {%- if diddmi.read_dyn_def_message_snref is not none %}
+    <READ-DYN-DEF-MESSAGE-SNREF SHORT-NAME="{{diddmi.read_dyn_def_message_snref}}" />
+    {%- endif %}
+    {%- if diddmi.supported_dyn_ids %}
+    <SUPPORTED-DYN-IDS>
+      {%- for dynid in diddmi.supported_dyn_ids %}
+      <SUPPORTED-DYN-ID>{{ dynid.hex() }}</SUPPORTED-DYN-ID>
+      {%- endfor %}
+    </SUPPORTED-DYN-IDS>
+    {%- endif %}
+    {%- if diddmi.selection_table_refs %}
+    <SELECTION-TABLE-REFS>
+      {%- for seltref in diddmi.selection_table_refs %}
+        {%- if hasattr(seltref, "ref_id") %}
+	<SELECTION-TABLE-REF ID-REF="{{ seltref.ref_id }}" />
+        {%- else %}
+	<SELECTION-TABLE-SNREF SHORT-NAME="{{ seltref }}" />
+        {%- endif %}
+      {%- endfor %}
+    </SELECTION-TABLE-REFS>
+    {%- endif %}
+  </DYN-ID-DEF-MODE-INFO>
+  {%- endfor %}
+</DYN-ID-DEF-MODE-INFOS>
+{%- endif %}
+</DYN-DEFINED-SPEC>
+{%- endmacro -%}

--- a/odxtools/templates/macros/printVariant.xml.jinja2
+++ b/odxtools/templates/macros/printVariant.xml.jinja2
@@ -26,6 +26,8 @@
 {%- import('macros/printAudience.xml.jinja2') as paud %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 {%- import('macros/printEcuVariantPattern.xml.jinja2') as pvpat %}
+{%- import('macros/printDynDefinedSpec.xml.jinja2') as pdynspec %}
+{%- import('macros/printDiagVariable.xml.jinja2') as pdv %}
 
 {%- macro printVariant(dl) -%}
 {%- set dlr = dl.diag_layer_raw %}
@@ -198,20 +200,35 @@
  {%- endfor %}
  </COMPARAM-REFS>
 {%- endif %}
-{%- if dlr.variant_type.value == "ECU-VARIANT" %}
- {%- if dlr.ecu_variant_patterns %}
- <ECU-VARIANT-PATTERNS>
-   {%- for vp in dlr.ecu_variant_patterns -%}
-   {{ pvpat.printEcuVariantPattern(vp)|indent(2) }}
-   {%- endfor -%}
- </ECU-VARIANT-PATTERNS>
- {%- endif %}
-{%- endif %}
 {%- if dlr.variant_type.value == "PROTOCOL" %}
 	<COMPARAM-SPEC-REF ID-REF="{{dlr.comparam_spec_ref.ref_id}}" DOCREF="{{dlr.comparam_spec_ref.ref_docs[0].doc_name}}" DOCTYPE="COMPARAM-SPEC"/>
   {%- if dlr.prot_stack_snref is not none %}
   <PROT-STACK-SNREF SHORT-NAME="{{dlr.prot_stack_snref}}"/>
   {%- endif %}
+{%- endif %}
+{%- if dlr.diag_variables %}
+  <DIAG-VARIABLES>
+    {%- for dv in dlr.diag_variables -%}
+    {{ pdv.printDiagVariable(dv)|indent(4) }}
+    {%- endfor -%}
+  </DIAG-VARIABLES>
+{%- endif %}
+{%- if dlr.variable_groups %}
+  <VARIABLE-GROUPS>
+    {%- for vg in dlr.variable_groups -%}
+    {{ pdv.printVariableGroup(vg)|indent(4) }}
+    {%- endfor -%}
+  </VARIABLE-GROUPS>
+{%- endif %}
+{%- if dlr.dyn_defined_spec %}
+  {{ pdynspec.printPrintDefinedSpec(dlr.dyn_defined_spec)|indent(4) }}
+{%- endif %}
+{%- if dlr.ecu_variant_patterns %}
+  <ECU-VARIANT-PATTERNS>
+    {%- for vp in dlr.ecu_variant_patterns -%}
+    {{ pvpat.printEcuVariantPattern(vp)|indent(4) }}
+{%- endfor -%}
+  </ECU-VARIANT-PATTERNS>
 {%- endif %}
 {%- if dlr.parent_refs %}
  <PARENT-REFS>

--- a/odxtools/variablegroup.py
+++ b/odxtools/variablegroup.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+from xml.etree import ElementTree
+
+from .element import IdentifiableElement, NamedElement
+from .odxlink import OdxDocFragment
+from .utils import dataclass_fields_asdict
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class VariableGroup(IdentifiableElement):
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "VariableGroup":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+
+        return VariableGroup(**kwargs)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -224,6 +224,9 @@ class TestIdentifyingService(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         db = Database()
@@ -343,6 +346,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -531,6 +537,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
 
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
@@ -680,6 +689,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         db = Database()
@@ -888,6 +900,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -1096,6 +1111,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -1430,6 +1448,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -1704,6 +1725,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -1935,6 +1959,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -2115,6 +2142,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -2301,6 +2331,9 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -294,6 +294,9 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -617,6 +620,9 @@ class TestParamLengthInfoType(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()
@@ -954,6 +960,9 @@ class TestMinMaxLengthType(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -219,6 +219,9 @@ def ecu_variant_1(
         ecu_variant_patterns=[ecu_variant_pattern1],
         comparam_spec_ref=None,
         prot_stack_snref=None,
+        diag_variables_raw=[],
+        variable_groups=NamedItemList(),
+        dyn_defined_spec=None,
     )
     result = DiagLayer(diag_layer_raw=raw_layer)
     odxlinks.update(result._build_odxlinks())
@@ -258,6 +261,9 @@ def ecu_variant_2(
         ecu_variant_patterns=[ecu_variant_pattern2],
         comparam_spec_ref=None,
         prot_stack_snref=None,
+        diag_variables_raw=[],
+        variable_groups=NamedItemList(),
+        dyn_defined_spec=None,
     )
     result = DiagLayer(diag_layer_raw=raw_layer)
     odxlinks.update(result._build_odxlinks())
@@ -298,6 +304,9 @@ def ecu_variant_3(
         ecu_variant_patterns=[ecu_variant_pattern1, ecu_variant_pattern3],
         comparam_spec_ref=None,
         prot_stack_snref=None,
+        diag_variables_raw=[],
+        variable_groups=NamedItemList(),
+        dyn_defined_spec=None,
     )
     result = DiagLayer(diag_layer_raw=raw_layer)
     odxlinks.update(result._build_odxlinks())

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -373,6 +373,9 @@ class TestEncodeRequest(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
 
         diag_layer = DiagLayer(diag_layer_raw=diag_layer_raw)

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -452,6 +452,9 @@ class TestSingleEcuJob(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None,
         )
         dl = DiagLayer(diag_layer_raw=diag_layer_raw)
         odxlinks = OdxLinkDatabase()

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -207,7 +207,9 @@ class TestUnitSpec(unittest.TestCase):
             ecu_variant_patterns=[],
             comparam_spec_ref=None,
             prot_stack_snref=None,
-        )
+            diag_variables_raw=[],
+            variable_groups=NamedItemList(),
+            dyn_defined_spec=None)
         dl = DiagLayer(diag_layer_raw=dl_raw)
         odxlinks = OdxLinkDatabase()
         odxlinks.update(dl._build_odxlinks())


### PR DESCRIPTION
In true "design by committee" spirit, the ODX specification supports to layer an entirely different communication paradigm over its default RPC-based model: Diagnostic variables. In this model, communication with the ECU is done by reading from and writing to a set of "variables". ODX glues this communication approach on its "normal" service-oriented model by specifying a set of variables plus setter and getter services for each.

Note that, since odxtools is not concerned with communicating with ECUs directly, odxtools can only expose the required information for this, not implement this approach itself.

Besides the diagnostic variables infrastructure, this patch also adds the code to internalize the information necessary for dynamically defined messages (`DYN-DEFINED-SPEC`), i.e., messages which exhibit formats that are defined at runtime instead of being known a-priori.

Note that, since I don't have any data file which use either of these features, your mileage may vary.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 