### PR TITLE
Fix the document fragments for objects not featured by the base diag layer

### DIFF
--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -33,7 +33,13 @@ class BaseVariantRaw(HierarchyElementRaw):
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "BaseVariantRaw":
-        kwargs = dataclass_fields_asdict(HierarchyElementRaw.from_et(et_element, doc_frags))
+        # objects contained by diagnostic layers exibit an additional
+        # document fragment for the diag layer, so we use the document
+        # fragments of the odx id of the diag layer for IDs of
+        # contained objects.
+        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        kwargs = dataclass_fields_asdict(her)
+        doc_frags = her.odx_id.doc_fragments
 
         diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:

--- a/odxtools/diaglayers/ecushareddataraw.py
+++ b/odxtools/diaglayers/ecushareddataraw.py
@@ -28,7 +28,13 @@ class EcuSharedDataRaw(DiagLayerRaw):
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "EcuSharedDataRaw":
-        kwargs = dataclass_fields_asdict(DiagLayerRaw.from_et(et_element, doc_frags))
+        # objects contained by diagnostic layers exibit an additional
+        # document fragment for the diag layer, so we use the document
+        # fragments of the odx id of the diag layer for IDs of
+        # contained objects.
+        dlr = DiagLayerRaw.from_et(et_element, doc_frags)
+        kwargs = dataclass_fields_asdict(dlr)
+        doc_frags = dlr.odx_id.doc_fragments
 
         diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:

--- a/odxtools/diaglayers/ecuvariantraw.py
+++ b/odxtools/diaglayers/ecuvariantraw.py
@@ -31,7 +31,13 @@ class EcuVariantRaw(HierarchyElementRaw):
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "EcuVariantRaw":
-        kwargs = dataclass_fields_asdict(HierarchyElementRaw.from_et(et_element, doc_frags))
+        # objects contained by diagnostic layers exibit an additional
+        # document fragment for the diag layer, so we use the document
+        # fragments of the odx id of the diag layer for IDs of
+        # contained objects.
+        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        kwargs = dataclass_fields_asdict(her)
+        doc_frags = her.odx_id.doc_fragments
 
         diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:

--- a/odxtools/diaglayers/functionalgroupraw.py
+++ b/odxtools/diaglayers/functionalgroupraw.py
@@ -30,7 +30,13 @@ class FunctionalGroupRaw(HierarchyElementRaw):
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "FunctionalGroupRaw":
-        kwargs = dataclass_fields_asdict(HierarchyElementRaw.from_et(et_element, doc_frags))
+        # objects contained by diagnostic layers exibit an additional
+        # document fragment for the diag layer, so we use the document
+        # fragments of the odx id of the diag layer for IDs of
+        # contained objects.
+        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        kwargs = dataclass_fields_asdict(her)
+        doc_frags = her.odx_id.doc_fragments
 
         diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:

--- a/odxtools/diaglayers/hierarchyelementraw.py
+++ b/odxtools/diaglayers/hierarchyelementraw.py
@@ -22,7 +22,13 @@ class HierarchyElementRaw(DiagLayerRaw):
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "HierarchyElementRaw":
-        kwargs = dataclass_fields_asdict(DiagLayerRaw.from_et(et_element, doc_frags))
+        # objects contained by diagnostic layers exibit an additional
+        # document fragment for the diag layer, so we use the document
+        # fragments of the odx id of the diag layer for IDs of
+        # contained objects.
+        dlr = DiagLayerRaw.from_et(et_element, doc_frags)
+        kwargs = dataclass_fields_asdict(dlr)
+        doc_frags = dlr.odx_id.doc_fragments
 
         comparam_refs = [
             ComparamInstance.from_et(el, doc_frags)

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -37,7 +37,13 @@ class ProtocolRaw(HierarchyElementRaw):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ProtocolRaw":
-        kwargs = dataclass_fields_asdict(HierarchyElementRaw.from_et(et_element, doc_frags))
+        # objects contained by diagnostic layers exibit an additional
+        # document fragment for the diag layer, so we use the document
+        # fragments of the odx id of the diag layer for IDs of
+        # contained objects.
+        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        kwargs = dataclass_fields_asdict(her)
+        doc_frags = her.odx_id.doc_fragments
 
         comparam_spec_ref = OdxLinkRef.from_et(
             odxrequire(et_element.find("COMPARAM-SPEC-REF")), doc_frags)


### PR DESCRIPTION
Since diagnostic layers constitute document fragments in addition to the containers which contain them, the odxlink ids must reflect that. So far, this did not happen for objects which are added by one of the concrete diagnostic layers classes, i.e. objects which were not handled by the diagnostic layer base class.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
