### PR TITLE
print_utils: minor cleanups

### DIFF
--- a/odxtools/cli/compare.py
+++ b/odxtools/cli/compare.py
@@ -131,8 +131,7 @@ class Display:
                         rich_print()
                 if self.param_detailed:
                     # print all parameter details of diagnostic service
-                    print_service_parameters(
-                        service, allow_unknown_bit_lengths=True, print_fn=rich_print)
+                    print_service_parameters(service, allow_unknown_bit_lengths=True)
 
     def print_database_changes(self, changes_variants: SpecsChangesVariants) -> None:
         # prints result of database comparison (input variable: dictionary: changes_variants)
@@ -659,8 +658,7 @@ def run(args: argparse.Namespace) -> None:
             print_dl_metrics([
                 variant for variant in task.databases[0].diag_layers
                 if variant.short_name in task.diagnostic_layer_names
-            ],
-                             print_fn=rich_print)
+            ])
 
             rich_print()
             rich_print(
@@ -668,8 +666,7 @@ def run(args: argparse.Namespace) -> None:
             print_dl_metrics([
                 variant for variant in task.databases[db_idx + 1].diag_layers
                 if variant.short_name in task.diagnostic_layer_names
-            ],
-                             print_fn=rich_print)
+            ])
 
             task.print_database_changes(
                 task.compare_databases(task.databases[0], task.databases[db_idx + 1]))
@@ -700,12 +697,12 @@ def run(args: argparse.Namespace) -> None:
 
             rich_print()
             rich_print(f"Overview of diagnostic layers (for {os.path.basename(db_names[0])})")
-            print_dl_metrics(list(task.databases[0].diag_layers), print_fn=rich_print)
+            print_dl_metrics(list(task.databases[0].diag_layers))
 
             rich_print()
             rich_print(
                 f"Overview of diagnostic layers (for {os.path.basename(db_names[db_idx+1])})")
-            print_dl_metrics(list(task.databases[db_idx + 1].diag_layers), print_fn=rich_print)
+            print_dl_metrics(list(task.databases[db_idx + 1].diag_layers))
 
             task.print_database_changes(
                 task.compare_databases(task.databases[0], task.databases[db_idx + 1]))
@@ -731,7 +728,7 @@ def run(args: argparse.Namespace) -> None:
 
         rich_print()
         rich_print(f"Overview of diagnostic layers: ")
-        print_dl_metrics(task.diagnostic_layers, print_fn=rich_print)
+        print_dl_metrics(task.diagnostic_layers)
 
         for db_idx, dl in enumerate(task.diagnostic_layers):
             if db_idx + 1 >= len(task.diagnostic_layers):

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -52,7 +52,7 @@ def print_summary(odxdb: Database,
     if diag_layers:
         rich.print("\n")
         rich.print(f"Overview of diagnostic layers: ")
-        print_dl_metrics(diag_layers, print_fn=rich.print)
+        print_dl_metrics(diag_layers)
 
     for dl in diag_layers:
         rich.print("\n")
@@ -93,8 +93,7 @@ def print_summary(odxdb: Database,
                             print_pre_condition_states=print_pre_condition_states,
                             print_state_transitions=print_state_transitions,
                             print_audiences=print_audiences,
-                            allow_unknown_bit_lengths=allow_unknown_bit_lengths,
-                            print_fn=rich.print)
+                            allow_unknown_bit_lengths=allow_unknown_bit_lengths)
                     elif isinstance(service, SingleEcuJob):
                         rich.print(f" Single ECU job: {service.odx_id}")
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "markdownify >= 0.11",
     "deprecation >= 2.1",
     "packaging",
-    "tabulate >= 0.9",
     "rich >= 13.7",
     "typing_extensions >= 4.9",
 ]


### PR DESCRIPTION
this is a minor follow-up to https://github.com/mercedes-benz/odxtools/pull/359: table columns are now always of type `List[str]`, better variable names for the column lists (´*_column´) and removal of the now unused `tabulate` dependency...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 