### PR TITLE
tablekeyparameter: fix short name reference resolution

### DIFF
--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -99,13 +99,20 @@ class TableKeyParameter(Parameter):
 
         if self.table_snref is not None:
             tables = odxrequire(context.diag_layer).diag_data_dictionary_spec.tables
-            self._table = resolve_snref(self.table_snref, tables, Table)
+            if TYPE_CHECKING:
+                self._table = resolve_snref(self.table_snref, tables, Table)
+            else:
+                self._table = resolve_snref(self.table_snref, tables)
         if self.table_row_snref is not None:
             # make sure that we know the table to which the table row
             # SNREF is relative to.
-            table = odxrequire(self._table,
-                               "If a table-row is referenced, a table must also be referenced.")
-            self._table_row = resolve_snref(self.table_row_snref, table.table_rows, TableRow)
+            table = odxrequire(
+                self._table, "If a table row is referenced via short name, a table must "
+                "be referenced as well")
+            if TYPE_CHECKING:
+                self._table_row = resolve_snref(self.table_row_snref, table.table_rows, TableRow)
+            else:
+                self._table_row = resolve_snref(self.table_row_snref, table.table_rows)
 
     @property
     def table(self) -> "Table":


### PR DESCRIPTION
unfortunately, the `Table` and `TableRow` classes are only available during type checking (i.e., not during normal execution) because this would lead to circular imports.

this should fix https://github.com/mercedes-benz/odxtools/issues/324.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 