### PR TITLE
EnvironmentDataDescription: do not add links to referenced environment data objects

### DIFF
--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -83,8 +83,9 @@ class EnvironmentDataDescription(ComplexDop):
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         odxlinks = {self.odx_id: self}
 
-        for ed in self.env_datas:
-            odxlinks.update(ed._build_odxlinks())
+        if not self.env_data_refs:
+            for ed in self.env_datas:
+                odxlinks.update(ed._build_odxlinks())
 
         return odxlinks
 


### PR DESCRIPTION
Just like for https://github.com/mercedes-benz/odxtools/pull/328, under normal circumstances, this only results in slightly lower performance, but in special situations like having to modify a database based on another, it can lead to environment data objects being falsely added. (I recently stumbled over such a case.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 