### PR TITLE
implement libraries

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -2142,7 +2142,7 @@ somersault_protocol_raw = ProtocolRaw(
     comparam_spec_ref=OdxLinkRef("CPS_ISO_15765_3_on_ISO_15765_2",
                                  [OdxDocFragment("ISO_15765_3_on_ISO_15765_2", "COMPARAM-SPEC")]),
     comparam_refs=somersault_comparam_refs,
-    librarys=NamedItemList(),
+    libraries=NamedItemList(),
     prot_stack_snref=None,
 )
 somersault_protocol = Protocol(diag_layer_raw=somersault_protocol_raw)
@@ -2181,7 +2181,7 @@ somersault_base_variant_raw = BaseVariantRaw(
     comparam_refs=[],
     diag_variables_raw=[],
     variable_groups=NamedItemList(),
-    librarys=NamedItemList(),
+    libraries=NamedItemList(),
     dyn_defined_spec=None)
 somersault_base_variant = BaseVariant(diag_layer_raw=somersault_base_variant_raw)
 
@@ -2229,7 +2229,7 @@ somersault_lazy_ecu_raw = EcuVariantRaw(
     ecu_variant_patterns=[],
     diag_variables_raw=[],
     variable_groups=NamedItemList(),
-    librarys=NamedItemList(),
+    libraries=NamedItemList(),
     dyn_defined_spec=None,
 )
 somersault_lazy_ecu = EcuVariant(diag_layer_raw=somersault_lazy_ecu_raw)
@@ -2467,7 +2467,7 @@ somersault_assiduous_ecu_raw = EcuVariantRaw(
     ecu_variant_patterns=[],
     diag_variables_raw=[],
     variable_groups=NamedItemList(),
-    librarys=NamedItemList(),
+    libraries=NamedItemList(),
     dyn_defined_spec=None,
 )
 somersault_assiduous_ecu = EcuVariant(diag_layer_raw=somersault_assiduous_ecu_raw)

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -2142,6 +2142,7 @@ somersault_protocol_raw = ProtocolRaw(
     comparam_spec_ref=OdxLinkRef("CPS_ISO_15765_3_on_ISO_15765_2",
                                  [OdxDocFragment("ISO_15765_3_on_ISO_15765_2", "COMPARAM-SPEC")]),
     comparam_refs=somersault_comparam_refs,
+    librarys=NamedItemList(),
     prot_stack_snref=None,
 )
 somersault_protocol = Protocol(diag_layer_raw=somersault_protocol_raw)
@@ -2180,6 +2181,7 @@ somersault_base_variant_raw = BaseVariantRaw(
     comparam_refs=[],
     diag_variables_raw=[],
     variable_groups=NamedItemList(),
+    librarys=NamedItemList(),
     dyn_defined_spec=None)
 somersault_base_variant = BaseVariant(diag_layer_raw=somersault_base_variant_raw)
 
@@ -2227,6 +2229,7 @@ somersault_lazy_ecu_raw = EcuVariantRaw(
     ecu_variant_patterns=[],
     diag_variables_raw=[],
     variable_groups=NamedItemList(),
+    librarys=NamedItemList(),
     dyn_defined_spec=None,
 )
 somersault_lazy_ecu = EcuVariant(diag_layer_raw=somersault_lazy_ecu_raw)
@@ -2464,6 +2467,7 @@ somersault_assiduous_ecu_raw = EcuVariantRaw(
     ecu_variant_patterns=[],
     diag_variables_raw=[],
     variable_groups=NamedItemList(),
+    librarys=NamedItemList(),
     dyn_defined_spec=None,
 )
 somersault_assiduous_ecu = EcuVariant(diag_layer_raw=somersault_assiduous_ecu_raw)

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -13,6 +13,7 @@ from ..diagcomm import DiagComm
 from ..diagdatadictionaryspec import DiagDataDictionarySpec
 from ..diagservice import DiagService
 from ..exceptions import DecodeError, odxassert, odxraise
+from ..library import Library
 from ..message import Message
 from ..nameditemlist import NamedItemList, TNamed
 from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -258,6 +259,10 @@ class DiagLayer:
     @property
     def import_refs(self) -> List[OdxLinkRef]:
         return self.diag_layer_raw.import_refs
