### PR TITLE
make `Multiplexer.cases` and `EnvironmentDataDescription.env_datas` `NamedItemLists`

### DIFF
--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -12,6 +12,7 @@ from .exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequir
 from .multiplexercase import MultiplexerCase
 from .multiplexerdefaultcase import MultiplexerDefaultCase
 from .multiplexerswitchkey import MultiplexerSwitchKey
+from .nameditemlist import NamedItemList
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .odxtypes import AtomicOdxType, ParameterValue, odxstr_to_bool
 from .snrefcontext import SnRefContext
@@ -30,7 +31,7 @@ class Multiplexer(ComplexDop):
     byte_position: int
     switch_key: MultiplexerSwitchKey
     default_case: Optional[MultiplexerDefaultCase]
-    cases: List[MultiplexerCase]
+    cases: NamedItemList[MultiplexerCase]
     is_visible_raw: Optional[bool]
 
     @staticmethod
@@ -48,9 +49,8 @@ class Multiplexer(ComplexDop):
         if (dc_elem := et_element.find("DEFAULT-CASE")) is not None:
             default_case = MultiplexerDefaultCase.from_et(dc_elem, doc_frags)
 
-        cases = []
-        if (cases_elem := et_element.find("CASES")) is not None:
-            cases = [MultiplexerCase.from_et(el, doc_frags) for el in cases_elem.iterfind("CASE")]
+        cases = NamedItemList(
+            [MultiplexerCase.from_et(el, doc_frags) for el in et_element.iterfind("CASES/CASE")])
 
         is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
 

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -15,7 +15,7 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class MultiplexerCase(NamedElement):
-    """This class represents a Case which represents multiple options in a Multiplexer."""
+    """This class represents a case which represents a range of keys of a multiplexer."""
 
     structure_ref: Optional[OdxLinkRef]
     structure_snref: Optional[str]

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -227,7 +227,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             sdgs=[],
             param_snref="flip_speed",
             param_snpathref=None,
-            env_datas=[],
+            env_datas=NamedItemList(),
             env_data_refs=[OdxLinkRef.from_id(env_data.odx_id)],
         )
 
@@ -317,7 +317,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                 structure_ref=None,
                 structure_snref=None,
             ),
-            cases=[
+            cases=NamedItemList([
                 MultiplexerCase(
                     short_name="forward_flip",
                     long_name="Preconditions for doing a Forward Flip",
@@ -340,7 +340,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     structure_ref=OdxLinkRef.from_id(mux_case2_struct.odx_id),
                     structure_snref=None,
                 ),
-            ],
+            ]),
             is_visible_raw=None,
         )
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -520,7 +520,7 @@ class TestEncodeRequest(unittest.TestCase):
             sdgs=[],
             param_snref="DTC",
             param_snpathref=None,
-            env_datas=[
+            env_datas=NamedItemList([
                 EnvironmentData(
                     odx_id=OdxLinkId("DTCs.trouble_explanation.boiler_plate", doc_frags),
                     oid=None,
@@ -608,7 +608,7 @@ class TestEncodeRequest(unittest.TestCase):
                             sdgs=[],
                         ),
                     ])),
-            ],
+            ]),
             env_data_refs=[],
         )
 


### PR DESCRIPTION
These objects are `NamedElements` anyway and accessing the items of these lists via their name is much more convenient...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
