### PR TITLE
attempt to fix issue #354 and #355

### DIFF
--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -120,6 +120,7 @@ class DtcDop(DopBase):
         return DiagnosticTroubleCode(
             trouble_code=trouble_code,
             odx_id=cast(OdxLinkId, None),
+            oid=None,
             short_name=f'DTC_{trouble_code:06x}',
             long_name=None,
             description=None,

--- a/odxtools/dyndefinedspec.py
+++ b/odxtools/dyndefinedspec.py
@@ -163,8 +163,6 @@ class DynDefinedSpec:
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
         result: Dict[OdxLinkId, Any] = {}
 
-        result.update(self._build_odxlinks())
-
         for didmi in self.dyn_id_def_mode_infos:
             result.update(didmi._build_odxlinks())
 


### PR DESCRIPTION
due to some copy-and-pasto, `DynDefinedSpec._build_odxlinks()` unconditionally called itself and the `oid` parameter was missing from the fallback code for DTC decoding. (Be aware that the latter points towards an incomplete dataset.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 