+
+    @property
+    def librarys(self) -> List[Library]:
+        return self.diag_layer_raw.librarys
 
     @property
     def sdgs(self) -> List[SpecialDataGroup]:

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -261,8 +261,8 @@ class DiagLayer:
         return self.diag_layer_raw.import_refs
 
     @property
-    def librarys(self) -> List[Library]:
-        return self.diag_layer_raw.librarys
+    def libraries(self) -> List[Library]:
+        return self.diag_layer_raw.libraries
 
     @property
     def sdgs(self) -> List[SpecialDataGroup]:

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -48,7 +48,7 @@ class DiagLayerRaw(IdentifiableElement):
     state_charts: NamedItemList[StateChart]
     additional_audiences: NamedItemList[AdditionalAudience]
     # sub_components: List[DiagLayer] # TODO
-    librarys: NamedItemList[Library]  # (sic!)
+    libraries: NamedItemList[Library]
     sdgs: List[SpecialDataGroup]
 
     @property
@@ -150,7 +150,7 @@ class DiagLayerRaw(IdentifiableElement):
             for el in et_element.iterfind("ADDITIONAL-AUDIENCES/ADDITIONAL-AUDIENCE")
         ]
 
-        librarys = [
+        libraries = [
             Library.from_et(el, doc_frags) for el in et_element.iterfind("LIBRARYS/LIBRARY")
         ]
 
@@ -173,7 +173,7 @@ class DiagLayerRaw(IdentifiableElement):
             import_refs=import_refs,
             state_charts=NamedItemList(state_charts),
             additional_audiences=NamedItemList(additional_audiences),
-            librarys=NamedItemList(librarys),
+            libraries=NamedItemList(libraries),
             sdgs=sdgs,
             **kwargs)
 
@@ -206,7 +206,7 @@ class DiagLayerRaw(IdentifiableElement):
             odxlinks.update(state_chart._build_odxlinks())
         for additional_audience in self.additional_audiences:
             odxlinks.update(additional_audience._build_odxlinks())
-        for library in self.librarys:
+        for library in self.libraries:
             odxlinks.update(library._build_odxlinks())
         for sdg in self.sdgs:
             odxlinks.update(sdg._build_odxlinks())
@@ -260,7 +260,7 @@ class DiagLayerRaw(IdentifiableElement):
             state_chart._resolve_odxlinks(odxlinks)
         for additional_audience in self.additional_audiences:
             additional_audience._resolve_odxlinks(odxlinks)
-        for library in self.librarys:
+        for library in self.libraries:
             library._resolve_odxlinks(odxlinks)
         for sdg in self.sdgs:
             sdg._resolve_odxlinks(odxlinks)
@@ -292,7 +292,7 @@ class DiagLayerRaw(IdentifiableElement):
             state_chart._resolve_snrefs(context)
         for additional_audience in self.additional_audiences:
             additional_audience._resolve_snrefs(context)
-        for library in self.librarys:
+        for library in self.libraries:
             library._resolve_snrefs(context)
         for sdg in self.sdgs:
             sdg._resolve_snrefs(context)

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -13,6 +13,7 @@ from ..diagservice import DiagService
 from ..element import IdentifiableElement
 from ..exceptions import odxassert, odxraise, odxrequire
 from ..functionalclass import FunctionalClass
+from ..library import Library
 from ..nameditemlist import NamedItemList
 from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..request import Request
@@ -47,7 +48,7 @@ class DiagLayerRaw(IdentifiableElement):
     state_charts: NamedItemList[StateChart]
     additional_audiences: NamedItemList[AdditionalAudience]
     # sub_components: List[DiagLayer] # TODO
-    # libraries: List[DiagLayer] # TODO
+    librarys: NamedItemList[Library]  # (sic!)
     sdgs: List[SpecialDataGroup]
 
     @property
@@ -149,6 +150,10 @@ class DiagLayerRaw(IdentifiableElement):
             for el in et_element.iterfind("ADDITIONAL-AUDIENCES/ADDITIONAL-AUDIENCE")
         ]
 
