### PR TITLE
More enums

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -43,7 +43,7 @@ from odxtools.exceptions import odxrequire
 from odxtools.functionalclass import FunctionalClass
 from odxtools.modification import Modification
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
 from odxtools.parameters.matchingrequestparameter import MatchingRequestParameter
@@ -90,12 +90,12 @@ SID: Any = IntEnum("SID", tmp)  # type: ignore[misc]
 dlc_short_name = "somersault"
 
 # document fragment for everything except the communication parameters
-doc_frags = [OdxDocFragment(dlc_short_name, "CONTAINER")]
+doc_frags = [OdxDocFragment(dlc_short_name, DocType.CONTAINER)]
 
 # document fragments for communication parameters
-cp_dwcan_doc_frags = [OdxDocFragment("ISO_11898_2_DWCAN", "COMPARAM-SUBSET")]
-cp_iso15765_2_doc_frags = [OdxDocFragment("ISO_15765_2", "COMPARAM-SUBSET")]
-cp_iso15765_3_doc_frags = [OdxDocFragment("ISO_15765_3", "COMPARAM-SUBSET")]
+cp_dwcan_doc_frags = [OdxDocFragment("ISO_11898_2_DWCAN", DocType.COMPARAM_SUBSET)]
+cp_iso15765_2_doc_frags = [OdxDocFragment("ISO_15765_2", DocType.COMPARAM_SUBSET)]
+cp_iso15765_3_doc_frags = [OdxDocFragment("ISO_15765_3", DocType.COMPARAM_SUBSET)]
 
 ##################
 # Base variant of Somersault ECU
@@ -2345,8 +2345,9 @@ somersault_protocol_raw = ProtocolRaw(
     additional_audiences=NamedItemList(),
     sdgs=[],
     parent_refs=[],
-    comparam_spec_ref=OdxLinkRef("CPS_ISO_15765_3_on_ISO_15765_2",
-                                 [OdxDocFragment("ISO_15765_3_on_ISO_15765_2", "COMPARAM-SPEC")]),
+    comparam_spec_ref=OdxLinkRef("CPS_ISO_15765_3_on_ISO_15765_2", [
+        OdxDocFragment("ISO_15765_3_on_ISO_15765_2", DocType.COMPARAM_SPEC)
+    ]),
     comparam_refs=somersault_comparam_refs,
     libraries=NamedItemList(),
     prot_stack_snref=None,

--- a/odxtools/comparamspec.py
+++ b/odxtools/comparamspec.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 
 from .nameditemlist import NamedItemList
 from .odxcategory import OdxCategory
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .protstack import ProtStack
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -16,12 +16,13 @@ if TYPE_CHECKING:
 
 @dataclass
 class ComparamSpec(OdxCategory):
+
     prot_stacks: NamedItemList[ProtStack]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ComparamSpec":
 
-        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type="COMPARAM-SPEC")
+        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type=DocType.COMPARAM_SPEC)
         doc_frags = cat.odx_id.doc_fragments
         kwargs = dataclass_fields_asdict(cat)
 

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -8,7 +8,7 @@ from .complexcomparam import ComplexComparam
 from .dataobjectproperty import DataObjectProperty
 from .nameditemlist import NamedItemList
 from .odxcategory import OdxCategory
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .unitspec import UnitSpec
 from .utils import dataclass_fields_asdict
@@ -19,19 +19,17 @@ if TYPE_CHECKING:
 
 @dataclass
 class ComparamSubset(OdxCategory):
-    # mandatory in ODX 2.2, but non-existent in ODX 2.0
-    category: Optional[str]
-
     comparams: NamedItemList[Comparam]
     complex_comparams: NamedItemList[ComplexComparam]
     data_object_props: NamedItemList[DataObjectProperty]
     unit_spec: Optional[UnitSpec]
+    category: Optional[str]  # mandatory in ODX 2.2, but non-existent in ODX 2.0
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "ComparamSubset":
 
-        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type="COMPARAM-SUBSET")
+        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type=DocType.COMPARAM_SUBSET)
         doc_frags = cat.odx_id.doc_fragments
         kwargs = dataclass_fields_asdict(cat)
 

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -12,7 +12,7 @@ from .diaglayers.functionalgroup import FunctionalGroup
 from .diaglayers.protocol import Protocol
 from .nameditemlist import NamedItemList
 from .odxcategory import OdxCategory
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -48,7 +48,7 @@ class DiagLayerContainer(OdxCategory):
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "DiagLayerContainer":
 
