### PR TITLE
SDGs: if the SDG caption is referenced, do not add its IDs to the odxlink database

### DIFF
--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -51,7 +51,7 @@ class SpecialDataGroup:
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         result = {}
 
-        if self.sdg_caption is not None:
+        if self.sdg_caption_ref is None and self.sdg_caption is not None:
             result.update(self.sdg_caption._build_odxlinks())
 
         for val in self.values:


### PR DESCRIPTION
This prevents these SDG captions to be added multiple times (i.e., for SDGs which only reference the caption but do not define it). Under normal circumstances, this only results in slightly lower performance, but in special situations like having to modify a database, it can lead to SDG captions added which are defined nowhere. (I recently stumbled over such a case.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 