### PR TITLE
odx 2.0 does not use DYN-END-DOP-REF tag

### DIFF
--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -28,8 +28,11 @@ class DynamicEndmarkerField(Field):
                 doc_frags: List[OdxDocFragment]) -> "DynamicEndmarkerField":
         kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
 
+        # ODX 2.0 uses DATA-OBJECT-PROP-REF
+        # ODX 2.2 uses DYN-END-DOP-REF
+        dop_ref = et_element.find("DYN-END-DOP-REF") or et_element.find("DATA-OBJECT-PROP-REF")
         dyn_end_dop_ref = DynEndDopRef.from_et(
-            odxrequire(et_element.find("DYN-END-DOP-REF")), doc_frags)
+            odxrequire(dop_ref), doc_frags)
 
         return DynamicEndmarkerField(dyn_end_dop_ref=dyn_end_dop_ref, **kwargs)
 

--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -31,8 +31,7 @@ class DynamicEndmarkerField(Field):
         # ODX 2.0 uses DATA-OBJECT-PROP-REF
         # ODX 2.2 uses DYN-END-DOP-REF
         dop_ref = et_element.find("DYN-END-DOP-REF") or et_element.find("DATA-OBJECT-PROP-REF")
-        dyn_end_dop_ref = DynEndDopRef.from_et(
-            odxrequire(dop_ref), doc_frags)
+        dyn_end_dop_ref = DynEndDopRef.from_et(odxrequire(dop_ref), doc_frags)
 
         return DynamicEndmarkerField(dyn_end_dop_ref=dyn_end_dop_ref, **kwargs)
 


### PR DESCRIPTION
ODX version 2.0 uses DATA-OBJECT-PROP-REF tag instead of DYN-END-DOP-REF tag.