### PR TITLE
fix MinMaxLengthType error when encoding bytearray value

### DIFF
--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -74,7 +74,7 @@ class MinMaxLengthType(DiagCodedType):
     @override
     def encode_into_pdu(self, internal_value: AtomicOdxType, encode_state: EncodeState) -> None:
 
-        if not isinstance(internal_value, (bytes, str)):
+        if not isinstance(internal_value, (bytes, str, bytearray)):
             odxraise("MinMaxLengthType is currently only implemented for strings and byte arrays",
                      EncodeError)
 


### PR DESCRIPTION
Add `bytearray` in condition to verify the data type of `MinMaxLengthType` when `encode_into_pdu` parameter's value. #351 