### PR TITLE
multiplexer.encode_into_pdu: Fix when case_spec is a string and it is the default case

### DIFF
--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -96,6 +96,7 @@ class Multiplexer(ComplexDop):
                 f"(case_name, content_value) tuple instead of as '{physical_value!r}'")
 
         mux_case: Union[MultiplexerCase, MultiplexerDefaultCase]
+        applicable_cases: List[Union[MultiplexerCase, MultiplexerDefaultCase]]
 
         if isinstance(case_spec, str):
             applicable_cases = [x for x in self.cases if x.short_name == case_spec]
@@ -107,7 +108,7 @@ class Multiplexer(ComplexDop):
 
             odxassert(len(applicable_cases) == 1)
             mux_case = applicable_cases[0]
-            if mux_case == self.default_case:
+            if self.default_case and mux_case == self.default_case:
                 key_value = 0
             else:
                 key_value, _ = self._get_case_limits(mux_case)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -96,15 +96,20 @@ class Multiplexer(ComplexDop):
                 f"(case_name, content_value) tuple instead of as '{physical_value!r}'")
 
         mux_case: Union[MultiplexerCase, MultiplexerDefaultCase]
+
+        key_value = 0
         if isinstance(case_spec, str):
             applicable_cases = [x for x in self.cases if x.short_name == case_spec]
+            if self.default_case:
+                applicable_cases.append(self.default_case)
             if len(applicable_cases) == 0:
                 raise EncodeError(
                     f"Multiplexer {self.short_name} does not know any case called {case_spec}")
 
             odxassert(len(applicable_cases) == 1)
             mux_case = applicable_cases[0]
-            key_value, _ = self._get_case_limits(mux_case)
+            if not self.default_case:
+                key_value, _ = self._get_case_limits(mux_case)
         elif isinstance(case_spec, int):
             applicable_cases = []
             for x in self.cases:

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -97,7 +97,6 @@ class Multiplexer(ComplexDop):
 
         mux_case: Union[MultiplexerCase, MultiplexerDefaultCase]
 
-        key_value = 0
         if isinstance(case_spec, str):
             applicable_cases = [x for x in self.cases if x.short_name == case_spec]
             if self.default_case:
@@ -108,7 +107,9 @@ class Multiplexer(ComplexDop):
 
             odxassert(len(applicable_cases) == 1)
             mux_case = applicable_cases[0]
-            if not self.default_case:
+            if mux_case == self.default_case:
+                key_value = 0
+            else:
                 key_value, _ = self._get_case_limits(mux_case)
         elif isinstance(case_spec, int):
             applicable_cases = []

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -99,7 +99,7 @@ class Multiplexer(ComplexDop):
 
         if isinstance(case_spec, str):
             applicable_cases = [x for x in self.cases if x.short_name == case_spec]
-            if self.default_case:
+            if not applicable_cases and self.default_case:
                 applicable_cases.append(self.default_case)
             if len(applicable_cases) == 0:
                 raise EncodeError(

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -108,10 +108,10 @@ class Multiplexer(ComplexDop):
 
             odxassert(len(applicable_cases) == 1)
             mux_case = applicable_cases[0]
-            if self.default_case and mux_case == self.default_case:
-                key_value = 0
-            else:
+            if isinstance(mux_case, MultiplexerCase):
                 key_value, _ = self._get_case_limits(mux_case)
+            else:
+                key_value = 0
         elif isinstance(case_spec, int):
             applicable_cases = []
             for x in self.cases:


### PR DESCRIPTION
An EncodeError occurs, showing that the multiplexer does not know the current case when it is the default case.