### PR TITLE
Priority should be given to local refs

### DIFF
--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -124,7 +124,7 @@ class DiagLayer:
             # imported references only apply within this specific
             # diagnostic layer
             extended_odxlinks = copy(odxlinks)
-            extended_odxlinks.update(imported_links)
+            extended_odxlinks.update(imported_links, False)
 
             self.diag_layer_raw._resolve_odxlinks(extended_odxlinks)
             return

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -124,7 +124,7 @@ class DiagLayer:
             # imported references only apply within this specific
             # diagnostic layer
             extended_odxlinks = copy(odxlinks)
-            extended_odxlinks.update(imported_links, False)
+            extended_odxlinks.update(imported_links, overwrite=False)
 
             self.diag_layer_raw._resolve_odxlinks(extended_odxlinks)
             return

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -124,7 +124,7 @@ class DiagLayer:
             # imported references only apply within this specific
             # diagnostic layer
             extended_odxlinks = copy(odxlinks)
-            extended_odxlinks.update(imported_links, False)
+            extended_odxlinks.update(imported_links)
 
             self.diag_layer_raw._resolve_odxlinks(extended_odxlinks)
             return

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -230,7 +230,7 @@ class OdxLinkDatabase:
 
         return None
 
-    def update(self, new_entries: Dict[OdxLinkId, Any], overwrite: bool = True) -> None:
+    def update(self, new_entries: Dict[OdxLinkId, Any]) -> None:
         """
         Add a bunch of new objects to the ODXLINK database.
 
@@ -244,10 +244,7 @@ class OdxLinkDatabase:
                 if doc_frag not in self._db:
                     self._db[doc_frag] = {}
 
-                if overwrite:
-                    self._db[doc_frag][odx_id.local_id] = obj
-                else:
-                    self._db[doc_frag].setdefault(odx_id.local_id, obj)
+                self._db[doc_frag][odx_id.local_id] = obj
 
 
 @overload

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -230,7 +230,7 @@ class OdxLinkDatabase:
 
         return None
 
-    def update(self, new_entries: Dict[OdxLinkId, Any], overwrite: bool = True) -> None:
+    def update(self, new_entries: Dict[OdxLinkId, Any], *, overwrite: bool = True) -> None:
         """
         Add a bunch of new objects to the ODXLINK database.
 

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -230,7 +230,7 @@ class OdxLinkDatabase:
 
         return None
 
-    def update(self, new_entries: Dict[OdxLinkId, Any]) -> None:
+    def update(self, new_entries: Dict[OdxLinkId, Any], overwrite: bool = True) -> None:
         """
         Add a bunch of new objects to the ODXLINK database.
 
@@ -244,7 +244,10 @@ class OdxLinkDatabase:
                 if doc_frag not in self._db:
                     self._db[doc_frag] = {}
 
-                self._db[doc_frag][odx_id.local_id] = obj
+                if overwrite:
+                    self._db[doc_frag][odx_id.local_id] = obj
+                else:
+                    self._db[doc_frag].setdefault(odx_id.local_id, obj)
 
 
 @overload


### PR DESCRIPTION
This merge request introduces an "overwrite" parameter to the update method of the OdxLinkDatabase class. This parameter, set to False for imported references, allows local references to take priority over imported ones.

In diaglayer. _resolve_odxlinks, the overwrite=False setting ensures that imported references do not override locally defined references. 

odxtools version: 8.0.5