-        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type="CONTAINER")
+        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type=DocType.CONTAINER)
         doc_frags = cat.odx_id.doc_fragments
         kwargs = dataclass_fields_asdict(cat)
 

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -15,7 +15,7 @@ from ..exceptions import odxassert, odxraise, odxrequire
 from ..functionalclass import FunctionalClass
 from ..library import Library
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..request import Request
 from ..response import Response
 from ..singleecujob import SingleEcuJob
@@ -81,7 +81,7 @@ class DiagLayerRaw(IdentifiableElement):
 
         # extend the applicable ODX "document fragments" for the diag layer objects
         doc_frags = copy(doc_frags)
-        doc_frags.append(OdxDocFragment(short_name, "LAYER"))
+        doc_frags.append(OdxDocFragment(short_name, DocType.LAYER))
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         admin_data = None

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -8,7 +8,7 @@ from .companydata import CompanyData
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
 from .utils import dataclass_fields_asdict
@@ -32,7 +32,7 @@ class OdxCategory(IdentifiableElement):
 
     @staticmethod
     def category_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
-                         doc_type: str) -> "OdxCategory":
+                         doc_type: DocType) -> "OdxCategory":
 
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         # create the current ODX "document fragment" (description of the

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -15,7 +15,7 @@
                  {{-make_xml_attrib("BASE-TYPE-ENCODING", dct.base_type_encoding and dct.base_type_encoding.value)}}
                  {{-make_bool_xml_attrib("IS-HIGHLOW-BYTE-ORDER", dct.is_highlow_byte_order_raw)}}
                  {%- if dct.termination is defined %}
-                 {{-make_xml_attrib("TERMINATION", dct.termination)}}
+                 {{-make_xml_attrib("TERMINATION", dct.termination.value)}}
                  {%- endif %}
                  {#- #} xsi:type="{{dct.dct_type}}">
  {%- if dct.dct_type in ("STANDARD-LENGTH-TYPE", "LEADING-LENGTH-INFO-TYPE") %}

--- a/odxtools/templates/macros/printProtocol.xml.jinja2
+++ b/odxtools/templates/macros/printProtocol.xml.jinja2
@@ -13,7 +13,7 @@
   {%- set dlr = protocol.protocol_raw %}
 
   {%- set cps_docfrag = dlr.comparam_spec_ref.ref_docs[-1] %}
-  <COMPARAM-SPEC-REF ID-REF="{{dlr.comparam_spec_ref.ref_id}}" DOCREF="{{cps_docfrag.doc_name}}" DOCTYPE="{{cps_docfrag.doc_type}}" />
+  <COMPARAM-SPEC-REF ID-REF="{{dlr.comparam_spec_ref.ref_id}}" DOCREF="{{cps_docfrag.doc_name}}" DOCTYPE="{{cps_docfrag.doc_type.value}}" />
 
   {%- if dlr.prot_stack_snref is not none %}
   <PROT-STACK-SNREF SHORT-NAME="{{ dlr.prot_stack_snref }}" />

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -21,13 +21,13 @@ from odxtools.compumethods.ratfunccompumethod import RatFuncCompuMethod
 from odxtools.compumethods.scaleratfunccompumethod import ScaleRatFuncCompuMethod
 from odxtools.compumethods.tabintpcompumethod import TabIntpCompuMethod
 from odxtools.exceptions import DecodeError, EncodeError, OdxError
-from odxtools.odxlink import OdxDocFragment
+from odxtools.odxlink import DocType, OdxDocFragment
 from odxtools.odxtypes import DataType
 from odxtools.progcode import ProgCode
 from odxtools.writepdxfile import (get_parent_container_name, jinja2_odxraise_helper,
                                    make_bool_xml_attrib, make_xml_attrib)
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestLinearCompuMethod(unittest.TestCase):

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -26,7 +26,7 @@ from odxtools.dynenddopref import DynEndDopRef
 from odxtools.endofpdufield import EndOfPduField
 from odxtools.exceptions import DecodeError, DecodeMismatch
 from odxtools.message import Message
-from odxtools.minmaxlengthtype import MinMaxLengthType
+from odxtools.minmaxlengthtype import MinMaxLengthType, Termination
 from odxtools.nameditemlist import NamedItemList
 from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType, ParameterValueDict
@@ -2581,7 +2581,7 @@ class TestDecodingAndEncoding(unittest.TestCase):
                 base_data_type=DataType.A_BYTEFIELD,
                 min_length=0,
                 max_length=None,
-                termination="END-OF-PDU",
+                termination=Termination.END_OF_PDU,
                 base_type_encoding=None,
                 is_highlow_byte_order_raw=None,
             ),

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -28,7 +28,7 @@ from odxtools.exceptions import DecodeError, DecodeMismatch
 from odxtools.message import Message
 from odxtools.minmaxlengthtype import MinMaxLengthType
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType, ParameterValueDict
 from odxtools.parameters.codedconstparameter import CodedConstParameter
 from odxtools.parameters.matchingrequestparameter import MatchingRequestParameter
