### PR TITLE
resolve snrefs for child items

### DIFF
--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -187,7 +187,12 @@ class DiagService(DiagComm):
         # here because ComparamInstance.short_name is only valid after
         # reference resolution
         self._comparams = NamedItemList(self.comparam_refs)
-
+        if self._request:
+            self._request._resolve_snrefs(context)
+        for response in self._positive_responses:
+            response._resolve_snrefs(context)
+        for response in self._negative_responses:
+            response._resolve_snrefs(context)
         context.diag_service = None
 
     def decode_message(self, raw_message: bytes) -> Message:

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -89,3 +89,7 @@ class Field(ComplexDop):
         if self.env_data_desc_snref is not None:
             self._env_data_desc = resolve_snref(self.env_data_desc_snref, ddds.env_data_descs,
                                                 EnvironmentDataDescription)
+        if self._structure:
+            self._structure._resolve_snrefs(context)
+        if self._env_data_desc:
+            self._env_data_desc._resolve_snrefs(context)

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -62,6 +62,8 @@ class ParameterWithDOP(Parameter):
         if self.dop_snref:
             ddds = odxrequire(context.diag_layer).diag_data_dictionary_spec
             self._dop = resolve_snref(self.dop_snref, ddds.all_data_object_properties, DopBase)
+        if self._dop:
+            self._dop._resolve_snrefs(context)
 
     @property
     def dop(self) -> DopBase:

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -91,6 +91,7 @@ class TableKeyParameter(Parameter):
                 self._table_row = odxlinks.resolve(self.table_row_ref, TableRow)
             else:
                 self._table_row = odxlinks.resolve(self.table_row_ref)
+            self._table_row._resolve_odxlinks(odxlinks)
             self._table = self._table_row.table
 
     @override


### PR DESCRIPTION
for issue #368, current solution is to resolve snrefs based on current variant context before trying to access it. To get the correct result, the snrefs of child items  should be resolved when calling its parent's _resolve_snrefs. So I add code to do the work for some missing items