+        librarys = [
+            Library.from_et(el, doc_frags) for el in et_element.iterfind("LIBRARYS/LIBRARY")
+        ]
+
         sdgs = [
             SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
         ]
@@ -168,6 +173,7 @@ class DiagLayerRaw(IdentifiableElement):
             import_refs=import_refs,
             state_charts=NamedItemList(state_charts),
             additional_audiences=NamedItemList(additional_audiences),
+            librarys=NamedItemList(librarys),
             sdgs=sdgs,
             **kwargs)
 
@@ -200,6 +206,8 @@ class DiagLayerRaw(IdentifiableElement):
             odxlinks.update(state_chart._build_odxlinks())
         for additional_audience in self.additional_audiences:
             odxlinks.update(additional_audience._build_odxlinks())
+        for library in self.librarys:
+            odxlinks.update(library._build_odxlinks())
         for sdg in self.sdgs:
             odxlinks.update(sdg._build_odxlinks())
 
@@ -252,6 +260,8 @@ class DiagLayerRaw(IdentifiableElement):
             state_chart._resolve_odxlinks(odxlinks)
         for additional_audience in self.additional_audiences:
             additional_audience._resolve_odxlinks(odxlinks)
+        for library in self.librarys:
+            library._resolve_odxlinks(odxlinks)
         for sdg in self.sdgs:
             sdg._resolve_odxlinks(odxlinks)
 
@@ -282,5 +292,7 @@ class DiagLayerRaw(IdentifiableElement):
             state_chart._resolve_snrefs(context)
         for additional_audience in self.additional_audiences:
             additional_audience._resolve_snrefs(context)
+        for library in self.librarys:
+            library._resolve_snrefs(context)
         for sdg in self.sdgs:
             sdg._resolve_snrefs(context)

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -42,7 +42,9 @@ class DiagService(DiagComm):
     pos_response_refs: List[OdxLinkRef]
     neg_response_refs: List[OdxLinkRef]
 
-    # TODO: pos_response_suppressable: Optional[PosResponseSuppressable] # (sic!)
+    # note that the spec has a typo here: it calls the corresponding
+    # XML tag POS-RESPONSE-SUPPRESSABLE...
+    # TODO: pos_response_suppressible: Optional[PosResponseSuppressible]
 
     is_cyclic_raw: Optional[bool]
     is_multiple_raw: Optional[bool]

--- a/odxtools/library.py
+++ b/odxtools/library.py
@@ -3,59 +3,55 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, cast
 from xml.etree import ElementTree
 
+from .element import IdentifiableElement
 from .exceptions import odxraise, odxrequire
-from .library import Library
-from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
+from .utils import dataclass_fields_asdict
 
 
 @dataclass
-class ProgCode:
-    """A reference to code that is executed by a single ECU job"""
+class Library(IdentifiableElement):
+    """
+    A library defines a shared library used for single ECU jobs etc.
+
+    It this is basically equivalent to ProgCode.
+    """
+
     code_file: str
     encryption: Optional[str]
     syntax: str
     revision: str
     entrypoint: Optional[str]
-    library_refs: List[OdxLinkRef]
 
     @property
     def code(self) -> bytes:
         return self._code
 
-    @property
-    def libraries(self) -> NamedItemList[Library]:
-        return self._libraries
-
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ProgCode":
-        code_file = odxrequire(et_element.findtext("CODE-FILE"))
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Library":
 
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+
+        code_file = odxrequire(et_element.findtext("CODE-FILE"))
         encryption = et_element.findtext("ENCRYPTION")
         syntax = odxrequire(et_element.findtext("SYNTAX"))
         revision = odxrequire(et_element.findtext("REVISION"))
         entrypoint = et_element.findtext("ENTRYPOINT")
 
-        library_refs = [
-            odxrequire(OdxLinkRef.from_et(el, doc_frags))
-            for el in et_element.iterfind("LIBRARY-REFS/LIBRARY-REF")
-        ]
-
-        return ProgCode(
+        return Library(
             code_file=code_file,
+            encryption=encryption,
             syntax=syntax,
             revision=revision,
-            encryption=encryption,
             entrypoint=entrypoint,
-            library_refs=library_refs,
-        )
+            **kwargs)
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        return {}
+        return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        self._libraries = NamedItemList([odxlinks.resolve(x, Library) for x in self.library_refs])
+        pass
 
     def _resolve_snrefs(self, context: SnRefContext) -> None:
         aux_file = odxrequire(context.database).auxiliary_files.get(self.code_file)