@@ -44,7 +44,7 @@ from odxtools.standardlengthtype import StandardLengthType
 from odxtools.staticfield import StaticField
 from odxtools.structure import Structure
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestIdentifyingService(unittest.TestCase):

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -24,7 +24,7 @@ from odxtools.exceptions import DecodeError, EncodeError, OdxError, odxrequire
 from odxtools.leadinglengthinfotype import LeadingLengthInfoType
 from odxtools.minmaxlengthtype import MinMaxLengthType
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
 from odxtools.parameters.lengthkeyparameter import LengthKeyParameter
@@ -34,7 +34,7 @@ from odxtools.physicaltype import PhysicalType
 from odxtools.request import Request
 from odxtools.standardlengthtype import StandardLengthType
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestLeadingLengthInfoType(unittest.TestCase):

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -22,7 +22,7 @@ from odxtools.encodestate import EncodeState
 from odxtools.encoding import Encoding
 from odxtools.exceptions import DecodeError, EncodeError, OdxError, odxrequire
 from odxtools.leadinglengthinfotype import LeadingLengthInfoType
-from odxtools.minmaxlengthtype import MinMaxLengthType
+from odxtools.minmaxlengthtype import MinMaxLengthType, Termination
 from odxtools.nameditemlist import NamedItemList
 from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
@@ -680,7 +680,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             base_type_encoding=None,
             min_length=1,
             max_length=4,
-            termination="HEX-FF",
+            termination=Termination.HEX_FF,
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0xFF, 0x34, 0x56, 0xFF]), cursor_byte_position=1)
@@ -695,7 +695,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             base_type_encoding=None,
             min_length=2,
             max_length=4,
-            termination="HEX-FF",
+            termination=Termination.HEX_FF,
             is_highlow_byte_order_raw=None,
         )
         state = DecodeState(bytes([0x12, 0xFF]), cursor_byte_position=1)
@@ -703,7 +703,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
     def test_decode_min_max_length_type_end_of_pdu(self) -> None:
         """If the PDU ends before max length is reached, the extracted value ends at the end of the PDU."""
-        for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
+        for termination in [Termination.END_OF_PDU, Termination.HEX_FF, Termination.ZERO]:
             dct = MinMaxLengthType(
                 base_data_type=DataType.A_BYTEFIELD,
                 base_type_encoding=None,
@@ -719,7 +719,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
     def test_decode_min_max_length_type_max_length(self) -> None:
         """If the max length is smaller than the end of PDU, the extracted value ends after max length."""
-        for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
+        for termination in [Termination.END_OF_PDU, Termination.HEX_FF, Termination.ZERO]:
             dct = MinMaxLengthType(
                 base_data_type=DataType.A_BYTEFIELD,
                 base_type_encoding=None,
@@ -739,7 +739,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             base_type_encoding=None,
             min_length=1,
             max_length=4,
-            termination="HEX-FF",
+            termination=Termination.HEX_FF,
             is_highlow_byte_order_raw=None,
         )
         state = EncodeState(is_end_of_pdu=False)
@@ -752,7 +752,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             base_type_encoding=None,
             min_length=2,
             max_length=4,
-            termination="ZERO",
+            termination=Termination.ZERO,
             is_highlow_byte_order_raw=None,
         )
         state = EncodeState(is_end_of_pdu=False)
