### PR TITLE
Add Pickle support

### DIFF
--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -189,6 +189,12 @@ class ItemAttributeList(List[T]):
 
         return result
 
+    def __reduce__(self):
+        reconstruct_function = self.__class__
+        args = (list(self),)
+        state = {"_item_dict": self._item_dict}
+        return reconstruct_function, args, state
+
 
 class NamedItemList(ItemAttributeList[T]):
 

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -189,7 +189,7 @@ class ItemAttributeList(List[T]):
 
         return result
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Any, ...]:
         reconstruct_function = self.__class__
         args = (list(self),)
         state = {"_item_dict": self._item_dict}

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -190,10 +190,14 @@ class ItemAttributeList(List[T]):
         return result
 
     def __reduce__(self) -> Tuple[Any, ...]:
-        reconstruct_function = self.__class__
-        args = (list(self),)
-        state = {"_item_dict": self._item_dict}
-        return reconstruct_function, args, state
+        """Support for Python's pickle protocol.
+        This method ensures that the object can be reconstructed with its current state,
+        using its class and the list of items it contains.
+        It returns a tuple containing the reconstruction function (the class)
+        and its arguments necessary to recreate the object.
+
+        """
+        return self.__class__, (list(self),)
 
 
 class NamedItemList(ItemAttributeList[T]):

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -157,3 +157,10 @@ class TableRow(IdentifiableElement):
     def dop(self) -> Optional[DataObjectProperty]:
         """The data object property object resolved by dop_ref."""
         return self._dop
+
+    def __reduce__(self):
+        state = self.__dict__.copy()
+        return (self.__class__, (self.short_name, self.long_name, self.description, self.odx_id,
+                                 self.oid, self.table_ref, self.key_raw, self.structure_ref,
+                                 self.structure_snref, self.dop_ref, self.dop_snref, self.semantic,
+                                 self.sdgs), state)

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from xml.etree import ElementTree
 
@@ -159,8 +159,6 @@ class TableRow(IdentifiableElement):
         return self._dop
 
     def __reduce__(self) -> Tuple[Any, ...]:
+        """This ensures that the object can be correctly reconstructed during unpickling."""
         state = self.__dict__.copy()
-        return (self.__class__,
-                (self.short_name, self.long_name, self.description, self.odx_id, self.oid,
-                 self.table_ref, self.key_raw, self.structure_ref, self.structure_snref,
-                 self.dop_ref, self.dop_snref, self.semantic, self.sdgs), state)
+        return self.__class__, tuple([getattr(self, x.name) for x in fields(self)]), state

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
@@ -158,9 +158,9 @@ class TableRow(IdentifiableElement):
         """The data object property object resolved by dop_ref."""
         return self._dop
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Any, ...]:
         state = self.__dict__.copy()
-        return (self.__class__, (self.short_name, self.long_name, self.description, self.odx_id,
-                                 self.oid, self.table_ref, self.key_raw, self.structure_ref,
-                                 self.structure_snref, self.dop_ref, self.dop_snref, self.semantic,
-                                 self.sdgs), state)
+        return (self.__class__,
+                (self.short_name, self.long_name, self.description, self.odx_id, self.oid,
+                 self.table_ref, self.key_raw, self.structure_ref, self.structure_snref,
+                 self.dop_ref, self.dop_snref, self.semantic, self.sdgs), state)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import pickle
 import unittest
 
 from odxtools.compumethods.compuinternaltophys import CompuInternalToPhys
@@ -2446,6 +2447,12 @@ class TestDecoding(unittest.TestCase):
             self.assertEqual(expected_message.service, decoded_message.service)
             self.assertEqual(expected_message.coding_object, decoded_message.coding_object)
             self.assertEqual(expected_message.param_dict, decoded_message.param_dict)
+
+        # check object serialization and deserialization using pickle
+        pickled_ecu_var = pickle.dumps(ecu_variant)
+        unpickled_ecu_var = pickle.loads(pickled_ecu_var)
+
+        self.assertEqual(ecu_variant, unpickled_ecu_var)
 
     def test_code_dtc(self) -> None:
         odxlinks = OdxLinkDatabase()

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import pickle
 import unittest
 from copy import copy
 
@@ -427,6 +428,11 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             coded_message=copy(encode_state.coded_message), cursor_byte_position=2)
         decoded = mux.decode_from_pdu(decode_state)
         self.assertEqual(decoded, ("default_case", {}))
+
+        # check that the object can be properly serialized and deserialized using pickle
+        pickled_ddds = pickle.dumps(ddds)
+        unpickled_ddds = pickle.loads(pickled_ddds)
+        self.assertEqual(ddds, unpickled_ddds)
 
 
 if __name__ == "__main__":

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import pickle
 import unittest
 from copy import copy
 
@@ -428,11 +427,6 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             coded_message=copy(encode_state.coded_message), cursor_byte_position=2)
         decoded = mux.decode_from_pdu(decode_state)
         self.assertEqual(decoded, ("default_case", {}))
-
-        # check that the object can be properly serialized and deserialized using pickle
-        pickled_ddds = pickle.dumps(ddds)
-        unpickled_ddds = pickle.loads(pickled_ddds)
-        self.assertEqual(ddds, unpickled_ddds)
 
 
 if __name__ == "__main__":

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -99,17 +99,15 @@ class X:
 
 class TestNamedItemList(unittest.TestCase):
 