--- a/odxtools/templates/macros/printCompuMethod.xml.jinja2
+++ b/odxtools/templates/macros/printCompuMethod.xml.jinja2
@@ -92,12 +92,13 @@
 {%- macro printProgCode(pc) -%}
 <PROG-CODE>
   <CODE-FILE>{{pc.code_file}}</CODE-FILE>
-  <SYNTAX>{{pc.syntax}}</SYNTAX>
   {%- if pc.encryption is not none %}
   <ENCRYPTION>{{pc.encryption}}</ENCRYPTION>
   {%- endif %}
+  <SYNTAX>{{pc.syntax}}</SYNTAX>
+  <REVISION>{{pc.revision}}</REVISION>
   {%- if pc.entry_point is not none %}
-  <ENTRY-POINT>{{pc.entry_point}}</ENTRY-POINT>
+  <ENTRYPOINT>{{pc.entrypoint}}</ENTRYPOINT>
   {%- endif %}
   {%- if pc.library_refs %}
   <LIBRARY-REFS>

--- a/odxtools/templates/macros/printDiagLayer.xml.jinja2
+++ b/odxtools/templates/macros/printDiagLayer.xml.jinja2
@@ -203,9 +203,9 @@
   {%- endfor %}
 </ADDITIONAL-AUDIENCES>
 {%- endif %}
-{%- if dlr.librarys %}
+{%- if dlr.libraries %}
 <LIBRARYS>
-  {%- for lib in dlr.librarys %}
+  {%- for lib in dlr.libraries %}
   {{ plib.printLibrary(lib)|indent(2) }}
   {%- endfor %}
 </LIBRARYS>

--- a/odxtools/templates/macros/printDiagLayer.xml.jinja2
+++ b/odxtools/templates/macros/printDiagLayer.xml.jinja2
@@ -22,6 +22,7 @@
 {%- import('macros/printResponse.xml.jinja2') as presp %}
 {%- import('macros/printStateChart.xml.jinja2') as psc %}
 {%- import('macros/printAudience.xml.jinja2') as paud %}
+{%- import('macros/printLibrary.xml.jinja2') as plib %}
 {%- import('macros/printSpecialData.xml.jinja2') as psd %}
 {%- import('macros/printEcuVariantPattern.xml.jinja2') as pvpat %}
 {%- import('macros/printAdminData.xml.jinja2') as pad %}
@@ -201,6 +202,13 @@
   {{ paud.printAdditionalAudience(audience)|indent(2) }}
   {%- endfor %}
 </ADDITIONAL-AUDIENCES>
+{%- endif %}
+{%- if dlr.librarys %}
+<LIBRARYS>
+  {%- for lib in dlr.librarys %}
+  {{ plib.printLibrary(lib)|indent(2) }}
+  {%- endfor %}
+</LIBRARYS>
 {%- endif %}
 {{- psd.printSpecialDataGroups(dlr.sdgs)|indent(0, first=True) }}
 {%- endmacro -%}

