### PR TITLE
remove all deprecated functionality

### DIFF
--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -8,8 +8,6 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
                     Union, cast)
 from xml.etree import ElementTree
 
-from deprecation import deprecated
-
 from ..additionalaudience import AdditionalAudience
 from ..admindata import AdminData
 from ..comparaminstance import ComparamInstance
@@ -724,10 +722,6 @@ class HierarchyElement(DiagLayer):
 
         return int(result)
 
-    @deprecated(details="use get_can_receive_id()")  # type: ignore[misc]
-    def get_receive_id(self) -> Optional[int]:
-        return self.get_can_receive_id()
-
     def get_can_send_id(self, protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:
         """CAN ID to which the ECU sends replies to diagnostic messages"""
 
@@ -752,10 +746,6 @@ class HierarchyElement(DiagLayer):
         odxassert(isinstance(result, str))
 
         return int(result)
-
-    @deprecated(details="use get_can_send_id()")  # type: ignore[misc]
-    def get_send_id(self) -> Optional[int]:
-        return self.get_can_send_id()
 
     def get_can_func_req_id(self,
                             protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:

--- a/odxtools/inputparam.py
+++ b/odxtools/inputparam.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree
 
-from deprecation import deprecated
-
 from .dopbase import DopBase
 from .element import NamedElement
 from .exceptions import odxrequire
@@ -48,9 +46,4 @@ class InputParam(NamedElement):
     @property
     def dop_base(self) -> DopBase:
         """The data object property describing this parameter."""
-        return self._dop_base
-
-    @property
-    @deprecated(details="use .dop_base")  # type: ignore[misc]
-    def dop(self) -> DopBase:
         return self._dop_base

--- a/odxtools/message.py
+++ b/odxtools/message.py
@@ -2,8 +2,6 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
-from deprecation import deprecated
-
 from .odxtypes import ParameterValue, ParameterValueDict
 
 if TYPE_CHECKING:
@@ -29,8 +27,3 @@ class Message:
 
     def __getitem__(self, key: str) -> ParameterValue:
         return self.param_dict[key]
-
-    @property
-    @deprecated("use .coding_object")  # type: ignore[misc]
-    def structure(self) -> Union["Request", "Response"]:
-        return self.coding_object

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree
 
-from deprecation import deprecated
-
 from .dopbase import DopBase
 from .element import IdentifiableElement
 from .exceptions import odxrequire
@@ -39,9 +37,4 @@ class OutputParam(IdentifiableElement):
     @property
     def dop_base(self) -> DopBase:
         """The data object property describing this parameter."""
-        return self._dop_base
-
-    @property
-    @deprecated(details="use .dop_base")  # type: ignore[misc]
-    def dop(self) -> DopBase:
         return self._dop_base

--- a/odxtools/uds.py
+++ b/odxtools/uds.py
@@ -3,8 +3,6 @@ from enum import IntEnum
 from itertools import chain
 from typing import Optional
 
-from deprecation import deprecated
-
 import odxtools.obd as obd
 
 
@@ -170,9 +168,3 @@ def is_response_pending(telegram_payload: bytes, request_sid: Optional[int] = No
 
     # if all of the above applies, we received a "stay tuned" response
     return True
-
-
-# previous versions of odxtools had a typo here. hit happens!
-@deprecated(details="use is_response_pending()")  # type: ignore[misc]
-def is_reponse_pending(telegram_payload: bytes, request_sid: Optional[int] = None) -> bool:
-    return is_response_pending(telegram_payload, request_sid)


### PR DESCRIPTION
This emerged in the context of https://github.com/mercedes-benz/odxtools/pull/364. We remove all deprecated functionality. All of this has been deprecated for at least a year, so the impact should not be too big. (Anyway, since this is a potentially breaking change, the next odxtools release after this patch will be 9.0.0)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 