-    def setUp(self) -> None:
-        self.foo_obj = NamedItemList([X("hello", 0), X("world", 1)])
-
     def test_NamedItemList(self) -> None:
-        # Test with the original object
-        foo = self.foo_obj.__class__(self.foo_obj)
-        self._test_NamedItemList_functionality(foo)
+        foo = NamedItemList([X("hello", 0), X("world", 1)])
 
-        # Test with the pickled object
-        pickled_foo = pickle.dumps(self.foo_obj)
+        pickled_foo = pickle.dumps(foo)
         unpickled_foo = pickle.loads(pickled_foo)
+
+        # Test with the original object
+        self._test_NamedItemList_functionality(foo)
+        # Test with the pickled object
         self._test_NamedItemList_functionality(unpickled_foo)
 
     def _test_NamedItemList_functionality(self, foo: NamedItemList[X]) -> None:

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -98,6 +98,7 @@ class X:
 
 
 class TestNamedItemList(unittest.TestCase):
+    
     def setUp(self) -> None:
         self.foo_obj = NamedItemList([X("hello", 0), X("world", 1)])
 

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import pickle
 import unittest
 from dataclasses import dataclass
 from typing import List
@@ -90,16 +91,28 @@ class TestComposeUDS(unittest.TestCase):
         self.assertEqual(bytes(coded_response), bytes.fromhex("faba03"))
 
 
+@dataclass
+class X:
+    short_name: str
+    value: int
+    
+
 class TestNamedItemList(unittest.TestCase):
 
-    def test_NamedItemList(self) -> None:
+    def setUp(self):
+        self.foo_obj = NamedItemList([X("hello", 0), X("world", 1)])
 
-        @dataclass
-        class X:
-            short_name: str
-            value: int
+    def test_NamedItemList(self):
+        # Test with the original object
+        foo = self.foo_obj.__class__(self.foo_obj)
+        self._test_NamedItemList_functionality(foo)
 
-        foo = NamedItemList([X("hello", 0), X("world", 1)])
+        # Test with the pickled object
+        pickled_foo = pickle.dumps(self.foo_obj)
+        unpickled_foo = pickle.loads(pickled_foo)
+        self._test_NamedItemList_functionality(unpickled_foo)
+
+    def _test_NamedItemList_functionality(self, foo):
         self.assertEqual(foo.hello, X("hello", 0))
         self.assertEqual(foo[0], X("hello", 0))
         self.assertEqual(foo[1], X("world", 1))

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -98,7 +98,7 @@ class X:
 
 
 class TestNamedItemList(unittest.TestCase):
-    
+
     def setUp(self) -> None:
         self.foo_obj = NamedItemList([X("hello", 0), X("world", 1)])
 

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -95,14 +95,13 @@ class TestComposeUDS(unittest.TestCase):
 class X:
     short_name: str
     value: int
-    
+
 
 class TestNamedItemList(unittest.TestCase):
-
-    def setUp(self):
+    def setUp(self) -> None:
         self.foo_obj = NamedItemList([X("hello", 0), X("world", 1)])
 
-    def test_NamedItemList(self):
+    def test_NamedItemList(self) -> None:
         # Test with the original object
         foo = self.foo_obj.__class__(self.foo_obj)
         self._test_NamedItemList_functionality(foo)
@@ -112,7 +111,7 @@ class TestNamedItemList(unittest.TestCase):
         unpickled_foo = pickle.loads(pickled_foo)
         self._test_NamedItemList_functionality(unpickled_foo)
 
-    def _test_NamedItemList_functionality(self, foo):
+    def _test_NamedItemList_functionality(self, foo: NamedItemList[X]) -> None:
         self.assertEqual(foo.hello, X("hello", 0))
         self.assertEqual(foo[0], X("hello", 0))
         self.assertEqual(foo[1], X("world", 1))


### PR DESCRIPTION
I am working on caching the PDX config parsing result to avoid reparsing it each time, using Pickle for serialization.

During the pickling process, no issues were encountered. However, during the unpickling step, the following exception occurred: "maximum recursion depth exceeded" which originated in the NamedItemList class.
The recursion occurred due to infinite calls to the NamedItemList.\_\_getattr__ method. Specifically, the code attempted to access a property that was uninitialized at the time, causing the \_\_getattr__ to be invoked repeatedly during the reconstruction of the object.
To address this, I added the \_\_reduce__ method which explicitly defines how an object is serialized and reconstructed during pickling and unpickling. After adding this method, the recursion issue was resolved.

After fixing the recursion issue, I got the following exception with some PDX files during the unpickling:

![image](https://github.com/user-attachments/assets/9e23a870-fa9a-4245-808f-3787317e3725)

This issue arises because the NamedItemList assumes all its elements conform to the OdxNamed interface, including having a short_name attribute. While the PDX files were correctly parsed initially, the issue arose because TableRow objects were reconstructed in a state where their short_name attribute was not properly restored or initialized.
Thus, the solution was to add the \_\_reduce__ method for the TableRow class, ensuring its attributes are correctly restored during unpickling.

odxtools: 8.3.4