### PR TITLE
Introduce OID attributes

### DIFF
--- a/examples/mksomersaultmodifiedpdx.py
+++ b/examples/mksomersaultmodifiedpdx.py
@@ -101,6 +101,7 @@ pr.parameters = NamedItemList(new_params)
 # add a new "flic-flac" service
 flic_flac_request = Request(
     odx_id=OdxLinkId("somersault.RQ.flic_flac", doc_frags),
+    oid=None,
     short_name="RQ_flic_flac",
     long_name=None,
     description=None,
@@ -108,6 +109,7 @@ flic_flac_request = Request(
     sdgs=[],
     parameters=NamedItemList([
         CodedConstParameter(
+            oid=None,
             short_name="sid",
             long_name=None,
             semantic=None,
@@ -125,6 +127,7 @@ somersault_young_dlr.requests.append(flic_flac_request)
 
 flic_flac_positive_response = Response(
     odx_id=OdxLinkId("somersault.PR.flic_flac", doc_frags),
+    oid=None,
     short_name="PR_flic_flac",
     long_name=None,
     description=None,
@@ -133,6 +136,7 @@ flic_flac_positive_response = Response(
     response_type=ResponseType.POSITIVE,
     parameters=NamedItemList([
         CodedConstParameter(
+            oid=None,
             short_name="sid",
             long_name=None,
             semantic=None,
@@ -144,6 +148,7 @@ flic_flac_positive_response = Response(
             sdgs=[],
         ),
         ValueParameter(
+            oid=None,
             short_name="can_do_backward_flips",
             long_name=None,
             semantic=None,
@@ -162,6 +167,7 @@ somersault_young_dlr.positive_responses.append(flic_flac_positive_response)
 
 flic_flac_service = DiagService(
     odx_id=OdxLinkId("somersault.service.flic_flac", doc_frags),
+    oid=None,
     short_name="flic_flac",
     long_name=None,
     description=None,

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -105,6 +105,7 @@ somersault_team_members = {
     "doggy":
         TeamMember(
             odx_id=OdxLinkId("TM.Doggy", doc_frags),
+            oid=None,
             short_name="Doggy",
             long_name="Doggy the dog",
             description=Description.from_string("<p>Dog is man's best friend</p>"),
@@ -120,6 +121,7 @@ somersault_team_members = {
     "horsey":
         TeamMember(
             odx_id=OdxLinkId("TM.Horsey", doc_frags),
+            oid=None,
             short_name="Horsey",
             long_name="Horsey the horse",
             description=Description.from_string("<p>Trustworthy worker</p>"),
@@ -135,6 +137,7 @@ somersault_team_members = {
     "slothy":
         TeamMember(
             odx_id=OdxLinkId("TM.Slothy", doc_frags),
+            oid=None,
             short_name="Slothy",
             long_name=None,
             description=None,
@@ -153,6 +156,7 @@ somersault_company_datas = {
     "suncus":
         CompanyData(
             odx_id=OdxLinkId("CD.Suncus", doc_frags),
+            oid=None,
             short_name="Suncus",
             long_name="Circus of the sun",
             description=Description.from_string("<p>Prestigious group of performers</p>"),
@@ -184,6 +188,7 @@ somersault_company_datas = {
     "acme":
         CompanyData(
             odx_id=OdxLinkId("CD.ACME", doc_frags),
+            oid=None,
             short_name="ACME_Corporation",
             long_name=None,
             description=None,
@@ -250,6 +255,7 @@ somersault_functional_classes = {
     "flip":
         FunctionalClass(
             odx_id=OdxLinkId("somersault.FNC.flip", doc_frags),
+            oid=None,
             short_name="flip",
             long_name="Flip",
             description=None,
@@ -257,6 +263,7 @@ somersault_functional_classes = {
     "session":
         FunctionalClass(
             odx_id=OdxLinkId("somersault.FNC.session", doc_frags),
+            oid=None,
             short_name="session",
             long_name="Session",
             description=None,
@@ -268,6 +275,7 @@ somersault_additional_audiences = {
     "attentive_admirer":
         AdditionalAudience(
             odx_id=OdxLinkId("somersault.AA.attentive_admirer", doc_frags),
+            oid=None,
             short_name="attentive_admirer",
             long_name="Attentive Admirer",
             description=None,
@@ -275,6 +283,7 @@ somersault_additional_audiences = {
     "anyone":
         AdditionalAudience(
             odx_id=OdxLinkId("somersault.AA.anyone", doc_frags),
+            oid=None,
             short_name="anyone",
             long_name="Anyone",
             description=None,
@@ -325,6 +334,7 @@ somersault_physical_dimensions = {
     "time":
         PhysicalDimension(
             odx_id=OdxLinkId("somersault.PD.time", doc_frags),
+            oid=None,
             short_name="time",
             long_name="Time",
             time_exp=1,
@@ -334,12 +344,12 @@ somersault_physical_dimensions = {
             temperature_exp=0,
             molar_amount_exp=0,
             luminous_intensity_exp=0,
-            oid=None,
             description=None,
         ),
     "temperature":
         PhysicalDimension(
             odx_id=OdxLinkId("somersault.PD.temperature", doc_frags),
+            oid=None,
             short_name="temperature",
             long_name="Temperature",
             time_exp=0,
@@ -349,7 +359,6 @@ somersault_physical_dimensions = {
             temperature_exp=1,
             molar_amount_exp=0,
             luminous_intensity_exp=0,
-            oid=None,
             description=None,
         )
 }
@@ -471,6 +480,7 @@ somersault_dops = {
     "num_flips":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.num_flips", doc_frags),
+            oid=None,
             short_name="num_flips",
             long_name=None,
             description=None,
@@ -486,6 +496,7 @@ somersault_dops = {
     "soberness_check":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.soberness_check", doc_frags),
+            oid=None,
             short_name="soberness_check",
             long_name=None,
             description=None,
@@ -501,6 +512,7 @@ somersault_dops = {
     "dizzyness_level":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.dizzyness_level", doc_frags),
+            oid=None,
             short_name="dizzyness_level",
             long_name=None,
             description=None,
@@ -516,6 +528,7 @@ somersault_dops = {
     "happiness_level":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.happiness_level", doc_frags),
+            oid=None,
             short_name="happiness_level",
             long_name=None,
             description=None,
@@ -531,6 +544,7 @@ somersault_dops = {
     "duration":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.duration", doc_frags),
+            oid=None,
             short_name="duration",
             long_name=None,
             description=None,
@@ -546,6 +560,7 @@ somersault_dops = {
     "temperature":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.temperature", doc_frags),
+            oid=None,
             short_name="temperature",
             long_name=None,
             description=None,
@@ -561,6 +576,7 @@ somersault_dops = {
     "error_code":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.error_code", doc_frags),
+            oid=None,
             short_name="error_code",
             long_name=None,
             description=None,
@@ -576,6 +592,7 @@ somersault_dops = {
     "boolean":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.boolean", doc_frags),
+            oid=None,
             short_name="boolean",
             long_name=None,
             description=None,
@@ -592,6 +609,7 @@ somersault_dops = {
     "uint8":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.uint8", doc_frags),
+            oid=None,
             short_name="uint8",
             long_name=None,
             description=None,
@@ -607,6 +625,7 @@ somersault_dops = {
     "uint16":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.uint16", doc_frags),
+            oid=None,
             short_name="uint16",
             long_name=None,
             description=None,
@@ -622,6 +641,7 @@ somersault_dops = {
     "float":
         DataObjectProperty(
             odx_id=OdxLinkId("somersault.DOP.float", doc_frags),
+            oid=None,
             short_name="float",
             long_name=None,
             description=None,
@@ -644,6 +664,7 @@ somersault_positive_responses = {
     "session":
         Response(
             odx_id=OdxLinkId("somersault.PR.session_start", doc_frags),
+            oid=None,
             short_name="session",
             long_name=None,
             description=None,
@@ -652,6 +673,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -664,6 +686,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="can_do_backward_flips",
                     long_name=None,
                     semantic=None,
@@ -681,6 +704,7 @@ somersault_positive_responses = {
     "tester_ok":
         Response(
             odx_id=OdxLinkId("somersault.PR.tester_present", doc_frags),
+            oid=None,
             short_name="tester_present",
             long_name=None,
             description=None,
@@ -689,6 +713,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -701,6 +726,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="status",
                     long_name=None,
                     semantic=None,
@@ -718,6 +744,7 @@ somersault_positive_responses = {
     "forward_flips_grudgingly_done":
         Response(
             odx_id=OdxLinkId("somersault.PR.grudging_forward", doc_frags),
+            oid=None,
             short_name="grudging_forward",
             long_name=None,
             description=None,
@@ -726,6 +753,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -739,6 +767,7 @@ somersault_positive_responses = {
                 ),
                 # TODO (?): non-byte aligned MatchingRequestParameters
                 MatchingRequestParameter(
+                    oid=None,
                     short_name="num_flips_done",
                     long_name=None,
                     semantic=None,
@@ -750,6 +779,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="sault_time",
                     long_name=None,
                     semantic=None,
@@ -767,6 +797,7 @@ somersault_positive_responses = {
     "forward_flips_happily_done":
         Response(
             odx_id=OdxLinkId("somersault.PR.happy_forward", doc_frags),
+            oid=None,
             short_name="happy_forward",
             long_name=None,
             description=None,
@@ -775,6 +806,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -788,6 +820,7 @@ somersault_positive_responses = {
                 ),
                 # TODO (?): non-byte aligned MatchingRequestParameters
                 MatchingRequestParameter(
+                    oid=None,
                     short_name="num_flips_done",
                     long_name=None,
                     semantic=None,
@@ -799,6 +832,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="yeha_level",
                     long_name=None,
                     semantic=None,
@@ -816,6 +850,7 @@ somersault_positive_responses = {
     "backward_flips_grudgingly_done":
         Response(
             odx_id=OdxLinkId("somersault.PR.grudging_backward", doc_frags),
+            oid=None,
             short_name="grudging_backward",
             long_name=None,
             description=None,
@@ -824,6 +859,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -836,6 +872,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="num_flips_done",
                     long_name=None,
                     semantic=None,
@@ -848,6 +885,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="grumpiness_level",
                     long_name=None,
                     semantic=None,
@@ -866,6 +904,7 @@ somersault_positive_responses = {
     "status_report":
         Response(
             odx_id=OdxLinkId("somersault.PR.status_report", doc_frags),
+            oid=None,
             short_name="status_report",
             long_name=None,
             description=None,
@@ -874,6 +913,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -886,6 +926,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="dizzyness_level",
                     long_name=None,
                     semantic=None,
@@ -898,6 +939,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="happiness_level",
                     long_name=None,
                     semantic=None,
@@ -910,6 +952,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 TableKeyParameter(
+                    oid=None,
                     odx_id=OdxLinkId("somersault.PR.report_status.last_pos_response_key",
                                      doc_frags),
                     short_name="last_pos_response_key",
@@ -925,6 +968,7 @@ somersault_positive_responses = {
                     sdgs=[],
                 ),
                 TableStructParameter(
+                    oid=None,
                     short_name="last_pos_response",
                     long_name=None,
                     semantic=None,
@@ -942,6 +986,7 @@ somersault_positive_responses = {
     "set_operation_params":
         Response(
             odx_id=OdxLinkId("somersault.PR.set_operation_params", doc_frags),
+            oid=None,
             short_name="set_operation_params",
             long_name=None,
             description=None,
@@ -950,6 +995,7 @@ somersault_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -982,6 +1028,7 @@ somersault_negative_responses = {
     "general":
         Response(
             odx_id=OdxLinkId("somersault.NR.general_negative_response", doc_frags),
+            oid=None,
             short_name="general_negative_response",
             long_name=None,
             description=None,
@@ -990,6 +1037,7 @@ somersault_negative_responses = {
             response_type=ResponseType.NEGATIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1001,6 +1049,7 @@ somersault_negative_responses = {
                     sdgs=[],
                 ),
                 MatchingRequestParameter(
+                    oid=None,
                     short_name="rq_sid",
                     long_name=None,
                     semantic=None,
@@ -1012,6 +1061,7 @@ somersault_negative_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="response_code",
                     long_name=None,
                     semantic=None,
@@ -1032,6 +1082,7 @@ somersault_negative_responses = {
     "tester_nok":
         Response(
             odx_id=OdxLinkId("somersault.NR.tester_nok", doc_frags),
+            oid=None,
             short_name="tester_nok",
             long_name=None,
             description=None,
@@ -1040,6 +1091,7 @@ somersault_negative_responses = {
             response_type=ResponseType.NEGATIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1051,6 +1103,7 @@ somersault_negative_responses = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="rq_sid",
                     long_name=None,
                     semantic=None,
@@ -1067,6 +1120,7 @@ somersault_negative_responses = {
     "flips_not_done":
         Response(
             odx_id=OdxLinkId("somersault.NR.flips_not_done", doc_frags),
+            oid=None,
             short_name="flips_not_done",
             long_name=None,
             description=None,
@@ -1075,6 +1129,7 @@ somersault_negative_responses = {
             response_type=ResponseType.NEGATIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1086,6 +1141,7 @@ somersault_negative_responses = {
                     sdgs=[],
                 ),
                 MatchingRequestParameter(
+                    oid=None,
                     short_name="rq_sid",
                     long_name=None,
                     semantic=None,
@@ -1097,6 +1153,7 @@ somersault_negative_responses = {
                     sdgs=[],
                 ),
                 NrcConstParameter(
+                    oid=None,
                     short_name="reason",
                     long_name=None,
                     semantic=None,
@@ -1112,6 +1169,7 @@ somersault_negative_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="flips_successfully_done",
                     long_name=None,
                     semantic=None,
@@ -1132,6 +1190,7 @@ somersault_global_negative_responses = {
     "general":
         Response(
             odx_id=OdxLinkId("GNR.too_hot", doc_frags),
+            oid=None,
             short_name="too_hot",
             long_name=None,
             description=None,
@@ -1140,6 +1199,7 @@ somersault_global_negative_responses = {
             response_type=ResponseType.GLOBAL_NEGATIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1151,6 +1211,7 @@ somersault_global_negative_responses = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="too_hot_dummy",
                     long_name=None,
                     semantic=None,
@@ -1162,6 +1223,7 @@ somersault_global_negative_responses = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="too_hot_id",
                     long_name=None,
                     semantic=None,
@@ -1173,6 +1235,7 @@ somersault_global_negative_responses = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="temperature",
                     long_name=None,
                     semantic=None,
@@ -1196,6 +1259,7 @@ somersault_tables = {
     "last_flip_details":
         Table(
             odx_id=last_flip_details_table_id,
+            oid=None,
             short_name="last_flip_details",
             long_name="Flip Details",
             description=Description.from_string(
@@ -1209,6 +1273,7 @@ somersault_tables = {
                 TableRow(
                     table_ref=last_flip_details_table_ref,
                     odx_id=OdxLinkId("somersault.table.last_flip_details.none", doc_frags),
+                    oid=None,
                     short_name="none",
                     long_name="No Flips Done Yet",
                     key_raw="0",
@@ -1224,6 +1289,7 @@ somersault_tables = {
                     table_ref=last_flip_details_table_ref,
                     odx_id=OdxLinkId("somersault.table.last_flip_details.forward_grudging",
                                      doc_frags),
+                    oid=None,
                     short_name="forward_grudging",
                     long_name="Forward Flips Grudgingly Done",
                     key_raw="3",
@@ -1240,6 +1306,7 @@ somersault_tables = {
                 TableRow(
                     table_ref=last_flip_details_table_ref,
                     odx_id=OdxLinkId("somersault.table.last_flip_details.forward_happy", doc_frags),
+                    oid=None,
                     short_name="forward_happily",
                     long_name="Forward Flips Happily Done",
                     description=None,
@@ -1255,6 +1322,7 @@ somersault_tables = {
                 TableRow(
                     table_ref=last_flip_details_table_ref,
                     odx_id=OdxLinkId("somersault.table.last_flip_details.backward", doc_frags),
+                    oid=None,
                     short_name="backward_grudging",
                     long_name="Backward Flips",
                     description=None,
@@ -1277,6 +1345,7 @@ somersault_requests = {
     "start_session":
         Request(
             odx_id=OdxLinkId("somersault.RQ.start_session", doc_frags),
+            oid=None,
             short_name="start_session",
             long_name="Start the diagnostic session & do some mischief",
             description=None,
@@ -1284,6 +1353,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1296,6 +1366,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="id",
                     long_name=None,
                     semantic=None,
@@ -1312,6 +1383,7 @@ somersault_requests = {
     "stop_session":
         Request(
             odx_id=OdxLinkId("somersault.RQ.stop_session", doc_frags),
+            oid=None,
             short_name="stop_session",
             long_name="Terminate the current diagnostic session",
             description=None,
@@ -1319,6 +1391,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1331,6 +1404,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="id",
                     long_name=None,
                     semantic=None,
@@ -1347,6 +1421,7 @@ somersault_requests = {
     "tester_present":
         Request(
             odx_id=OdxLinkId("somersault.RQ.tester_present", doc_frags),
+            oid=None,
             short_name="tester_present",
             long_name="Prevent the current diagnostic session from timing out",
             description=None,
@@ -1354,6 +1429,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1365,6 +1441,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="id",
                     long_name=None,
                     semantic=None,
@@ -1381,6 +1458,7 @@ somersault_requests = {
     "set_operation_params":
         Request(
             odx_id=OdxLinkId("somersault.RQ.set_operation_params", doc_frags),
+            oid=None,
             short_name="set_operation_params",
             long_name="Specify the mode of operation for the ECU; e.g. if rings "
             "of fire ought to be used for maximum effect",
@@ -1389,6 +1467,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1401,6 +1480,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="use_fire_ring",
                     long_name=None,
                     semantic=None,
@@ -1418,6 +1498,7 @@ somersault_requests = {
     "forward_flips":
         Request(
             odx_id=OdxLinkId("somersault.RQ.do_forward_flips", doc_frags),
+            oid=None,
             short_name="do_forward_flips",
             long_name="Do forward somersaults & some other mischief",
             description=None,
@@ -1425,6 +1506,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1436,6 +1518,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="forward_soberness_check",
                     long_name=None,
                     semantic=None,
@@ -1449,6 +1532,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="num_flips",
                     long_name=None,
                     semantic=None,
@@ -1466,6 +1550,7 @@ somersault_requests = {
     "backward_flips":
         Request(
             odx_id=OdxLinkId("somersault.RQ.do_backward_flips", doc_frags),
+            oid=None,
             short_name="do_backward_flips",
             long_name="Do a backward somersault & some other mischief",
             description=None,
@@ -1473,6 +1558,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1484,6 +1570,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="backward_soberness_check",
                     long_name=None,
                     semantic=None,
@@ -1497,6 +1584,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="num_flips",
                     long_name=None,
                     semantic=None,
@@ -1514,6 +1602,7 @@ somersault_requests = {
     "report_status":
         Request(
             odx_id=OdxLinkId("somersault.RQ.report_status", doc_frags),
+            oid=None,
             short_name="report_status",
             long_name="Report back the current level of dizzy- & happiness.",
             description=None,
@@ -1521,6 +1610,7 @@ somersault_requests = {
             sdgs=[],
             parameters=[
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -1533,6 +1623,7 @@ somersault_requests = {
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="id",
                     long_name=None,
                     semantic=None,
@@ -1553,6 +1644,7 @@ somersault_services = {
     "start_session":
         DiagService(
             odx_id=OdxLinkId("somersault.service.session_start", doc_frags),
+            oid=None,
             short_name="session_start",
             long_name=None,
             description=None,
@@ -1587,6 +1679,7 @@ somersault_services = {
     "stop_session":
         DiagService(
             odx_id=OdxLinkId("somersault.service.session_stop", doc_frags),
+            oid=None,
             short_name="session_stop",
             long_name=None,
             description=None,
@@ -1621,6 +1714,7 @@ somersault_services = {
     "tester_present":
         DiagService(
             odx_id=OdxLinkId("somersault.service.tester_present", doc_frags),
+            oid=None,
             short_name="tester_present",
             long_name=None,
             description=None,
@@ -1664,6 +1758,7 @@ somersault_services = {
     "set_operation_params":
         DiagService(
             odx_id=OdxLinkId("somersault.service.set_operation_params", doc_frags),
+            oid=None,
             short_name="set_operation_params",
             long_name=None,
             description=None,
@@ -1696,6 +1791,7 @@ somersault_services = {
     "forward_flips":
         DiagService(
             odx_id=OdxLinkId("somersault.service.do_forward_flips", doc_frags),
+            oid=None,
             short_name="do_forward_flips",
             long_name=None,
             description=Description.from_string("<p>Do a forward flip.</p>"),
@@ -1747,6 +1843,7 @@ somersault_services = {
     "backward_flips":
         DiagService(
             odx_id=OdxLinkId("somersault.service.do_backward_flips", doc_frags),
+            oid=None,
             short_name="do_backward_flips",
             long_name=None,
             description=None,
@@ -1792,6 +1889,7 @@ somersault_services = {
     "report_status":
         DiagService(
             odx_id=OdxLinkId("somersault.service.report_status", doc_frags),
+            oid=None,
             short_name="report_status",
             long_name=None,
             description=None,
@@ -1838,6 +1936,7 @@ somersault_single_ecu_jobs = {
         SingleEcuJob(
             audience=None,
             odx_id=OdxLinkId("somersault.service.compulsory_program", doc_frags),
+            oid=None,
             short_name="compulsory_program",
             long_name="Compulsory Program",
             description=Description.from_string("<p>Do several fancy moves.</p>"),
@@ -2021,6 +2120,7 @@ somersault_diag_data_dictionary_spec = DiagDataDictionarySpec(
 somersault_protocol_raw = ProtocolRaw(
     variant_type=DiagLayerType.PROTOCOL,
     odx_id=OdxLinkId("somersault.protocol", doc_frags),
+    oid=None,
     short_name="somersault_protocol",
     long_name="Somersault protocol info",
     description=Description.from_string(
@@ -2050,6 +2150,7 @@ somersault_protocol = Protocol(diag_layer_raw=somersault_protocol_raw)
 somersault_base_variant_raw = BaseVariantRaw(
     variant_type=DiagLayerType.BASE_VARIANT,
     odx_id=OdxLinkId("somersault", doc_frags),
+    oid=None,
     short_name="somersault",
     long_name="Somersault base variant",
     description=Description.from_string("<p>Base variant of the somersault ECU &amp; cetera</p>"),
@@ -2089,6 +2190,7 @@ somersault_base_variant = BaseVariant(diag_layer_raw=somersault_base_variant_raw
 somersault_lazy_ecu_raw = EcuVariantRaw(
     variant_type=DiagLayerType.ECU_VARIANT,
     odx_id=OdxLinkId("somersault_lazy", doc_frags),
+    oid=None,
     short_name="somersault_lazy",
     long_name="Somersault lazy ECU",
     description=Description.from_string(
@@ -2139,6 +2241,7 @@ somersault_assiduous_requests = {
     "headstand":
         Request(
             odx_id=OdxLinkId("somersault_assiduous.RQ.do_headstand", doc_frags),
+            oid=None,
             short_name="do_headstand",
             long_name="Do a headstand & whatever else is required to entertain the customer",
             description=None,
@@ -2146,6 +2249,7 @@ somersault_assiduous_requests = {
             sdgs=[],
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -2157,6 +2261,7 @@ somersault_assiduous_requests = {
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="duration",
                     long_name=None,
                     semantic=None,
@@ -2178,6 +2283,7 @@ somersault_assiduous_positive_responses = {
     "headstand_done":
         Response(
             odx_id=OdxLinkId("somersault_assiduous.PR.headstand_done", doc_frags),
+            oid=None,
             short_name="headstand_done",
             long_name=None,
             description=None,
@@ -2186,6 +2292,7 @@ somersault_assiduous_positive_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -2198,6 +2305,7 @@ somersault_assiduous_positive_responses = {
                 ),
                 # TODO (?): non-byte aligned MatchingRequestParameters
                 MatchingRequestParameter(
+                    oid=None,
                     short_name="duration",
                     long_name=None,
                     semantic=None,
@@ -2218,6 +2326,7 @@ somersault_assiduous_negative_responses = {
     "fell_over":
         Response(
             odx_id=OdxLinkId("somersault_assiduous.NR.fell_over", doc_frags),
+            oid=None,
             short_name="fell_over",
             long_name=None,
             description=None,
@@ -2226,6 +2335,7 @@ somersault_assiduous_negative_responses = {
             response_type=ResponseType.POSITIVE,
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="sid",
                     long_name=None,
                     semantic=None,
@@ -2238,6 +2348,7 @@ somersault_assiduous_negative_responses = {
                 ),
                 # TODO (?): non-byte aligned MatchingRequestParameters
                 MatchingRequestParameter(
+                    oid=None,
                     short_name="duration",
                     long_name=None,
                     semantic=None,
@@ -2258,6 +2369,7 @@ somersault_assiduous_services = {
     "headstand":
         DiagService(
             odx_id=OdxLinkId("somersault_assiduous.service.headstand", doc_frags),
+            oid=None,
             short_name="headstand",
             long_name=None,
             description=None,
@@ -2303,6 +2415,7 @@ somersault_assiduous_services = {
 somersault_assiduous_ecu_raw = EcuVariantRaw(
     variant_type=DiagLayerType.ECU_VARIANT,
     odx_id=OdxLinkId("somersault_assiduous", doc_frags),
+    oid=None,
     short_name="somersault_assiduous",
     long_name="Somersault assiduous ECU",
     description=Description.from_string(
@@ -2362,6 +2475,7 @@ somersault_assiduous_ecu = EcuVariant(diag_layer_raw=somersault_assiduous_ecu_ra
 # create a "diagnosis layer container" object
 somersault_dlc = DiagLayerContainer(
     odx_id=OdxLinkId("DLC.somersault", doc_frags),
+    oid=None,
     short_name=dlc_short_name,
     long_name="Collect all saults in the summer",
     description=Description.from_string(

--- a/odxtools/element.py
+++ b/odxtools/element.py
@@ -15,10 +15,7 @@ class NamedElement:
     description: Optional[Description]
 
     @staticmethod
-    def from_et(
-        et_element: ElementTree.Element,
-        doc_frags: List[OdxDocFragment],
-    ) -> "NamedElement":
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "NamedElement":
 
         return NamedElement(
             short_name=odxrequire(et_element.findtext("SHORT-NAME")),
@@ -30,15 +27,15 @@ class NamedElement:
 @dataclass
 class IdentifiableElement(NamedElement):
     odx_id: OdxLinkId
+    oid: Optional[str]
 
     @staticmethod
-    def from_et(
-        et_element: ElementTree.Element,
-        doc_frags: List[OdxDocFragment],
-    ) -> "IdentifiableElement":
+    def from_et(et_element: ElementTree.Element,
+                doc_frags: List[OdxDocFragment]) -> "IdentifiableElement":
 
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
-        return IdentifiableElement(
-            **kwargs,
-            odx_id=odxrequire(OdxLinkId.from_et(et_element, doc_frags)),
-        )
+
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        oid = et_element.get("OID")
+
+        return IdentifiableElement(**kwargs, odx_id=odx_id, oid=oid)

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -16,7 +16,6 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class OutputParam(IdentifiableElement):
     dop_base_ref: OdxLinkRef
-    oid: Optional[str]
     semantic: Optional[str]
 
     @staticmethod
@@ -25,9 +24,8 @@ class OutputParam(IdentifiableElement):
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
         dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags))
         semantic = et_element.get("SEMANTIC")
-        oid = et_element.get("OID")
 
-        return OutputParam(dop_base_ref=dop_base_ref, semantic=semantic, oid=oid, **kwargs)
+        return OutputParam(dop_base_ref=dop_base_ref, semantic=semantic, **kwargs)
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         return {}

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -40,6 +40,7 @@ class Parameter(NamedElement):
     define any non-positionable parameter types.
 
     """
+    oid: Optional[str]
     byte_position: Optional[int]
     bit_position: Optional[int]
     semantic: Optional[str]
@@ -51,6 +52,7 @@ class Parameter(NamedElement):
 
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
+        oid = et_element.get("OID")
         semantic = et_element.get("SEMANTIC")
         sdgs = [
             SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
@@ -63,6 +65,7 @@ class Parameter(NamedElement):
         bit_position = int(bit_position_str) if bit_position_str is not None else None
 
         return Parameter(
+            oid=oid,
             byte_position=byte_position,
             bit_position=bit_position,
             semantic=semantic,

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -41,7 +41,6 @@ class PhysicalDimension(IdentifiableElement):
     )
     ```
     """
-    oid: Optional[str]
     length_exp: int
     mass_exp: int
     time_exp: int
@@ -54,7 +53,6 @@ class PhysicalDimension(IdentifiableElement):
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "PhysicalDimension":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
-        oid = et_element.get("OID")
 
         def read_optional_int(element: ElementTree.Element, name: str) -> int:
             if val_str := element.findtext(name):
@@ -71,7 +69,6 @@ class PhysicalDimension(IdentifiableElement):
         luminous_intensity_exp = read_optional_int(et_element, "LUMINOUS-INTENSITY-EXP")
 
         return PhysicalDimension(
-            oid=oid,
             length_exp=length_exp,
             mass_exp=mass_exp,
             time_exp=time_exp,

--- a/odxtools/templates/macros/printAudience.xml.jinja2
+++ b/odxtools/templates/macros/printAudience.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printAdditionalAudience(audience) -%}
-<ADDITIONAL-AUDIENCE ID="{{audience.odx_id.local_id}}">
+<ADDITIONAL-AUDIENCE {{-peid.printElementIdAttribs(audience)}}>
  {{ peid.printElementIdSubtags(audience)|indent(1) }}
 </ADDITIONAL-AUDIENCE>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printCompanyData.xml.jinja2
+++ b/odxtools/templates/macros/printCompanyData.xml.jinja2
@@ -8,7 +8,7 @@
 {%- import('macros/printDescription.xml.jinja2') as pd %}
 
 {%- macro printCompanyData(company_data) %}
-<COMPANY-DATA ID="{{company_data.odx_id.local_id}}">
+<COMPANY-DATA {{-peid.printElementIdAttribs(company_data)}}>
  {{ peid.printElementIdSubtags(company_data)|indent(1) }}
  {%- if company_data.roles is not none %}
  <ROLES>
@@ -20,7 +20,7 @@
  {%- if company_data.team_members is not none %}
  <TEAM-MEMBERS>
   {%- for team_member in company_data.team_members %}
-  <TEAM-MEMBER ID="{{team_member.odx_id.local_id}}">
+  <TEAM-MEMBER {{-peid.printElementIdAttribs(team_member)}}>
    {{ peid.printElementIdSubtags(team_member)|indent(3) }}
    {%- if team_member.roles is not none %}
    <ROLES>

--- a/odxtools/templates/macros/printComparam.xml.jinja2
+++ b/odxtools/templates/macros/printComparam.xml.jinja2
@@ -38,7 +38,7 @@
 {%- endmacro %}
 
 {%- macro printSimpleComparam(cp) %}
-<COMPARAM ID="{{cp.odx_id.local_id}}"
+<COMPARAM {{-peid.printElementIdAttribs(cp)}}
           PARAM-CLASS="{{cp.param_class}}"
           CPTYPE="{{cp.cptype.value}}"
          {{make_xml_attrib("DISPLAY-LEVEL", cp.display_level)}}{#- #}
@@ -52,7 +52,7 @@
 {%- endmacro %}
 
 {%- macro printComplexComparam(cp) %}
-<COMPLEX-COMPARAM ID="{{cp.odx_id.local_id}}"
+<COMPLEX-COMPARAM {{-peid.printElementIdAttribs(cp)}}
                   PARAM-CLASS="{{cp.param_class}}"
                   CPTYPE="{{cp.cptype.value}}"
                  {{make_xml_attrib("DISPLAY-LEVEL", cp.display_level)}}{#- #}

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -130,7 +130,7 @@
  {%- if hasattr(dtc, "ref_id") %}
   <DTC-REF ID-REF="{{dtc.ref_id}}" />
  {%- else %}
-  <DTC ID="{{dtc.odx_id.local_id}}">
+  <DTC {{-peid.printElementIdAttribs(dtc)}}>
    <SHORT-NAME>{{dtc.short_name}}</SHORT-NAME>
    <TROUBLE-CODE>{{dtc.trouble_code}}</TROUBLE-CODE>
   {%- if dtc.display_trouble_code is not none   %}

--- a/odxtools/templates/macros/printDiagComm.xml.jinja2
+++ b/odxtools/templates/macros/printDiagComm.xml.jinja2
@@ -9,7 +9,7 @@
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printDiagCommAttribs(dc) -%}
-ID="{{dc.odx_id.local_id}}"
+{{-peid.printElementIdAttribs(dc)}}
 {{-make_xml_attrib("SEMANTIC", dc.semantic)}}
 {{-make_xml_attrib("DIAGNOSTIC-CLASS", dc.diagnostic_class and dc.diagnostic_class.value)}}
 {{-make_bool_xml_attrib("IS-MANDATORY", dc.is_mandatory_raw)}}

--- a/odxtools/templates/macros/printDiagLayer.xml.jinja2
+++ b/odxtools/templates/macros/printDiagLayer.xml.jinja2
@@ -27,7 +27,7 @@
 {%- import('macros/printAdminData.xml.jinja2') as pad %}
 
 {%- macro printDiagLayerAttribs(dl) -%}
-{#- #} ID="{{dl.diag_layer_raw.odx_id.local_id}}"{# -#}
+{#- #} {{-peid.printElementIdAttribs(dl)}}{# -#}
 {%- endmacro -%}
 
 {%- macro printDiagLayerSubtags(dl) -%}

--- a/odxtools/templates/macros/printDiagVariable.xml.jinja2
+++ b/odxtools/templates/macros/printDiagVariable.xml.jinja2
@@ -7,7 +7,7 @@
 {%- import('macros/printDescription.xml.jinja2') as pd %}
 
 {%- macro printDiagVariable(diag_var) -%}
-<DIAG-VARIABLE>
+<DIAG-VARIABLE {{-peid.printElementIdAttribs(diag_var)}}>
   {{ peid.printElementIdSubtags(diag_variable)|indent(2) }}
   {%- if diag_variable.admin_data is not none %}
   {{ pad.printAdminData(diag_variable.admin_data)|indent(2) }}
@@ -16,7 +16,7 @@
   {%- if diag_variable.sw_variables %}
   <SW-VARIABLES>
     {%- for sw_var in diag_variable.sw_variables %}
-    <SW-VARIABLE>
+    <SW-VARIABLE {{-peid.printElementIdAttribs(sw_var)}}>
       {{ peid.printElementIdSubtags(sw_var)|indent(6) }}
       {%- if sw_var.origin is not none %}
       <ORIGIN>{{ sw_var.origin }}</ORIGIN>
@@ -60,7 +60,7 @@
 {%- endmacro -%}
 
 {%- macro printVariableGroup(var_group) -%}
-<VARIABLE-GROUP>
+<VARIABLE-GROUP {{-peid.printElementIdAttribs(var_group)}}>
   {{ peid.printElementIdSubtags(diag_variable)|indent(2) }}
 </VARIABLE-GROUP>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printDynamicEndmarkerField.xml.jinja2
+++ b/odxtools/templates/macros/printDynamicEndmarkerField.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printStaticField(demf) -%}
-<DYNAMIC-ENDMARKER-FIELD ID="{{demf.odx_id.local_id}}">
+<DYNAMIC-ENDMARKER-FIELD {{-peid.printElementIdAttribs(demf)}}>
  {{ peid.printElementIdSubtags(demf)|indent(1) }}
  <BASIC-STRUCTURE-REF ID-REF="{{demf.structure_ref.ref_id}}" />
  <DYN-END-DOP-REF ID-REF="{{demf.dyn_end_dop_ref.ref_id}}">

--- a/odxtools/templates/macros/printDynamicLengthField.xml.jinja2
+++ b/odxtools/templates/macros/printDynamicLengthField.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printDynamicLengthField(dlf) -%}
-<DYNAMIC-LENGTH-FIELD ID="{{dlf.odx_id.local_id}}">
+<DYNAMIC-LENGTH-FIELD {{-peid.printElementIdAttribs(dlf)}}>
  {{ peid.printElementIdSubtags(dlf)|indent(1) }}
  <BASIC-STRUCTURE-REF ID-REF="{{dlf.structure_ref.ref_id}}" />
  <OFFSET>{{dlf.offset}}</OFFSET>

--- a/odxtools/templates/macros/printElementId.xml.jinja2
+++ b/odxtools/templates/macros/printElementId.xml.jinja2
@@ -5,6 +5,11 @@
 
 {%- import('macros/printDescription.xml.jinja2') as pd %}
 
+{%- macro printElementIdAttribs(obj) -%}
+{#- #} {{- make_xml_attrib("ID", obj.odx_id.local_id) }}
+{#- #} {{- make_xml_attrib("OID", getattr(obj, "oid", none)) -}}
+{%- endmacro -%}
+
 {%- macro printElementIdSubtags(obj) -%}
 <SHORT-NAME>{{ obj.short_name }}</SHORT-NAME>
 {%- if obj.long_name %}

--- a/odxtools/templates/macros/printEndOfPdu.xml.jinja2
+++ b/odxtools/templates/macros/printEndOfPdu.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printEndOfPdu(eopdu) -%}
-<END-OF-PDU-FIELD ID="{{eopdu.odx_id.local_id}}">
+<END-OF-PDU-FIELD {{-peid.printElementIdAttribs(eopdu)}}>
  {{ peid.printElementIdSubtags(eopdu)|indent(1) }}
  <BASIC-STRUCTURE-REF ID-REF="{{eopdu.structure_ref.ref_id}}" />
  {%- if eopdu.max_number_of_items is not none %}

--- a/odxtools/templates/macros/printEnvDataDesc.xml.jinja2
+++ b/odxtools/templates/macros/printEnvDataDesc.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printEnvDataDesc(env_data_desc) %}
-<ENV-DATA-DESC ID="{{env_data_desc.odx_id.local_id}}">
+<ENV-DATA-DESC {{-peid.printElementIdAttribs(env_data_desc)}}>
   {{ peid.printElementIdSubtags(env_data_desc)|indent(1) }}
   <PARAM-SNREF SHORT-NAME="{{env_data_desc.param_snref}}"/>
   <ENV-DATA-REFS>

--- a/odxtools/templates/macros/printFunctionalClass.xml.jinja2
+++ b/odxtools/templates/macros/printFunctionalClass.xml.jinja2
@@ -7,7 +7,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printFunctionalClass(fc) -%}
-<FUNCT-CLASS ID="{{fc.odx_id.local_id}}">
+<FUNCT-CLASS {{-peid.printElementIdAttribs(fc)}}>
  {{ peid.printElementIdSubtags(fc)|indent(1) }}
 </FUNCT-CLASS>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printMux.xml.jinja2
+++ b/odxtools/templates/macros/printMux.xml.jinja2
@@ -8,7 +8,7 @@
 {%- import('macros/printDOP.xml.jinja2') as pdop %}
 
 {%- macro printMux(mux) %}
-<MUX ID="{{mux.odx_id.local_id}}"
+<MUX {{-peid.printElementIdAttribs(mux)}}
      {{-make_bool_xml_attrib("IS-VISIBLE", mux.is_visible_raw)}}
      {#- #}>
   {{ peid.printElementIdSubtags(mux)|indent(1) }}

--- a/odxtools/templates/macros/printParam.xml.jinja2
+++ b/odxtools/templates/macros/printParam.xml.jinja2
@@ -11,8 +11,8 @@
 {%- set semattrib = make_xml_attrib("SEMANTIC", param.semantic) -%}
 {%- if param.parameter_type == "TABLE-KEY"  %}
 <PARAM {{ semattrib }}
-  {{- make_xml_attrib("ID", param.odx_id and param.odx_id.local_id) }}
-  xsi:type="{{param.parameter_type}}">
+       {{-peid.printElementIdAttribs(param)}}
+       xsi:type="{{param.parameter_type}}">
 {%- elif param.parameter_type == "SYSTEM" %}
 <PARAM {{ semattrib }}
   {{- make_xml_attrib("SYSPARAM", param.sysparam) }}

--- a/odxtools/templates/macros/printProtStack.xml.jinja2
+++ b/odxtools/templates/macros/printProtStack.xml.jinja2
@@ -7,7 +7,7 @@
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printProtStack(ps) %}
-<PROT-STACK ID="{{ps.odx_id.local_id}}">
+<PROT-STACK {{-peid.printElementIdAttribs(ps)}}>
  {{ peid.printElementIdSubtags(ps) | indent(1) }}
  <PDU-PROTOCOL-TYPE>{{ ps.pdu_protocol_type }}</PDU-PROTOCOL-TYPE>
  <PHYSICAL-LINK-TYPE>{{ ps.physical_link_type }}</PHYSICAL-LINK-TYPE>

--- a/odxtools/templates/macros/printRequest.xml.jinja2
+++ b/odxtools/templates/macros/printRequest.xml.jinja2
@@ -9,7 +9,7 @@
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printRequest(request) -%}
-<REQUEST ID="{{request.odx_id.local_id}}">
+<REQUEST {{-peid.printElementIdAttribs(request)}}>
  {{ peid.printElementIdSubtags(request)|indent(1) }}
 {%- if request.parameters %}
  <PARAMS>

--- a/odxtools/templates/macros/printResponse.xml.jinja2
+++ b/odxtools/templates/macros/printResponse.xml.jinja2
@@ -8,7 +8,7 @@
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 
 {%- macro printResponse(resp, tag_name="POS-RESPONSE") -%}
-<{{tag_name}} ID="{{resp.odx_id.local_id}}">
+<{{tag_name}} {{-peid.printElementIdAttribs(resp)}}>
  {{ peid.printElementIdSubtags(resp)|indent(1) }}
 {%- if resp.parameters %}
  <PARAMS>

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -73,7 +73,7 @@
 {%- endmacro -%}
 
 {%- macro printOutputParam(param) -%}
-<OUTPUT-PARAM ID="{{param.odx_id.local_id}}"
+<OUTPUT-PARAM {{-peid.printElementIdAttribs(param)}}
               {{-make_xml_attrib("OID", param.oid)}}
               {{-make_xml_attrib("SEMANTIC", param.semantic)}}>
  {{ peid.printElementIdSubtags(param)|indent(1) }}

--- a/odxtools/templates/macros/printSpecialData.xml.jinja2
+++ b/odxtools/templates/macros/printSpecialData.xml.jinja2
@@ -17,7 +17,7 @@
 {%- endmacro %}
 
 {%- macro printSdgCaption(sdg_caption) %}
-<SDG-CAPTION ID="{{sdg_caption.odx_id.local_id}}">
+<SDG-CAPTION {{-peid.printElementIdAttribs(sdg_caption)}}>
  {{ peid.printElementIdSubtags(sdg_caption)|indent(1) }}
 </SDG-CAPTION>
 {%- endmacro %}

--- a/odxtools/templates/macros/printState.xml.jinja2
+++ b/odxtools/templates/macros/printState.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printState(state) -%}
-<STATE ID="{{state.odx_id.local_id}}">
+<STATE {{-peid.printElementIdAttribs(state)}}>
  {{ peid.printElementIdSubtags(state)|indent(1) }}
 </STATE>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printStateChart.xml.jinja2
+++ b/odxtools/templates/macros/printStateChart.xml.jinja2
@@ -8,7 +8,7 @@
 {%- import('macros/printStateTransition.xml.jinja2') as pst %}
 
 {%- macro printStateChart(state_chart) -%}
-<STATE-CHART ID="{{state_chart.odx_id.local_id}}">
+<STATE-CHART {{-peid.printElementIdAttribs(state_chart)}}>
  {{ peid.printElementIdSubtags(state_chart)|indent(1) }}
  <SEMANTIC>{{state_chart.semantic}}</SEMANTIC>
  {%- if state_chart.state_transitions %}

--- a/odxtools/templates/macros/printStateTransition.xml.jinja2
+++ b/odxtools/templates/macros/printStateTransition.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printStateTransition(state_transition) -%}
-<STATE-TRANSITION ID="{{state_transition.odx_id.local_id}}">
+<STATE-TRANSITION {{-peid.printElementIdAttribs(state_transition)}}>
  {{ peid.printElementIdSubtags(state_transition)|indent(1) }}
  <SOURCE-SNREF SHORT-NAME="{{state_transition.source_snref}}" />
  <TARGET-SNREF SHORT-NAME="{{state_transition.target_snref}}" />

--- a/odxtools/templates/macros/printStaticField.xml.jinja2
+++ b/odxtools/templates/macros/printStaticField.xml.jinja2
@@ -6,7 +6,7 @@
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 
 {%- macro printStaticField(sf) -%}
-<STATIC-FIELD ID="{{sf.odx_id.local_id}}">
+<STATIC-FIELD {{-peid.printElementIdAttribs(sf)}}>
  {{ peid.printElementIdSubtags(sf)|indent(1) }}
  <BASIC-STRUCTURE-REF ID-REF="{{sf.structure_ref.ref_id}}" />
  <FIXED-NUMBER-OF-ITEMS>{{sf.fixed_number_of_items}}</FIXED-NUMBER-OF-ITEMS>

--- a/odxtools/templates/macros/printStructure.xml.jinja2
+++ b/odxtools/templates/macros/printStructure.xml.jinja2
@@ -7,7 +7,7 @@
 {%- import('macros/printParam.xml.jinja2') as pp %}
 
 {%- macro printStructure(st) -%}
-<STRUCTURE ID="{{st.odx_id.local_id}}">
+<STRUCTURE {{-peid.printElementIdAttribs(st)}}>
  {{ peid.printElementIdSubtags(st)|indent(1) }}
 {%- if st.byte_size is not none %}
  <BYTE-SIZE>{{st.byte_size}}</BYTE-SIZE>

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -8,7 +8,7 @@
 {%- import('macros/printDescription.xml.jinja2') as pd %}
 
 {%- macro printTable(table) %}
-<TABLE ID="{{table.odx_id.local_id}}"
+<TABLE {{-peid.printElementIdAttribs(table)}}
        {{-make_xml_attrib("SEMANTIC", table.semantic)}}>
  {{ peid.printElementIdSubtags(table)|indent(1) }}
 {%- if table.key_dop_ref %}
@@ -16,7 +16,7 @@
 {%- endif %}
  {%- for table_row in table.table_rows_raw %}
  {%- if hasattr(table_row, "key") %}
- <TABLE-ROW ID="{{table_row.odx_id.local_id}}"
+ <TABLE-ROW {{-peid.printElementIdAttribs(table_row)}}
             {{-make_xml_attrib("SEMANTIC", table_row.semantic)}}>
   <SHORT-NAME>{{table_row.short_name}}</SHORT-NAME>
   {%- if table_row.long_name %}

--- a/odxtools/templates/macros/printUnitSpec.xml.jinja2
+++ b/odxtools/templates/macros/printUnitSpec.xml.jinja2
@@ -35,8 +35,7 @@
 
 
 {%- macro printUnit(unit) -%}
-<UNIT ID="{{unit.odx_id.local_id}}"
-      {{-make_xml_attrib("OID", unit.oid)}}>
+<UNIT {{-peid.printElementIdAttribs(unit)}}>
  {{ peid.printElementIdSubtags(unit)|indent(1) }}
  <DISPLAY-NAME>{{ unit.display_name }}</DISPLAY-NAME>
  {%- if unit.factor_si_to_unit is not none %}
@@ -52,7 +51,7 @@
 {%- endmacro -%}
 
 {%- macro printUnitGroup(group) -%}
-<UNIT-GROUP {%- if group.oid %} OID="{{group.oid}}" {%- endif %}>
+<UNIT-GROUP {{-make_xml_attrib("OID", group.oid)}}>
  {{ peid.printElementIdSubtags(group)|indent(1) }}
  <CATEGORY>{{ group.category.value }}</CATEGORY>
  {%- if group.unit_refs %}
@@ -66,8 +65,7 @@
 {%- endmacro -%}
 
 {%- macro printPhysicalDimesion(dim) -%}
-<PHYSICAL-DIMENSION ID="{{dim.odx_id.local_id}}"
-                    {{-make_xml_attrib("OID",dim.oid)}}>
+<PHYSICAL-DIMENSION {{-peid.printElementIdAttribs(dim)}}>
  {{ peid.printElementIdSubtags(dim)|indent(1) }}
  {%- if dim.length_exp %}
  <LENGTH-EXP>{{ dim.length_exp }}</LENGTH-EXP>

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -53,7 +53,6 @@ class Unit(IdentifiableElement):
     ```
     """
     display_name: str
-    oid: Optional[str]
     factor_si_to_unit: Optional[float]
     offset_si_to_unit: Optional[float]
     physical_dimension_ref: Optional[OdxLinkRef]
@@ -64,7 +63,7 @@ class Unit(IdentifiableElement):
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Unit":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
-        oid = et_element.get("OID")
+
         display_name = odxrequire(et_element.findtext("DISPLAY-NAME"))
 
         def read_optional_float(element: ElementTree.Element, name: str) -> Optional[float]:
@@ -80,7 +79,6 @@ class Unit(IdentifiableElement):
 
         return Unit(
             display_name=display_name,
-            oid=oid,
             factor_si_to_unit=factor_si_to_unit,
             offset_si_to_unit=offset_si_to_unit,
             physical_dimension_ref=physical_dimension_ref,

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -140,6 +140,7 @@ def write_pdx_file(
                 out_file.write(data_file.read())
 
         jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
+        jinja_env.globals["getattr"] = getattr
         jinja_env.globals["hasattr"] = hasattr
         jinja_env.globals["odxraise"] = jinja2_odxraise_helper
         jinja_env.globals["make_xml_attrib"] = make_xml_attrib

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -66,6 +66,7 @@ class TestIdentifyingService(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -77,6 +78,7 @@ class TestIdentifyingService(unittest.TestCase):
             sdgs=[],
         )
         req_param2 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_2",
             long_name=None,
             description=None,
@@ -89,6 +91,7 @@ class TestIdentifyingService(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -101,6 +104,7 @@ class TestIdentifyingService(unittest.TestCase):
         odxlinks.update({req.odx_id: req})
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -128,6 +132,7 @@ class TestIdentifyingService(unittest.TestCase):
         )
 
         req2_param2 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_3",
             long_name=None,
             description=None,
@@ -140,6 +145,7 @@ class TestIdentifyingService(unittest.TestCase):
         )
         req2 = Request(
             odx_id=OdxLinkId("request_id2", doc_frags),
+            oid=None,
             short_name="request_sn2",
             long_name=None,
             description=None,
@@ -151,6 +157,7 @@ class TestIdentifyingService(unittest.TestCase):
         odxlinks.update({req2.odx_id: req2})
 
         resp2_param2 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_4",
             long_name=None,
             description=None,
@@ -163,6 +170,7 @@ class TestIdentifyingService(unittest.TestCase):
         )
         resp2 = Response(
             odx_id=OdxLinkId("response_id2", doc_frags),
+            oid=None,
             short_name="response_sn2",
             long_name=None,
             description=None,
@@ -176,6 +184,7 @@ class TestIdentifyingService(unittest.TestCase):
 
         service2 = DiagService(
             odx_id=OdxLinkId("service_id2", doc_frags),
+            oid=None,
             short_name="service_sn2",
             long_name=None,
             description=None,
@@ -205,6 +214,7 @@ class TestIdentifyingService(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -263,6 +273,7 @@ class TestDecoding(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -274,6 +285,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param2 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_2",
             long_name=None,
             description=None,
@@ -286,6 +298,7 @@ class TestDecoding(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -297,6 +310,7 @@ class TestDecoding(unittest.TestCase):
 
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -325,6 +339,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -383,6 +398,7 @@ class TestDecoding(unittest.TestCase):
         )
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             long_name="example dop",
             description=None,
@@ -401,6 +417,7 @@ class TestDecoding(unittest.TestCase):
             physical_constr=None,
         )
         param1 = CodedConstParameter(
+            oid=None,
             short_name="param1",
             long_name=None,
             description=None,
@@ -412,6 +429,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         param2 = NrcConstParameter(
+            oid=None,
             short_name="param2",
             long_name=None,
             description=None,
@@ -423,6 +441,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         param3 = ValueParameter(
+            oid=None,
             short_name="param3",
             long_name=None,
             description=None,
@@ -436,6 +455,7 @@ class TestDecoding(unittest.TestCase):
         )
         resp = Response(
             odx_id=OdxLinkId("response_id", doc_frags),
+            oid=None,
             short_name="response_sn",
             long_name=None,
             description=None,
@@ -448,6 +468,7 @@ class TestDecoding(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -455,6 +476,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="req_param1",
                     long_name=None,
                     description=None,
@@ -471,6 +493,7 @@ class TestDecoding(unittest.TestCase):
 
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -500,6 +523,7 @@ class TestDecoding(unittest.TestCase):
         base_variant_raw = BaseVariantRaw(
             variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -576,6 +600,7 @@ class TestDecoding(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -587,6 +612,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param2 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_2",
             long_name=None,
             description=None,
@@ -598,6 +624,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param3 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_3",
             long_name=None,
             description=None,
@@ -609,6 +636,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param4 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter_4",
             long_name=None,
             description=None,
@@ -621,6 +649,7 @@ class TestDecoding(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -634,6 +663,7 @@ class TestDecoding(unittest.TestCase):
         odxlinks.update({req.odx_id: req})
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -662,6 +692,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -746,6 +777,7 @@ class TestDecoding(unittest.TestCase):
             physical_type=DataType.A_INT32)
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.odx_id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             long_name=None,
             description=None,
@@ -760,6 +792,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -772,6 +805,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         struct_param1 = CodedConstParameter(
+            oid=None,
             short_name="struct_param_1",
             long_name=None,
             description=None,
@@ -783,6 +817,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         struct_param2 = ValueParameter(
+            oid=None,
             short_name="struct_param_2",
             long_name=None,
             description=None,
@@ -796,6 +831,7 @@ class TestDecoding(unittest.TestCase):
         )
         struct = Structure(
             odx_id=OdxLinkId("struct_id", doc_frags),
+            oid=None,
             short_name="struct",
             long_name=None,
             description=None,
@@ -805,6 +841,7 @@ class TestDecoding(unittest.TestCase):
             byte_size=None,
         )
         req_param2 = ValueParameter(
+            oid=None,
             short_name="structured_param",
             long_name=None,
             description=None,
@@ -819,6 +856,7 @@ class TestDecoding(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -829,6 +867,7 @@ class TestDecoding(unittest.TestCase):
         )
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -857,6 +896,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -939,6 +979,7 @@ class TestDecoding(unittest.TestCase):
             physical_type=DataType.A_INT32)
         dop = DataObjectProperty(
             odx_id=OdxLinkId("static_field.dop.id", doc_frags),
+            oid=None,
             short_name="static_field_dop_sn",
             long_name=None,
             description=None,
@@ -953,6 +994,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -965,6 +1007,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         struct_param1 = ValueParameter(
+            oid=None,
             short_name="static_field_struct_param_1",
             long_name=None,
             description=None,
@@ -977,6 +1020,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         struct_param2 = ValueParameter(
+            oid=None,
             short_name="static_field_struct_param_2",
             long_name=None,
             description=None,
@@ -990,6 +1034,7 @@ class TestDecoding(unittest.TestCase):
         )
         struct = Structure(
             odx_id=OdxLinkId("static_field_struct.id", doc_frags),
+            oid=None,
             short_name="static_field_struct",
             long_name=None,
             description=None,
@@ -1000,6 +1045,7 @@ class TestDecoding(unittest.TestCase):
         )
         static_field = StaticField(
             odx_id=OdxLinkId("static_field.id", doc_frags),
+            oid=None,
             short_name="static_field_sn",
             long_name=None,
             description=None,
@@ -1014,6 +1060,7 @@ class TestDecoding(unittest.TestCase):
             item_byte_size=3,
         )
         req_param2 = ValueParameter(
+            oid=None,
             short_name="static_field_param",
             long_name=None,
             description=None,
@@ -1028,6 +1075,7 @@ class TestDecoding(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("static_field.request.id", doc_frags),
+            oid=None,
             short_name="static_field_request_sn",
             long_name=None,
             description=None,
@@ -1038,6 +1086,7 @@ class TestDecoding(unittest.TestCase):
         )
         service = DiagService(
             odx_id=OdxLinkId("static_field.service.id", doc_frags),
+            oid=None,
             short_name="static_field_service_sn",
             long_name=None,
             description=None,
@@ -1066,6 +1115,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl.id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -1184,6 +1234,7 @@ class TestDecoding(unittest.TestCase):
 
         dop = DataObjectProperty(
             odx_id=OdxLinkId("demf.dop.id", doc_frags),
+            oid=None,
             short_name="demf_dop_sn",
             long_name=None,
             description=None,
@@ -1198,6 +1249,7 @@ class TestDecoding(unittest.TestCase):
         )
         dyn_end_dop = DataObjectProperty(
             odx_id=OdxLinkId("demf.end_dop.id", doc_frags),
+            oid=None,
             short_name="demf_end_dop_sn",
             long_name=None,
             description=None,
@@ -1217,6 +1269,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -1228,6 +1281,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param1_1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -1240,6 +1294,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         struct_param1 = CodedConstParameter(
+            oid=None,
             short_name="struct_param_1",
             long_name=None,
             description=None,
@@ -1251,6 +1306,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         struct_param2 = ValueParameter(
+            oid=None,
             short_name="struct_param_2",
             long_name=None,
             description=None,
@@ -1264,6 +1320,7 @@ class TestDecoding(unittest.TestCase):
         )
         struct = Structure(
             odx_id=OdxLinkId("demf_struct.id", doc_frags),
+            oid=None,
             short_name="demf_struct",
             long_name=None,
             description=None,
@@ -1274,6 +1331,7 @@ class TestDecoding(unittest.TestCase):
         )
         demf = DynamicEndmarkerField(
             odx_id=OdxLinkId("demf.id", doc_frags),
+            oid=None,
             short_name="demf_sn",
             long_name=None,
             description=None,
@@ -1287,6 +1345,7 @@ class TestDecoding(unittest.TestCase):
             dyn_end_dop_ref=dyn_end_dop_ref,
         )
         req_param2 = ValueParameter(
+            oid=None,
             short_name="demf_param",
             long_name=None,
             description=None,
@@ -1299,6 +1358,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_demf_endmarker_param = ReservedParameter(
+            oid=None,
             short_name="demf_endmarker",
             long_name=None,
             description=None,
@@ -1309,6 +1369,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param3 = CodedConstParameter(
+            oid=None,
             short_name="demf_post_param",
             long_name=None,
             description=None,
@@ -1322,6 +1383,7 @@ class TestDecoding(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("demf.request.id", doc_frags),
+            oid=None,
             short_name="demf_request_sn",
             long_name=None,
             description=None,
@@ -1336,6 +1398,7 @@ class TestDecoding(unittest.TestCase):
         # field is at the end of the PDU, so no endmarker is added
         req_end_of_pdu = Request(
             odx_id=OdxLinkId("demf_eopdu.request.id", doc_frags),
+            oid=None,
             short_name="demf_eopdu_request_sn",
             long_name=None,
             description=None,
@@ -1347,6 +1410,7 @@ class TestDecoding(unittest.TestCase):
 
         service = DiagService(
             odx_id=OdxLinkId("demf.service.id", doc_frags),
+            oid=None,
             short_name="demf_service_sn",
             long_name=None,
             description=None,
@@ -1374,6 +1438,7 @@ class TestDecoding(unittest.TestCase):
         )
         service_eopdu = DiagService(
             odx_id=OdxLinkId("demf.service_eopdu.id", doc_frags),
+            oid=None,
             short_name="demf_service_eopdu_sn",
             long_name=None,
             description=None,
@@ -1402,6 +1467,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl.id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -1549,6 +1615,7 @@ class TestDecoding(unittest.TestCase):
             physical_type=DataType.A_INT32)
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dlf.dop.id", doc_frags),
+            oid=None,
             short_name="dlf_dop_sn",
             long_name=None,
             description=None,
@@ -1563,6 +1630,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -1575,6 +1643,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         struct_param1 = CodedConstParameter(
+            oid=None,
             short_name="struct_param_1",
             long_name=None,
             description=None,
@@ -1586,6 +1655,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         struct_param2 = ValueParameter(
+            oid=None,
             short_name="struct_param_2",
             long_name=None,
             description=None,
@@ -1599,6 +1669,7 @@ class TestDecoding(unittest.TestCase):
         )
         struct = Structure(
             odx_id=OdxLinkId("dlf_struct.id", doc_frags),
+            oid=None,
             short_name="dlf_struct",
             long_name=None,
             description=None,
@@ -1611,6 +1682,7 @@ class TestDecoding(unittest.TestCase):
             byte_position=1, bit_position=3, dop_ref=OdxLinkRef.from_id(dop.odx_id))
         dlf = DynamicLengthField(
             odx_id=OdxLinkId("dlf.id", doc_frags),
+            oid=None,
             short_name="dlf_sn",
             long_name=None,
             description=None,
@@ -1625,6 +1697,7 @@ class TestDecoding(unittest.TestCase):
             determine_number_of_items=det_num_items,
         )
         req_param2 = ValueParameter(
+            oid=None,
             short_name="dlf_param",
             long_name=None,
             description=None,
@@ -1639,6 +1712,7 @@ class TestDecoding(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("dlf.request.id", doc_frags),
+            oid=None,
             short_name="dlf_request_sn",
             long_name=None,
             description=None,
@@ -1649,6 +1723,7 @@ class TestDecoding(unittest.TestCase):
         )
         service = DiagService(
             odx_id=OdxLinkId("dlf.service.id", doc_frags),
+            oid=None,
             short_name="dlf_service_sn",
             long_name=None,
             description=None,
@@ -1677,6 +1752,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl.id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -1783,6 +1859,7 @@ class TestDecoding(unittest.TestCase):
             physical_type=DataType.A_INT32)
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             long_name=None,
             description=None,
@@ -1797,6 +1874,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -1809,6 +1887,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         struct_param1 = CodedConstParameter(
+            oid=None,
             short_name="struct_param_1",
             long_name=None,
             description=None,
@@ -1820,6 +1899,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         struct_param2 = ValueParameter(
+            oid=None,
             short_name="struct_param_2",
             long_name=None,
             description=None,
@@ -1833,6 +1913,7 @@ class TestDecoding(unittest.TestCase):
         )
         struct = Structure(
             odx_id=OdxLinkId("struct_id", doc_frags),
+            oid=None,
             short_name="struct",
             long_name=None,
             description=None,
@@ -1843,6 +1924,7 @@ class TestDecoding(unittest.TestCase):
         )
         eopf = EndOfPduField(
             odx_id=OdxLinkId("eopf_id", doc_frags),
+            oid=None,
             short_name="eopf_sn",
             long_name=None,
             description=None,
@@ -1857,6 +1939,7 @@ class TestDecoding(unittest.TestCase):
             is_visible_raw=True,
         )
         req_param2 = ValueParameter(
+            oid=None,
             short_name="eopf_param",
             long_name=None,
             description=None,
@@ -1871,6 +1954,7 @@ class TestDecoding(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -1881,6 +1965,7 @@ class TestDecoding(unittest.TestCase):
         )
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -1909,6 +1994,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -2015,6 +2101,7 @@ class TestDecoding(unittest.TestCase):
         )
         dop = DataObjectProperty(
             odx_id=OdxLinkId("linear.dop.id", doc_frags),
+            oid=None,
             short_name="linear_dop_sn",
             long_name=None,
             description=None,
@@ -2028,6 +2115,7 @@ class TestDecoding(unittest.TestCase):
             physical_constr=None,
         )
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2039,6 +2127,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param2 = ValueParameter(
+            oid=None,
             short_name="value_parameter_2",
             long_name=None,
             description=None,
@@ -2052,6 +2141,7 @@ class TestDecoding(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -2063,6 +2153,7 @@ class TestDecoding(unittest.TestCase):
 
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -2091,6 +2182,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -2162,6 +2254,7 @@ class TestDecoding(unittest.TestCase):
             is_highlow_byte_order_raw=None,
         )
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2173,6 +2266,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         req_param2 = CodedConstParameter(
+            oid=None,
             short_name="req_param",
             long_name=None,
             description=None,
@@ -2185,6 +2279,7 @@ class TestDecoding(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -2195,6 +2290,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         resp_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2206,6 +2302,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         resp_param2 = MatchingRequestParameter(
+            oid=None,
             short_name="matching_req_param",
             long_name=None,
             description=None,
@@ -2218,6 +2315,7 @@ class TestDecoding(unittest.TestCase):
         )
         pos_response = Response(
             odx_id=OdxLinkId("pos_response_id", doc_frags),
+            oid=None,
             short_name="pos_response_sn",
             long_name=None,
             description=None,
@@ -2229,6 +2327,7 @@ class TestDecoding(unittest.TestCase):
         )
 
         resp_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2240,6 +2339,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         resp_param2 = MatchingRequestParameter(
+            oid=None,
             short_name="matching_req_param",
             long_name=None,
             description=None,
@@ -2252,6 +2352,7 @@ class TestDecoding(unittest.TestCase):
         )
         neg_response = Response(
             odx_id=OdxLinkId("neg_response_id", doc_frags),
+            oid=None,
             short_name="neg_response_sn",
             long_name=None,
             description=None,
@@ -2264,6 +2365,7 @@ class TestDecoding(unittest.TestCase):
 
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -2292,6 +2394,7 @@ class TestDecoding(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -2358,6 +2461,7 @@ class TestDecoding(unittest.TestCase):
 
         dtc1 = DiagnosticTroubleCode(
             odx_id=OdxLinkId("dtcID1", doc_frags),
+            oid=None,
             short_name="P34_sn",
             long_name=None,
             description=None,
@@ -2371,6 +2475,7 @@ class TestDecoding(unittest.TestCase):
 
         dtc2 = DiagnosticTroubleCode(
             odx_id=OdxLinkId("dtcID2", doc_frags),
+            oid=None,
             short_name="P56_sn",
             long_name=None,
             description=None,
@@ -2383,6 +2488,7 @@ class TestDecoding(unittest.TestCase):
         )
         dop = DtcDop(
             odx_id=OdxLinkId("dtc.dop.odx_id", doc_frags),
+            oid=None,
             short_name="dtc_dop_sn",
             long_name=None,
             description=None,
@@ -2397,6 +2503,7 @@ class TestDecoding(unittest.TestCase):
         )
         odxlinks.update(dop._build_odxlinks())
         resp_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2408,6 +2515,7 @@ class TestDecoding(unittest.TestCase):
             sdgs=[],
         )
         resp_param2 = ValueParameter(
+            oid=None,
             short_name="DTC_Param",
             long_name=None,
             description=None,
@@ -2421,6 +2529,7 @@ class TestDecoding(unittest.TestCase):
         )
         pos_response = Response(
             odx_id=OdxLinkId("pos_response_id", doc_frags),
+            oid=None,
             short_name="pos_response_sn",
             long_name=None,
             description=None,
@@ -2452,6 +2561,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         odxlinks = OdxLinkDatabase()
         self.dop_bytes_termination_end_of_pdu = DataObjectProperty(
             odx_id=OdxLinkId("DOP_ID", doc_frags),
+            oid=None,
             short_name="DOP",
             long_name=None,
             description=None,
@@ -2479,6 +2589,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         dop = self.dop_bytes_termination_end_of_pdu
         odxlinks.update(dop._build_odxlinks())
         self.parameter_termination_end_of_pdu = ValueParameter(
+            oid=None,
             short_name="min_max_parameter",
             long_name=None,
             description=None,
@@ -2492,6 +2603,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         )
 
         self.parameter_sid = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2522,6 +2634,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         req_param2 = self.parameter_termination_end_of_pdu
         request = Request(
             odx_id=OdxLinkId("request", doc_frags),
+            oid=None,
             short_name="Request",
             long_name=None,
             description=None,
@@ -2546,6 +2659,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
 
         structure = Structure(
             odx_id=OdxLinkId("structure_id", doc_frags),
+            oid=None,
             short_name="Structure_with_End_of_PDU_termination",
             long_name=None,
             description=None,
@@ -2558,6 +2672,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
 
         req_param1 = self.parameter_sid
         req_param2 = ValueParameter(
+            oid=None,
             short_name="min_max_parameter",
             long_name=None,
             description=None,
@@ -2572,6 +2687,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
 
         request = Request(
             odx_id=OdxLinkId("request", doc_frags),
+            oid=None,
             short_name="Request",
             long_name=None,
             description=None,
@@ -2614,6 +2730,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         offset = 0x34
         dop = DataObjectProperty(
             odx_id=OdxLinkId("DOP_ID", doc_frags),
+            oid=None,
             short_name="DOP",
             long_name=None,
             description=None,
@@ -2652,6 +2769,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         )
         odxlinks.update(dop._build_odxlinks())
         req_param1 = CodedConstParameter(
+            oid=None,
             short_name="SID",
             long_name=None,
             description=None,
@@ -2663,6 +2781,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
             sdgs=[],
         )
         req_param2 = PhysicalConstantParameter(
+            oid=None,
             short_name="physical_constant_parameter",
             long_name=None,
             description=None,
@@ -2676,6 +2795,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
         )
         request = Request(
             odx_id=OdxLinkId("request", doc_frags),
+            oid=None,
             short_name="Request",
             long_name=None,
             description=None,

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -202,6 +202,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             "certificateClient":
                 DataObjectProperty(
                     odx_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                    oid=None,
                     short_name="certificateClient",
                     long_name=None,
                     description=None,
@@ -220,6 +221,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         # Request
         request = Request(
             odx_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            oid=None,
             short_name="sendCertificate",
             long_name=None,
             description=None,
@@ -227,6 +229,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="SID",
                     long_name=None,
                     description=None,
@@ -238,6 +241,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="certificateClient",
                     long_name=None,
                     description=Description.from_string("The certificate to verify."),
@@ -258,6 +262,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
+            oid=None,
             short_name="dummy_DL",
             long_name=None,
             description=None,
@@ -378,6 +383,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         length_key_ref = OdxLinkRef.from_id(length_key_id)
         length_key = LengthKeyParameter(
             odx_id=length_key_id,
+            oid=None,
             short_name="length_key",
             long_name=None,
             description=None,
@@ -410,6 +416,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         length_key_id = OdxLinkId("param.length_key", doc_frags)
         length_key = LengthKeyParameter(
             odx_id=length_key_id,
+            oid=None,
             short_name="length_key",
             long_name=None,
             description=None,
@@ -497,6 +504,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             "uint8_times_8":
                 DataObjectProperty(
                     odx_id=OdxLinkId("BV.dummy_DL.DOP.uint8_times_8", doc_frags),
+                    oid=None,
                     short_name="uint8_times_8",
                     long_name=None,
                     description=None,
@@ -513,6 +521,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             "certificateClient":
                 DataObjectProperty(
                     odx_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                    oid=None,
                     short_name="certificateClient",
                     long_name=None,
                     description=None,
@@ -531,6 +540,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         # Request using LengthKeyParameter and ParamLengthInfoType
         request = Request(
             odx_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            oid=None,
             short_name="sendCertificate",
             long_name=None,
             description=None,
@@ -538,6 +548,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="SID",
                     long_name=None,
                     description=None,
@@ -555,6 +566,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                     semantic=None,
                     # LengthKeyParams have an ID to be referenced by a ParamLengthInfoType (which is a diag coded type)
                     odx_id=OdxLinkId("param.dummy_length_key", doc_frags),
+                    oid=None,
                     byte_position=1,
                     bit_position=None,
                     # The DOP multiplies the coded value by 8, since the length key ref expects the number of bits.
@@ -563,6 +575,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="certificateClient",
                     long_name=None,
                     description=Description.from_string("The certificate to verify."),
@@ -583,6 +596,7 @@ class TestParamLengthInfoType(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
+            oid=None,
             short_name="dummy_DL",
             long_name=None,
             description=None,
@@ -854,6 +868,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             "certificateClient":
                 DataObjectProperty(
                     odx_id=OdxLinkId("BV.dummy_DL.DOP.certificateClient", doc_frags),
+                    oid=None,
                     short_name="certificateClient",
                     long_name=None,
                     description=None,
@@ -872,6 +887,7 @@ class TestMinMaxLengthType(unittest.TestCase):
         # Request
         request = Request(
             odx_id=OdxLinkId("BV.dummy_DL.RQ.sendCertificate", doc_frags),
+            oid=None,
             short_name="sendCertificate",
             long_name=None,
             description=None,
@@ -879,6 +895,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="SID",
                     long_name=None,
                     description=None,
@@ -890,6 +907,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="certificateClient",
                     long_name=None,
                     description=Description.from_string("The certificate to verify."),
@@ -903,6 +921,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                     sdgs=[],
                 ),
                 CodedConstParameter(
+                    oid=None,
                     short_name="dummy",
                     long_name=None,
                     description=None,
@@ -921,6 +940,7 @@ class TestMinMaxLengthType(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.BASE_VARIANT,
             odx_id=OdxLinkId("BV.dummy_DL", doc_frags),
+            oid=None,
             short_name="dummy_DL",
             long_name=None,
             description=None,

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -53,6 +53,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         dtc_dop = DtcDop(
             odx_id=OdxLinkId("test_ddds.dop.dtc_dop", doc_frags),
+            oid=None,
             short_name="dtc_dop",
             long_name=None,
             description=None,
@@ -64,6 +65,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             dtcs_raw=[
                 DiagnosticTroubleCode(
                     odx_id=OdxLinkId("test_ddds.dop.dtc_dop.DTC.X10", doc_frags),
+                    oid=None,
                     short_name="X10",
                     long_name=None,
                     description=None,
@@ -81,6 +83,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         dop_1 = DataObjectProperty(
             odx_id=OdxLinkId("test_ddds.dop.the_dop", doc_frags),
+            oid=None,
             short_name="the_dop",
             long_name=None,
             description=None,
@@ -96,6 +99,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         dop_2 = DataObjectProperty(
             odx_id=OdxLinkId("test_ddds.dop.another_dop", doc_frags),
+            oid=None,
             short_name="another_dop",
             long_name=None,
             description=None,
@@ -113,6 +117,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         flip_quality_ref = OdxLinkRef.from_id(flip_quality_id)
         table = Table(
             odx_id=flip_quality_id,
+            oid=None,
             short_name="flip_quality",
             long_name="Flip Quality",
             description=None,
@@ -124,6 +129,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             table_rows_raw=[
                 TableRow(
                     odx_id=OdxLinkId("test_ddds.table.flip_quality.average", doc_frags),
+                    oid=None,
                     table_ref=flip_quality_ref,
                     short_name="average",
                     long_name="Average",
@@ -138,6 +144,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                 ),
                 TableRow(
                     odx_id=OdxLinkId("test_ddds.table.flip_quality.good", doc_frags),
+                    oid=None,
                     table_ref=flip_quality_ref,
                     short_name="good",
                     long_name="Good",
@@ -152,6 +159,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                 ),
                 TableRow(
                     odx_id=OdxLinkId("test_ddds.table.flip_quality.best", doc_frags),
+                    oid=None,
                     table_ref=flip_quality_ref,
                     short_name="best",
                     long_name="Best",
@@ -170,6 +178,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         env_data = EnvironmentData(
             odx_id=OdxLinkId("test_ddds.env_data.flip_env_data", doc_frags),
+            oid=None,
             short_name="flip_env_data",
             long_name="Flip Env Data",
             description=None,
@@ -177,6 +186,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 ValueParameter(
+                    oid=None,
                     short_name="flip_speed",
                     long_name="Flip Speed",
                     description=None,
@@ -189,6 +199,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     sdgs=[],
                 ),
                 PhysicalConstantParameter(
+                    oid=None,
                     short_name="flip_direction",
                     long_name="Flip Direction",
                     description=None,
@@ -208,6 +219,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         env_data_desc = EnvironmentDataDescription(
             odx_id=OdxLinkId("test_ddds.env_data_desc.flip_env_data_desc", doc_frags),
+            oid=None,
             short_name="flip_env_data_desc",
             long_name="Flip Env Data Desc",
             description=None,
@@ -221,6 +233,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         mux_case1_struct = Structure(
             odx_id=OdxLinkId("ddds_test.mux.case1.struct", doc_frags),
+            oid=None,
             short_name="mux_case1_struct",
             long_name=None,
             description=None,
@@ -228,6 +241,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 ValueParameter(
+                    oid=None,
                     short_name="min_donation",
                     long_name=None,
                     description=None,
@@ -240,6 +254,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     sdgs=[],
                 ),
                 ValueParameter(
+                    oid=None,
                     short_name="min_surface_softness",
                     long_name=None,
                     description=None,
@@ -257,6 +272,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         mux_case2_struct = Structure(
             odx_id=OdxLinkId("ddds_test.mux.case2.struct", doc_frags),
+            oid=None,
             short_name="mux_case2_struct",
             long_name=None,
             description=None,
@@ -264,6 +280,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 ValueParameter(
+                    oid=None,
                     short_name="min_temperature",
                     long_name=None,
                     description=None,
@@ -281,6 +298,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         mux = Multiplexer(
             odx_id=OdxLinkId("test_ddds.multiplexer.flip_precondition", doc_frags),
+            oid=None,
             short_name="flip_precondition",
             long_name="Preconditions for doing flips",
             description=None,

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -27,6 +27,7 @@ odxlinks = OdxLinkDatabase()
 def dummy_response(monkeypatch: pytest.MonkeyPatch) -> Response:
     resp = Response(
         odx_id=OdxLinkId(local_id="dummy_resp", doc_fragments=doc_frags),
+        oid=None,
         short_name="dummy_resp",
         long_name=None,
         description=None,
@@ -52,6 +53,7 @@ def dummy_response(monkeypatch: pytest.MonkeyPatch) -> Response:
 def ident_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) -> DiagService:
     dummy_req = Request(
         odx_id=OdxLinkId(local_id="dummy_req", doc_fragments=doc_frags),
+        oid=None,
         short_name="dummy_req",
         long_name=None,
         description=None,
@@ -64,6 +66,7 @@ def ident_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) -> 
 
     diagService = DiagService(
         odx_id=OdxLinkId(local_id="identService", doc_fragments=doc_frags),
+        oid=None,
         short_name="identService",
         long_name=None,
         description=None,
@@ -101,6 +104,7 @@ def ident_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) -> 
 def supplier_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) -> DiagService:
     dummy_req = Request(
         odx_id=OdxLinkId(local_id="dummy_req", doc_fragments=doc_frags),
+        oid=None,
         short_name="dummy_req",
         long_name=None,
         description=None,
@@ -113,6 +117,7 @@ def supplier_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) 
 
     diagService = DiagService(
         odx_id=OdxLinkId(local_id="supplierService", doc_fragments=doc_frags),
+        oid=None,
         short_name="supplierService",
         long_name=None,
         description=None,
@@ -198,6 +203,7 @@ def ecu_variant_1(
     raw_layer = EcuVariantRaw(
         variant_type=DiagLayerType.ECU_VARIANT,
         odx_id=OdxLinkId(local_id="ecu_variant1", doc_fragments=doc_frags),
+        oid=None,
         short_name="ecu_variant1",
         long_name=None,
         description=None,
@@ -238,6 +244,7 @@ def ecu_variant_2(
     raw_layer = EcuVariantRaw(
         variant_type=DiagLayerType.ECU_VARIANT,
         odx_id=OdxLinkId(local_id="ecu_variant2", doc_fragments=doc_frags),
+        oid=None,
         short_name="ecu_variant2",
         long_name=None,
         description=None,
@@ -279,6 +286,7 @@ def ecu_variant_3(
     raw_layer = EcuVariantRaw(
         variant_type=DiagLayerType.ECU_VARIANT,
         odx_id=OdxLinkId(local_id="ecu_variant3", doc_fragments=doc_frags),
+        oid=None,
         short_name="ecu_variant3",
         long_name=None,
         description=None,

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -49,6 +49,7 @@ class TestEncodeRequest(unittest.TestCase):
             is_condensed_raw=None,
         )
         param1 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter",
             long_name=None,
             description=None,
@@ -60,6 +61,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param2 = CodedConstParameter(
+            oid=None,
             short_name="coded_const_parameter",
             long_name=None,
             description=None,
@@ -72,6 +74,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -92,6 +95,7 @@ class TestEncodeRequest(unittest.TestCase):
             is_condensed_raw=None,
         )
         param1 = CodedConstParameter(
+            oid=None,
             short_name="param1",
             long_name=None,
             description=None,
@@ -103,6 +107,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param2 = CodedConstParameter(
+            oid=None,
             short_name="param2",
             long_name=None,
             description=None,
@@ -115,6 +120,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -162,6 +168,7 @@ class TestEncodeRequest(unittest.TestCase):
             physical_type=DataType.A_UINT32)
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             long_name="example dop",
             description=None,
@@ -176,6 +183,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         odxlinks.update({dop.odx_id: dop})
         param1 = ValueParameter(
+            oid=None,
             short_name="value_parameter",
             long_name=None,
             description=None,
@@ -189,6 +197,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request.id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -222,6 +231,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             long_name="example dop",
             description=None,
@@ -240,6 +250,7 @@ class TestEncodeRequest(unittest.TestCase):
             physical_constr=None,
         )
         param1 = CodedConstParameter(
+            oid=None,
             short_name="param1",
             long_name=None,
             description=None,
@@ -251,6 +262,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param2 = NrcConstParameter(
+            oid=None,
             short_name="param2",
             long_name=None,
             description=None,
@@ -262,6 +274,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param3 = ValueParameter(
+            oid=None,
             short_name="param3",
             long_name=None,
             description=None,
@@ -275,6 +288,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         resp = Response(
             odx_id=OdxLinkId("response_id", doc_frags),
+            oid=None,
             short_name="response_sn",
             long_name=None,
             description=None,
@@ -287,6 +301,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -294,6 +309,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
             parameters=NamedItemList([
                 CodedConstParameter(
+                    oid=None,
                     short_name="req_param1",
                     long_name=None,
                     description=None,
@@ -310,6 +326,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         service = DiagService(
             odx_id=OdxLinkId("service_id", doc_frags),
+            oid=None,
             short_name="service_sn",
             long_name=None,
             description=None,
@@ -339,6 +356,7 @@ class TestEncodeRequest(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("dl_id", doc_frags),
+            oid=None,
             short_name="dl_sn",
             long_name=None,
             description=None,
@@ -403,6 +421,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop.id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             long_name="example dop",
             description=None,
@@ -431,6 +450,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         dtc_dop = DtcDop(
             odx_id=OdxLinkId("dtcdop.id", doc_frags),
+            oid=None,
             short_name="dtcdop_sn",
             long_name=None,
             description=Description(
@@ -451,6 +471,7 @@ class TestEncodeRequest(unittest.TestCase):
             dtcs_raw=[
                 DiagnosticTroubleCode(
                     odx_id=OdxLinkId("DTCs.first_trouble", doc_frags),
+                    oid=None,
                     short_name="first_trouble",
                     long_name=None,
                     description=None,
@@ -462,6 +483,7 @@ class TestEncodeRequest(unittest.TestCase):
                     sdgs=[]),
                 DiagnosticTroubleCode(
                     odx_id=OdxLinkId("DTCs.follow_up_trouble", doc_frags),
+                    oid=None,
                     short_name="follow_up_trouble",
                     long_name=None,
                     description=None,
@@ -473,6 +495,7 @@ class TestEncodeRequest(unittest.TestCase):
                     sdgs=[]),
                 DiagnosticTroubleCode(
                     odx_id=OdxLinkId("DTCs.screwed_up_hard", doc_frags),
+                    oid=None,
                     short_name="screwed_up_hard",
                     long_name=None,
                     description=None,
@@ -489,6 +512,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         env_data_desc = EnvironmentDataDescription(
             odx_id=OdxLinkId("DTCs.trouble_explanation", doc_frags),
+            oid=None,
             short_name="trouble_explanation",
             long_name=None,
             description=None,
@@ -499,6 +523,7 @@ class TestEncodeRequest(unittest.TestCase):
             env_datas=[
                 EnvironmentData(
                     odx_id=OdxLinkId("DTCs.trouble_explanation.boiler_plate", doc_frags),
+                    oid=None,
                     short_name="boiler_plate",
                     long_name=None,
                     description=None,
@@ -509,6 +534,7 @@ class TestEncodeRequest(unittest.TestCase):
                     dtc_values=[],
                     parameters=NamedItemList([
                         CodedConstParameter(
+                            oid=None,
                             short_name="blabla_boiler",
                             long_name=None,
                             description=None,
@@ -522,6 +548,7 @@ class TestEncodeRequest(unittest.TestCase):
                     ])),
                 EnvironmentData(
                     odx_id=OdxLinkId("DTCs.trouble_explanation.reason_for_1", doc_frags),
+                    oid=None,
                     short_name="reason_for_1",
                     long_name=None,
                     description=None,
@@ -532,6 +559,7 @@ class TestEncodeRequest(unittest.TestCase):
                     dtc_values=[0x112233],
                     parameters=NamedItemList([
                         CodedConstParameter(
+                            oid=None,
                             short_name="blabla_1",
                             long_name=None,
                             description=None,
@@ -545,6 +573,7 @@ class TestEncodeRequest(unittest.TestCase):
                     ])),
                 EnvironmentData(
                     odx_id=OdxLinkId("DTCs.trouble_explanation.reason_for_2", doc_frags),
+                    oid=None,
                     short_name="reason_for_2",
                     long_name=None,
                     description=None,
@@ -555,6 +584,7 @@ class TestEncodeRequest(unittest.TestCase):
                     dtc_values=[0x445566],
                     parameters=NamedItemList([
                         CodedConstParameter(
+                            oid=None,
                             short_name="blabla_3",
                             long_name=None,
                             description=None,
@@ -566,6 +596,7 @@ class TestEncodeRequest(unittest.TestCase):
                             sdgs=[],
                         ),
                         CodedConstParameter(
+                            oid=None,
                             short_name="blabla_2",
                             long_name=None,
                             description=None,
@@ -582,6 +613,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
 
         param1 = ValueParameter(
+            oid=None,
             short_name="DTC",
             long_name=None,
             description=None,
@@ -594,6 +626,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param2 = ValueParameter(
+            oid=None,
             short_name="dtc_info",
             long_name=None,
             description=Description(
@@ -609,6 +642,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         resp = Response(
             odx_id=OdxLinkId("DTCs.report_dtc.answer", doc_frags),
+            oid=None,
             short_name="report_dtc_answer",
             long_name=None,
             description=None,
@@ -672,6 +706,7 @@ class TestEncodeRequest(unittest.TestCase):
             is_condensed_raw=None,
         )
         param1 = CodedConstParameter(
+            oid=None,
             short_name="code",
             long_name=None,
             description=None,
@@ -683,6 +718,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param2 = CodedConstParameter(
+            oid=None,
             short_name="part1",
             long_name=None,
             description=None,
@@ -694,6 +730,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
         )
         param3 = CodedConstParameter(
+            oid=None,
             short_name="part2",
             long_name=None,
             description=None,
@@ -706,6 +743,7 @@ class TestEncodeRequest(unittest.TestCase):
         )
         req = Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             long_name=None,
             description=None,
@@ -720,6 +758,7 @@ class TestEncodeRequest(unittest.TestCase):
     def _create_request(self, parameters: List[Parameter]) -> Request:
         return Request(
             odx_id=OdxLinkId("request_id", doc_frags),
+            oid=None,
             short_name="request_sn",
             parameters=NamedItemList(parameters),
             long_name=None,
@@ -756,6 +795,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         inner_dop = DataObjectProperty(
             odx_id=OdxLinkId('dop.inner', doc_frags),
+            oid=None,
             short_name="inner_dop",
             long_name=None,
             description=None,
@@ -770,6 +810,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         outer_dop = DataObjectProperty(
             odx_id=OdxLinkId('dop.outer', doc_frags),
+            oid=None,
             short_name="outer_dop",
             long_name=None,
             description=None,
@@ -790,6 +831,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         # Inner
         inner_param = ValueParameter(
+            oid=None,
             short_name="inner_param",
             long_name=None,
             description=None,
@@ -806,6 +848,7 @@ class TestEncodeRequest(unittest.TestCase):
 
         # Outer
         outer_param = ValueParameter(
+            oid=None,
             short_name="outer_param",
             long_name=None,
             description=None,

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -65,18 +65,21 @@ class TestSingleEcuJob(unittest.TestCase):
         self.context = Context(
             extensiveTask=FunctionalClass(
                 odx_id=OdxLinkId("ID.extensiveTask", doc_frags),
+                oid=None,
                 short_name="extensiveTask",
                 long_name=None,
                 description=None,
             ),
             specialAudience=AdditionalAudience(
                 odx_id=OdxLinkId("ID.specialAudience", doc_frags),
+                oid=None,
                 short_name="specialAudience",
                 long_name=None,
                 description=None,
             ),
             inputDOP=DataObjectProperty(
                 odx_id=OdxLinkId("ID.inputDOP", doc_frags),
+                oid=None,
                 short_name="inputDOP",
                 long_name=None,
                 description=None,
@@ -135,6 +138,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ),
             outputDOP=DataObjectProperty(
                 odx_id=OdxLinkId("ID.outputDOP", doc_frags),
+                oid=None,
                 short_name="outputDOP",
                 long_name=None,
                 description=None,
@@ -180,6 +184,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ),
             negOutputDOP=DataObjectProperty(
                 odx_id=OdxLinkId("ID.negOutputDOP", doc_frags),
+                oid=None,
                 short_name="negOutputDOP",
                 long_name=None,
                 description=None,
@@ -259,6 +264,7 @@ class TestSingleEcuJob(unittest.TestCase):
 
         self.singleecujob_object = SingleEcuJob(
             odx_id=OdxLinkId("ID.JumpStart", doc_frags),
+            oid=None,
             short_name="JumpStart",
             long_name=None,
             description=None,
@@ -366,6 +372,7 @@ class TestSingleEcuJob(unittest.TestCase):
         jinja_env.globals["odxraise"] = jinja2_odxraise_helper
         jinja_env.globals["make_xml_attrib"] = make_xml_attrib
         jinja_env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
+        jinja_env.globals["getattr"] = getattr
         jinja_env.globals["hasattr"] = hasattr
 
         # Small template
@@ -393,6 +400,7 @@ class TestSingleEcuJob(unittest.TestCase):
         """Test that empty lists are assigned to list-attributes if no explicit value is passed."""
         sej = SingleEcuJob(
             odx_id=OdxLinkId("ID.SomeID", doc_frags),
+            oid=None,
             short_name="SN.SomeShortName",
             long_name=None,
             description=None,
@@ -433,6 +441,7 @@ class TestSingleEcuJob(unittest.TestCase):
         ecu_variant_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("ID.bv", doc_frags),
+            oid=None,
             short_name="bv",
             long_name=None,
             description=None,

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -111,6 +111,7 @@ class TestUnitSpec(unittest.TestCase):
         )
         dop = DataObjectProperty(
             odx_id=OdxLinkId("dop_id", doc_frags),
+            oid=None,
             short_name="dop_sn",
             admin_data=None,
             long_name=None,
@@ -131,6 +132,7 @@ class TestUnitSpec(unittest.TestCase):
         dl_raw = EcuVariantRaw(
             variant_type=DiagLayerType.ECU_VARIANT,
             odx_id=OdxLinkId("BV_id", doc_frags),
+            oid=None,
             short_name="BaseVariant",
             long_name=None,
             description=None,
@@ -162,6 +164,7 @@ class TestUnitSpec(unittest.TestCase):
             requests=NamedItemList([
                 Request(
                     odx_id=OdxLinkId("rq_id", doc_frags),
+                    oid=None,
                     short_name="rq_sn",
                     admin_data=None,
                     long_name=None,
@@ -169,6 +172,7 @@ class TestUnitSpec(unittest.TestCase):
                     sdgs=[],
                     parameters=NamedItemList([
                         CodedConstParameter(
+                            oid=None,
                             short_name="sid",
                             long_name=None,
                             description=None,
@@ -180,6 +184,7 @@ class TestUnitSpec(unittest.TestCase):
                             sdgs=[],
                         ),
                         ValueParameter(
+                            oid=None,
                             short_name="time",
                             long_name=None,
                             description=None,


### PR DESCRIPTION
OID stands for "Object ID" and is meant to be a UUID for objects, i.e. it is supposed to be an invariant globally unique identifier for objects. It can e.g., be used to locate objects in an ODX editor across projects, but there is no formal mechanism to reference an object via its OID within the ODX data model.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