@@ -761,7 +761,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
     def test_encode_min_max_length_type_end_of_pdu(self) -> None:
         """If the parameter is at the end of the PDU, no termination char is added."""
-        for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
+        for termination in [Termination.END_OF_PDU, Termination.HEX_FF, Termination.ZERO]:
             dct = MinMaxLengthType(
                 base_data_type=DataType.A_BYTEFIELD,
                 base_type_encoding=None,
@@ -774,7 +774,7 @@ class TestMinMaxLengthType(unittest.TestCase):
             dct.encode_into_pdu(bytes([0x34, 0x56, 0x78, 0x9A]), state)
             self.assertEqual(state.coded_message.hex(), "3456789a")
 
-            if termination == "END-OF-PDU":
+            if termination == Termination.END_OF_PDU:
                 state = EncodeState(coded_message=bytearray(), is_end_of_pdu=False)
                 self.assertRaises(OdxError, dct.encode_into_pdu, bytes([0x34, 0x56, 0x78, 0x9A]),
                                   state)
@@ -785,7 +785,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
     def test_encode_min_max_length_type_min_length(self) -> None:
         """If the internal value is smaller than min length, an EncodeError must be raised."""
-        for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
+        for termination in [Termination.END_OF_PDU, Termination.HEX_FF, Termination.ZERO]:
             dct = MinMaxLengthType(
                 base_data_type=DataType.A_BYTEFIELD,
                 base_type_encoding=None,
@@ -806,7 +806,7 @@ class TestMinMaxLengthType(unittest.TestCase):
 
     def test_encode_min_max_length_type_max_length(self) -> None:
         """If the internal value is larger than max length, an EncodeError must be raised."""
-        for termination in ["END-OF-PDU", "HEX-FF", "ZERO"]:
+        for termination in [Termination.END_OF_PDU, Termination.HEX_FF, Termination.ZERO]:
             dct = MinMaxLengthType(
                 base_data_type=DataType.A_BYTEFIELD,
                 base_type_encoding=None,
@@ -843,7 +843,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                     base_type_encoding=None,
                     min_length=2,
                     max_length=10,
-                    termination="ZERO",
+                    termination=Termination.ZERO,
                     is_highlow_byte_order_raw=None,
                 ),
         }
@@ -878,7 +878,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                     admin_data=None,
                     diag_coded_type=diagcodedtypes["certificateClient"],
                     physical_type=PhysicalType(
-                        DataType.A_BYTEFIELD, display_radix=None, precision=None),
+                        base_data_type=DataType.A_BYTEFIELD, display_radix=None, precision=None),
                     compu_method=compumethods["bytes_passthrough"],
                     unit_ref=None,
                     sdgs=[],
@@ -1018,14 +1018,14 @@ class TestMinMaxLengthType(unittest.TestCase):
             base_type_encoding=Encoding.ISO_8859_1,
             min_length=8,
             max_length=16,
