### PR TITLE
odxtypes.parse_int: detect the value base automatically

### DIFF
--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -64,7 +64,7 @@ def bool_to_odxstr(bool_val: bool) -> str:
 
 def parse_int(value: str) -> int:
     try:
-        return int(value)
+        return int(value, 0)
     except ValueError:
         try:
             v = float(value)

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -65,7 +65,7 @@ def bool_to_odxstr(bool_val: bool) -> str:
 def parse_int(value: str) -> int:
     try:
         return int(value, 0)
-    except ValueError:
+    except (ValueError, TypeError):
         try:
             v = float(value)
         except Exception as e:


### PR DESCRIPTION
The current implementation of **odxtypes.parse_int** function only supports the conversion of base 10 values into integers, not hex or other bases.