--- a/odxtools/templates/macros/printLibrary.xml.jinja2
+++ b/odxtools/templates/macros/printLibrary.xml.jinja2
@@ -1,0 +1,21 @@
+{#- -*- mode: sgml; tab-width: 1; indent-tabs-mode: nil -*-
+ #
+ # SPDX-License-Identifier: MIT
+-#}
+
+{%- import('macros/printElementId.xml.jinja2') as peid %}
+
+{%- macro printLibrary(library) %}
+<LIBRARY{#- #} {{-peid.printElementIdAttribs(library)}}{# -#}>
+  {{ peid.printElementIdSubtags(library)|indent(1) }}
+  <CODE-FILE>{{library.code_file}}</CODE-FILE>
+  {%- if library.encryption is not none %}
+  <ENCRYPTION>{{library.encryption}}</ENCRYPTION>
+  {%- endif %}
+  <SYNTAX>{{library.syntax}}</SYNTAX>
+  <REVISION>{{library.revision}}</REVISION>
+  {%- if library.entrypoint is not none %}
+  <ENTRYPOINT>{{library.entrypoint}}</ENTRYPOINT>
+  {%- endif %}
+</LIBRARY>
+{%- endmacro %}

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -5,13 +5,14 @@
 
 {%- import('macros/printElementId.xml.jinja2') as peid %}
 {%- import('macros/printDiagComm.xml.jinja2') as pdc %}
+{%- import('macros/printCompuMethod.xml.jinja2') as pcm %}
 
 {%- macro printSingleEcuJob(job) -%}
 <SINGLE-ECU-JOB {{pdc.printDiagCommAttribs(job)|indent(1) }}>
   {{pdc.printDiagCommSubtags(job) | indent(2, first=True) }}
   <PROG-CODES>
     {%- for prog in job.prog_codes %}
-    {{ printProgCode(prog)|indent(4) }}
+    {{ pcm.printProgCode(prog)|indent(4) }}
     {%- endfor %}
   </PROG-CODES>
   {%- if job.input_params %}
@@ -36,28 +37,6 @@
   </NEG-OUTPUT-PARAMS>
   {%- endif %}
 </SINGLE-ECU-JOB>
-{%- endmacro -%}
-
-
-{%- macro printProgCode(prog) -%}
-<PROG-CODE>
- <CODE-FILE>{{prog.code_file}}</CODE-FILE>
-{%- if prog.encryption %}
- <ENCRYPTION>{{prog.encryption}}</ENCRYPTION>
-{%- endif %}
- <SYNTAX>{{prog.syntax}}</SYNTAX>
- <REVISION>{{prog.revision}}</REVISION>
-{%- if prog.entrypoint %}
- <ENTRYPOINT>{{prog.entrypoint}}</ENTRYPOINT>
-{%- endif %}
-{%- if prog.library_refs %}
- <LIBRARY-REFS>
- {%- for ref in prog.library_refs %}
-   <LIBRARY-REF ID-REF="{{ref.ref_id}}" />
- {%- endfor %}
- </LIBRARY-REFS>
-{%- endif %}
-</PROG-CODE>
 {%- endmacro -%}
 
 

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -236,7 +236,7 @@ class TestIdentifyingService(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -362,7 +362,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -560,7 +560,7 @@ class TestDecoding(unittest.TestCase):
             comparam_refs=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = BaseVariant(diag_layer_raw=base_variant_raw)
@@ -717,7 +717,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -936,7 +936,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -1156,7 +1156,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -1509,7 +1509,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -1795,7 +1795,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -2038,7 +2038,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -2227,7 +2227,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -2426,7 +2426,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -236,6 +236,7 @@ class TestIdentifyingService(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -361,6 +362,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -558,6 +560,7 @@ class TestDecoding(unittest.TestCase):
             comparam_refs=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = BaseVariant(diag_layer_raw=base_variant_raw)
@@ -714,6 +717,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -932,6 +936,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -1151,6 +1156,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -1503,6 +1509,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -1788,6 +1795,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -2030,6 +2038,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -2218,6 +2227,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -2416,6 +2426,7 @@ class TestDecoding(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -299,7 +299,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -634,7 +634,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -979,7 +979,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -299,6 +299,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -633,6 +634,7 @@ class TestParamLengthInfoType(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -977,6 +979,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -225,6 +225,7 @@ def ecu_variant_1(
         ecu_variant_patterns=[ecu_variant_pattern1],
         diag_variables_raw=[],
         variable_groups=NamedItemList(),
+        librarys=NamedItemList(),
         dyn_defined_spec=None,
     )
     result = EcuVariant(diag_layer_raw=raw_layer)
@@ -266,6 +267,7 @@ def ecu_variant_2(
         ecu_variant_patterns=[ecu_variant_pattern2],
         diag_variables_raw=[],
         variable_groups=NamedItemList(),
+        librarys=NamedItemList(),
         dyn_defined_spec=None,
     )
     result = EcuVariant(diag_layer_raw=raw_layer)
@@ -308,6 +310,7 @@ def ecu_variant_3(
         ecu_variant_patterns=[ecu_variant_pattern1, ecu_variant_pattern3],
         diag_variables_raw=[],
         variable_groups=NamedItemList(),
+        librarys=NamedItemList(),
         dyn_defined_spec=None,
     )
     result = EcuVariant(diag_layer_raw=raw_layer)

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -225,7 +225,7 @@ def ecu_variant_1(
         ecu_variant_patterns=[ecu_variant_pattern1],
         diag_variables_raw=[],
         variable_groups=NamedItemList(),
-        librarys=NamedItemList(),
+        libraries=NamedItemList(),
         dyn_defined_spec=None,
     )
     result = EcuVariant(diag_layer_raw=raw_layer)
@@ -267,7 +267,7 @@ def ecu_variant_2(
         ecu_variant_patterns=[ecu_variant_pattern2],
         diag_variables_raw=[],
         variable_groups=NamedItemList(),
-        librarys=NamedItemList(),
+        libraries=NamedItemList(),
         dyn_defined_spec=None,
     )
     result = EcuVariant(diag_layer_raw=raw_layer)
@@ -310,7 +310,7 @@ def ecu_variant_3(
         ecu_variant_patterns=[ecu_variant_pattern1, ecu_variant_pattern3],
         diag_variables_raw=[],
         variable_groups=NamedItemList(),
-        librarys=NamedItemList(),
+        libraries=NamedItemList(),
         dyn_defined_spec=None,
     )
     result = EcuVariant(diag_layer_raw=raw_layer)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -396,6 +396,7 @@ class TestEncodeRequest(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -396,7 +396,7 @@ class TestEncodeRequest(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
 

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -28,6 +28,7 @@ from odxtools.diaglayers.ecuvariantraw import EcuVariantRaw
 from odxtools.exceptions import odxrequire
 from odxtools.functionalclass import FunctionalClass
 from odxtools.inputparam import InputParam
+from odxtools.library import Library
 from odxtools.nameditemlist import NamedItemList
 from odxtools.negoutputparam import NegOutputParam
 from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -463,6 +464,19 @@ class TestSingleEcuJob(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList([
+                Library(
+                    short_name="great_lib",
+                    long_name=None,
+                    description=None,
+                    odx_id=OdxLinkId("my.favourite.lib", doc_frags),
+                    oid=None,
+                    code_file="great_lib.py",
+                    encryption=None,
+                    syntax="PYTHON",
+                    revision="3.141529",
+                    entrypoint="i_am_great")
+            ]),
             dyn_defined_spec=None,
         )
         ecu_variant = EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -482,6 +496,10 @@ class TestSingleEcuJob(unittest.TestCase):
         db = Database()
         db.add_auxiliary_file("abc.jar",
                               BytesIO(b"this is supposed to be a JAR archive, but it isn't (HARR)"))
+        db.add_auxiliary_file(
+            "great_lib.py",
+            BytesIO(b"def i_am_great():\n"
+                    b"    print('The greatest algorithm eva!')"))
 
         ecu_variant._resolve_odxlinks(odxlinks)
         ecu_variant._finalize_init(db, odxlinks)

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -464,7 +464,7 @@ class TestSingleEcuJob(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList([
+            libraries=NamedItemList([
                 Library(
                     short_name="great_lib",
                     long_name=None,

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -212,7 +212,7 @@ class TestUnitSpec(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
-            librarys=NamedItemList(),
+            libraries=NamedItemList(),
             dyn_defined_spec=None,
         )
         dl = EcuVariant(diag_layer_raw=dl_raw)

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -212,6 +212,7 @@ class TestUnitSpec(unittest.TestCase):
             ecu_variant_patterns=[],
             diag_variables_raw=[],
             variable_groups=NamedItemList(),
+            librarys=NamedItemList(),
             dyn_defined_spec=None,
         )
         dl = EcuVariant(diag_layer_raw=dl_raw)


### PR DESCRIPTION
 AFAICS, these are pretty much equivalent to `PROG-CODE`.

Besides implementing libraries, this patch also fixes a few minor but important issues with the `PROG-CODE` handling.

(Note that ODX likes to pluralize everything by appending a `s` to the singular, so we get gems like `LIBRARYS` or `FUNCTIONAL-CLASSS` in the standard.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 