-            termination="ZERO",
+            termination=Termination.ZERO,
             is_highlow_byte_order_raw=None,
         )
 
         # diag-coded-type requires xsi namespace
         diagcodedtype_odx = f"""
         <ODX xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <DIAG-CODED-TYPE BASE-TYPE-ENCODING="{expected.base_type_encoding and expected.base_type_encoding.value}" BASE-DATA-TYPE="{expected.base_data_type.value}" TERMINATION="{expected.termination}" xsi:type="MIN-MAX-LENGTH-TYPE">
+            <DIAG-CODED-TYPE BASE-TYPE-ENCODING="{expected.base_type_encoding and expected.base_type_encoding.value}" BASE-DATA-TYPE="{expected.base_data_type.value}" TERMINATION="{expected.termination.value}" xsi:type="MIN-MAX-LENGTH-TYPE">
                 <MIN-LENGTH>{expected.min_length}</MIN-LENGTH>
                 <MAX-LENGTH>{expected.max_length}</MAX-LENGTH>
             </DIAG-CODED-TYPE>

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -19,7 +19,7 @@ from odxtools.multiplexercase import MultiplexerCase
 from odxtools.multiplexerdefaultcase import MultiplexerDefaultCase
 from odxtools.multiplexerswitchkey import MultiplexerSwitchKey
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.physicalconstantparameter import PhysicalConstantParameter
 from odxtools.parameters.valueparameter import ValueParameter
@@ -30,7 +30,7 @@ from odxtools.table import Table
 from odxtools.tablerow import TableRow
 
 # the document fragment which is used throughout the test
-doc_frags = [OdxDocFragment("DiagDataDictionarySpecTest", "CONTAINER")]
+doc_frags = [OdxDocFragment("DiagDataDictionarySpecTest", DocType.CONTAINER)]
 
 
 class TestDiagDataDictionarySpec(unittest.TestCase):

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -14,11 +14,11 @@ from odxtools.ecuvariantpattern import EcuVariantPattern
 from odxtools.exceptions import OdxError
 from odxtools.matchingparameter import MatchingParameter
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.request import Request
 from odxtools.response import Response, ResponseType
 
-doc_frags = [OdxDocFragment(doc_name="pytest", doc_type="WinneThePoh")]
+doc_frags = [OdxDocFragment(doc_name="pytest", doc_type=DocType.CONTAINER)]
 
 odxlinks = OdxLinkDatabase()
 

--- a/tests/test_ecu_variant_patterns.py
+++ b/tests/test_ecu_variant_patterns.py
@@ -5,9 +5,9 @@ import pytest
 
 from odxtools.createecuvariantpatterns import create_ecu_variant_patterns_from_et
 from odxtools.exceptions import OdxError
-from odxtools.odxlink import OdxDocFragment
+from odxtools.odxlink import DocType, OdxDocFragment
 
-doc_frags = [OdxDocFragment(doc_name="pytest", doc_type="WinneThePoh")]
+doc_frags = [OdxDocFragment(doc_name="pytest", doc_type=DocType.CONTAINER)]
 
 
 @pytest.fixture()

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -27,7 +27,7 @@ from odxtools.environmentdata import EnvironmentData
 from odxtools.environmentdatadescription import EnvironmentDataDescription
 from odxtools.exceptions import EncodeError, OdxError
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
 from odxtools.parameters.nrcconstparameter import NrcConstParameter
@@ -40,7 +40,7 @@ from odxtools.response import Response, ResponseType
 from odxtools.snrefcontext import SnRefContext
 from odxtools.standardlengthtype import StandardLengthType
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestEncodeRequest(unittest.TestCase):

--- a/tests/test_readparameters.py
+++ b/tests/test_readparameters.py
@@ -2,12 +2,12 @@
 import unittest
 from xml.etree import ElementTree
 
-from odxtools.odxlink import OdxDocFragment
+from odxtools.odxlink import DocType, OdxDocFragment
 from odxtools.odxtypes import DataType
 from odxtools.parameters.createanyparameter import create_any_parameter_from_et
 from odxtools.parameters.nrcconstparameter import NrcConstParameter
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestReadNrcParam(unittest.TestCase):

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -31,7 +31,7 @@ from odxtools.inputparam import InputParam
 from odxtools.library import Library
 from odxtools.nameditemlist import NamedItemList
 from odxtools.negoutputparam import NegOutputParam
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.outputparam import OutputParam
 from odxtools.physicaltype import PhysicalType
@@ -40,7 +40,7 @@ from odxtools.singleecujob import SingleEcuJob
 from odxtools.standardlengthtype import StandardLengthType
 from odxtools.writepdxfile import jinja2_odxraise_helper, make_bool_xml_attrib, make_xml_attrib
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestSingleEcuJob(unittest.TestCase):

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -12,7 +12,7 @@ from odxtools.diaglayers.ecuvariant import EcuVariant
 from odxtools.diaglayers.ecuvariantraw import EcuVariantRaw
 from odxtools.exceptions import odxrequire
 from odxtools.nameditemlist import NamedItemList
-from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
 from odxtools.parameters.valueparameter import ValueParameter
@@ -23,7 +23,7 @@ from odxtools.standardlengthtype import StandardLengthType
 from odxtools.unit import Unit
 from odxtools.unitspec import UnitSpec
 
-doc_frags = [OdxDocFragment("UnitTest", "WinneThePoh")]
+doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
 
 class TestUnitSpec(unittest.TestCase):


### PR DESCRIPTION
This replaces most cases where strings are used by odxtools but the specification limits the possible values with `Enum` classes. The main benefit is that using enumeration classes are checked at runtime and can also be type checked using e.g. `mypy`.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
