### PR TITLE
`PhysicalDataType`: always pass all parameters by name

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -503,7 +503,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -519,7 +520,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -535,7 +537,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -551,7 +554,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -567,7 +571,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=OdxLinkRef.from_id(somersault_units["second"].odx_id),
             sdgs=[],
@@ -583,7 +588,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=OdxLinkRef.from_id(somersault_units["celsius"].odx_id),
             sdgs=[],
@@ -599,7 +605,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -616,7 +623,7 @@ somersault_dops = {
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
             physical_type=PhysicalType(
-                DataType.A_UNICODE2STRING, display_radix=None, precision=None),
+                base_data_type=DataType.A_UNICODE2STRING, display_radix=None, precision=None),
             compu_method=somersault_compumethods["boolean"],
             unit_ref=None,
             sdgs=[],
@@ -632,7 +639,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -648,7 +656,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint16"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -664,7 +673,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["float32"],
-            physical_type=PhysicalType(DataType.A_FLOAT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_FLOAT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["float_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -680,7 +690,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["int8"],
-            physical_type=PhysicalType(DataType.A_INT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_INT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["int_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -696,7 +707,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["uint8"],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["uint_passthrough"],
             unit_ref=None,
             sdgs=[],
@@ -712,7 +724,8 @@ somersault_dops = {
             description=None,
             admin_data=None,
             diag_coded_type=somersault_diagcodedtypes["float32"],
-            physical_type=PhysicalType(DataType.A_FLOAT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_FLOAT32, display_radix=None, precision=None),
             compu_method=somersault_compumethods["float_passthrough"],
             unit_ref=None,
             sdgs=[],

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -74,4 +74,5 @@ class PhysicalType:
         precision_str = et_element.findtext("PRECISION")
         precision = int(precision_str) if precision_str is not None else None
 
-        return PhysicalType(base_data_type, display_radix=display_radix, precision=precision)
+        return PhysicalType(
+            base_data_type=base_data_type, display_radix=display_radix, precision=precision)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -405,7 +405,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=IdenticalCompuMethod(
                 category=CompuCategory.IDENTICAL,
                 compu_internal_to_phys=None,
@@ -785,7 +786,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type_4,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -988,7 +990,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -1244,7 +1247,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type_4,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -1259,7 +1263,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_endmarker_type,
-            physical_type=PhysicalType(DataType.A_BYTEFIELD, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_BYTEFIELD, display_radix=None, precision=None),
             compu_method=compu_method_bytefield,
             unit_ref=None,
             sdgs=[],
@@ -1625,7 +1630,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type_4,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -1870,7 +1876,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type_4,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -2113,7 +2120,8 @@ class TestDecoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -2507,7 +2515,8 @@ class TestDecoding(unittest.TestCase):
             admin_data=None,
             diag_coded_type=diag_coded_type,
             linked_dtc_dops_raw=[],
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             dtcs_raw=[dtc1, dtc2],
             sdgs=[],
@@ -2585,7 +2594,8 @@ class TestDecodingAndEncoding(unittest.TestCase):
                 base_type_encoding=None,
                 is_highlow_byte_order_raw=None,
             ),
-            physical_type=PhysicalType(DataType.A_BYTEFIELD, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_BYTEFIELD, display_radix=None, precision=None),
             compu_method=IdenticalCompuMethod(
                 category=CompuCategory.IDENTICAL,
                 compu_internal_to_phys=None,
@@ -2745,7 +2755,8 @@ class TestDecodingAndEncoding(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_INT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_INT32, display_radix=None, precision=None),
             compu_method=LinearCompuMethod(
                 category=CompuCategory.LINEAR,
                 compu_internal_to_phys=CompuInternalToPhys(

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -210,7 +210,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                     admin_data=None,
                     diag_coded_type=diagcodedtypes["certificateClient"],
                     physical_type=PhysicalType(
-                        DataType.A_BYTEFIELD, display_radix=None, precision=None),
+                        base_data_type=DataType.A_BYTEFIELD, display_radix=None, precision=None),
                     compu_method=compumethods["bytes_passthrough"],
                     unit_ref=None,
                     sdgs=[],
@@ -513,7 +513,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                     admin_data=None,
                     diag_coded_type=diagcodedtypes["uint8"],
                     physical_type=PhysicalType(
-                        DataType.A_UINT32, display_radix=None, precision=None),
+                        base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
                     compu_method=compumethods["multiply_with_8"],
                     unit_ref=None,
                     sdgs=[],
@@ -530,7 +530,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                     admin_data=None,
                     diag_coded_type=diagcodedtypes["length_key_id_to_lengthOfCertificateClient"],
                     physical_type=PhysicalType(
-                        DataType.A_UINT32, display_radix=None, precision=None),
+                        base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
                     compu_method=compumethods["uint_passthrough"],
                     unit_ref=None,
                     sdgs=[],

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -59,7 +59,8 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=uint8_dct,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             linked_dtc_dops_raw=[],
             compu_method=ident_compu_method,
             dtcs_raw=[
@@ -89,7 +90,8 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=uint8_dct,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=ident_compu_method,
             unit_ref=None,
             sdgs=[],
@@ -105,7 +107,8 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=uint8_dct,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=ident_compu_method,
             unit_ref=None,
             sdgs=[],

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -524,7 +524,8 @@ class TestEncodeRequest(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=compu_method,
             unit_ref=None,
             sdgs=[],
@@ -586,7 +587,8 @@ class TestEncodeRequest(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=IdenticalCompuMethod(
                 category=CompuCategory.IDENTICAL,
                 compu_internal_to_phys=None,
@@ -776,7 +778,8 @@ class TestEncodeRequest(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=diag_coded_type,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=IdenticalCompuMethod(
                 category=CompuCategory.IDENTICAL,
                 compu_internal_to_phys=None,
@@ -844,7 +847,8 @@ class TestEncodeRequest(unittest.TestCase):
             description=None,
             admin_data=None,
             diag_coded_type=dct,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=IdenticalCompuMethod(
                 category=CompuCategory.IDENTICAL,
                 compu_internal_to_phys=None,

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -94,7 +94,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     is_highlow_byte_order_raw=None,
                 ),
                 physical_type=PhysicalType(
-                    DataType.A_UNICODE2STRING, display_radix=None, precision=None),
+                    base_data_type=DataType.A_UNICODE2STRING, display_radix=None, precision=None),
                 compu_method=TexttableCompuMethod(
                     category=CompuCategory.TEXTTABLE,
                     compu_phys_to_internal=None,
@@ -153,7 +153,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     is_highlow_byte_order_raw=None,
                 ),
                 physical_type=PhysicalType(
-                    DataType.A_UNICODE2STRING, display_radix=None, precision=None),
+                    base_data_type=DataType.A_UNICODE2STRING, display_radix=None, precision=None),
                 compu_method=LinearCompuMethod(
                     category=CompuCategory.LINEAR,
                     compu_internal_to_phys=CompuInternalToPhys(
@@ -199,7 +199,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     is_highlow_byte_order_raw=None,
                 ),
                 physical_type=PhysicalType(
-                    DataType.A_UNICODE2STRING, display_radix=None, precision=None),
+                    base_data_type=DataType.A_UNICODE2STRING, display_radix=None, precision=None),
                 compu_method=LinearCompuMethod(
                     category=CompuCategory.LINEAR,
                     compu_internal_to_phys=CompuInternalToPhys(

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -117,7 +117,8 @@ class TestUnitSpec(unittest.TestCase):
             long_name=None,
             description=None,
             diag_coded_type=dct,
-            physical_type=PhysicalType(DataType.A_UINT32, display_radix=None, precision=None),
+            physical_type=PhysicalType(
+                base_data_type=DataType.A_UINT32, display_radix=None, precision=None),
             compu_method=IdenticalCompuMethod(
                 category=CompuCategory.IDENTICAL,
                 compu_internal_to_phys=None,


### PR DESCRIPTION
IMO, using positional parameters for dataclasses is usually bad style and it would break as soon as we switch the minimum python version to 3.10 and make these classes `kw_only`...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 