### PR TITLE
linearsegment.from_compu_scale: factor value should be equal to 0 if only one numerator is specified

### DIFF
--- a/odxtools/compumethods/linearsegment.py
+++ b/odxtools/compumethods/linearsegment.py
@@ -38,7 +38,7 @@ class LinearSegment:
         coeffs = odxrequire(scale.compu_rational_coeffs)
 
         offset = coeffs.numerators[0]
-        factor = coeffs.numerators[1]
+        factor = 0 if len(coeffs.numerators) == 1 else coeffs.numerators[1]
 
         denominator = 1.0
         if len(coeffs.denominators) > 0:


### PR DESCRIPTION
The current implementation shows "IndexError: list index out of range" when the 'coeffs.numerators' list contains only one value, so, in this case, the factor should take the value 0.