### PR TITLE
Implement en- and decoding of SYSTEM parameters

### DIFF
--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -15,6 +15,10 @@ from ..utils import dataclass_fields_asdict
 from .parameter import ParameterType
 from .parameterwithdop import ParameterWithDOP
 
+# The SYSTEM parameter types mandated by the ODX 2.2 standard. Users
+# are free to specify additional types, but these must be handled
+# (cf. table 5 in section 7.3.5.4 of the ASAM ODX 2.2 specification
+# document.)
 PREDEFINED_SYSPARAM_VALUES = [
     "TIMESTAMP", "SECOND", "MINUTE", "HOUR", "TIMEZONE", "DAY", "WEEK", "MONTH", "YEAR", "CENTURY",
     "TESTERID", "USERID"


### PR DESCRIPTION
If the value of these parameters are not explicitly specified, their value is determined by looking at the current state of the system the program is running on. (If their type is one of the values specified by the ODX standard.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
