### PR TITLE
Enable loading PDX from IO

### DIFF
--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -37,34 +37,36 @@ class Database:
         self._comparam_subsets = NamedItemList[ComparamSubset]()
         self._comparam_specs = NamedItemList[ComparamSpec]()
 
-    def add_pdx_file(self, pdx_file: Union[str, PathLike[str], IO[bytes], ZipFile]) -> None:
+    def add_pdx_file(self, pdx_file: Union[str, PathLike, IO[bytes], ZipFile]) -> None:
         """Add PDX file to database.
         Either pass the path to the file, an IO with the file content or a ZipFile object.
         """
-        if not isinstance(pdx_file, ZipFile):
-            pdx_file = ZipFile(pdx_file)
-        for zip_member in pdx_file.namelist():
+        if isinstance(pdx_file, ZipFile):
+            pdx_zip = pdx_file
+        else:
+            pdx_zip = ZipFile(pdx_file)
+        for zip_member in pdx_zip.namelist():
             # The name of ODX files can end with .odx, .odx-d,
             # .odx-c, .odx-cs, .odx-e, .odx-f, .odx-fd, .odx-m,
             # .odx-v .  We could test for all that, or just make
             # sure that the file's suffix starts with .odx
             p = Path(zip_member)
             if p.suffix.lower().startswith(".odx"):
-                root = ElementTree.parse(pdx_file.open(zip_member)).getroot()
+                root = ElementTree.parse(pdx_zip.open(zip_member)).getroot()
                 self._process_xml_tree(root)
             elif p.name.lower() != "index.xml":
-                self.add_auxiliary_file(zip_member, pdx_file.open(zip_member))
+                self.add_auxiliary_file(zip_member, pdx_zip.open(zip_member))
 
-    def add_odx_file(self, odx_file_name: str) -> None:
+    def add_odx_file(self, odx_file_name: Union[str, PathLike]) -> None:
         self._process_xml_tree(ElementTree.parse(odx_file_name).getroot())
 
     def add_auxiliary_file(self,
-                           aux_file_name: str,
+                           aux_file_name: Union[str, PathLike],
                            aux_file_obj: Optional[IO[bytes]] = None) -> None:
         if aux_file_obj is None:
             aux_file_obj = open(aux_file_name, "rb")
 
-        self.auxiliary_files[aux_file_name] = aux_file_obj
+        self.auxiliary_files[str(aux_file_name)] = aux_file_obj
 
     def _process_xml_tree(self, root: ElementTree.Element) -> None:
         dlcs: List[DiagLayerContainer] = []

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from itertools import chain
 from pathlib import Path
-from typing import IO, Any, Dict, List, Optional, OrderedDict
+from typing import IO, Any, Dict, List, Optional, OrderedDict, Union
 from xml.etree import ElementTree
 from zipfile import ZipFile
 
@@ -27,10 +27,7 @@ class Database:
     into a single PDX file.
     """
 
-    def __init__(self,
-                 *,
-                 pdx_zip: Optional[ZipFile] = None,
-                 odx_d_file_name: Optional[str] = None) -> None:
+    def __init__(self) -> None:
         self.model_version: Optional[Version] = None
         self.auxiliary_files: OrderedDict[str, IO[bytes]] = OrderedDict()
 
@@ -39,9 +36,14 @@ class Database:
         self._comparam_subsets = NamedItemList[ComparamSubset]()
         self._comparam_specs = NamedItemList[ComparamSpec]()
 
-    def add_pdx_file(self, pdx_file_name: str) -> None:
-        pdx_zip = ZipFile(pdx_file_name)
+    def add_pdx_file(self, pdx_file: Union[str, IO[bytes]]) -> None:
+        """Add PDX file to database.
+        Either pass the path to the file or an IO with the file content.
+        """
+        pdx_zip = ZipFile(pdx_file)
+        self.add_pdx_zip(pdx_zip)
 
+    def add_pdx_zip(self, pdx_zip: ZipFile) -> None:
         for zip_member in pdx_zip.namelist():
             # The name of ODX files can end with .odx, .odx-d,
             # .odx-c, .odx-cs, .odx-e, .odx-f, .odx-fd, .odx-m,

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -37,7 +37,7 @@ class Database:
         self._comparam_subsets = NamedItemList[ComparamSubset]()
         self._comparam_specs = NamedItemList[ComparamSpec]()
 
-    def add_pdx_file(self, pdx_file: Union[str, PathLike, IO[bytes], ZipFile]) -> None:
+    def add_pdx_file(self, pdx_file: Union[str, "PathLike[Any]", IO[bytes], ZipFile]) -> None:
         """Add PDX file to database.
         Either pass the path to the file, an IO with the file content or a ZipFile object.
         """
@@ -57,11 +57,11 @@ class Database:
             elif p.name.lower() != "index.xml":
                 self.add_auxiliary_file(zip_member, pdx_zip.open(zip_member))
 
-    def add_odx_file(self, odx_file_name: Union[str, PathLike]) -> None:
+    def add_odx_file(self, odx_file_name: Union[str, "PathLike[Any]"]) -> None:
         self._process_xml_tree(ElementTree.parse(odx_file_name).getroot())
 
     def add_auxiliary_file(self,
-                           aux_file_name: Union[str, PathLike],
+                           aux_file_name: Union[str, "PathLike[Any]"],
                            aux_file_obj: Optional[IO[bytes]] = None) -> None:
         if aux_file_obj is None:
             aux_file_obj = open(aux_file_name, "rb")


### PR DESCRIPTION
Remove unused parameters from constructor and enable adding PDX files based on an IO / file-like object to a database.

Michael Hahn <[michael.a.hahn@mercedes-benz.com](mailto:michael.a.hahn@mercedes-benz.com)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)