### PR TITLE
Implement some fringe features

### DIFF
--- a/examples/mksomersaultmodifiedpdx.py
+++ b/examples/mksomersaultmodifiedpdx.py
@@ -193,6 +193,7 @@ flic_flac_service = DiagService(
     neg_response_refs=[
         OdxLinkRef.from_id(somersaultecu.somersault_negative_responses["general"].odx_id),
     ],
+    pos_response_suppressible=None,
     sdgs=[],
 )
 

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1826,6 +1826,7 @@ somersault_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
             ],
+            pos_response_suppressible=None,
             functional_class_refs=[
                 OdxLinkRef.from_id(somersault_functional_classes["session"].odx_id),
             ],
@@ -1861,6 +1862,7 @@ somersault_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
             ],
+            pos_response_suppressible=None,
             functional_class_refs=[
                 OdxLinkRef.from_id(somersault_functional_classes["session"].odx_id)
             ],
@@ -1908,6 +1910,7 @@ somersault_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_negative_responses["tester_nok"].odx_id),
             ],
+            pos_response_suppressible=None,
             sdgs=[],
         ),
     "set_operation_params":
@@ -1941,6 +1944,7 @@ somersault_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
             ],
+            pos_response_suppressible=None,
             sdgs=[],
         ),
     "forward_flips":
@@ -1990,6 +1994,7 @@ somersault_services = {
                 # OdxLinkRef.from_id(somersault_negative_responses["too_dizzy"].odx_id),
                 # OdxLinkRef.from_id(somersault_negative_responses["not_sober"].odx_id),
             ],
+            pos_response_suppressible=None,
             functional_class_refs=[
                 OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_id)
             ],
@@ -2036,6 +2041,7 @@ somersault_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_negative_responses["flips_not_done"].odx_id),
             ],
+            pos_response_suppressible=None,
             functional_class_refs=[
                 OdxLinkRef.from_id(somersault_functional_classes["flip"].odx_id)
             ],
@@ -2082,6 +2088,7 @@ somersault_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_negative_responses["general"].odx_id),
             ],
+            pos_response_suppressible=None,
             sdgs=[],
         ),
     "schroedinger":
@@ -2110,6 +2117,7 @@ somersault_services = {
             semantic="ROUTINE",
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             functional_class_refs=[],
             sdgs=[],
         ),
@@ -2616,6 +2624,7 @@ somersault_assiduous_services = {
             neg_response_refs=[
                 OdxLinkRef.from_id(somersault_assiduous_negative_responses["fell_over"].odx_id),
             ],
+            pos_response_suppressible=None,
             comparam_refs=[],
             is_cyclic_raw=None,
             is_multiple_raw=None,

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -1471,6 +1471,7 @@ somersault_tables = {
                     sdgs=[],
                 ),
             ],
+            table_diag_comm_connectors=[],
             sdgs=[],
         )
 }

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -7,9 +7,26 @@ from .odxlink import OdxDocFragment
 
 
 @dataclass
+class ExternalDoc:
+    description: Optional[str]
+    href: str
+
+    @staticmethod
+    def from_et(et_element: Optional[ElementTree.Element],
+                doc_frags: List[OdxDocFragment]) -> Optional["ExternalDoc"]:
+        if et_element is None:
+            return None
+
+        description = et_element.text
+        href = odxrequire(et_element.get("HREF"))
+
+        return ExternalDoc(description=description, href=href)
+
+
+@dataclass
 class Description:
     text: str
-    external_docs: List[str]
+    external_docs: List[ExternalDoc]
     text_identifier: Optional[str]
 
     @staticmethod
@@ -35,7 +52,7 @@ class Description:
 
         external_docs = \
             [
-                odxrequire(ed.get("HREF")) for ed in et_element.iterfind("EXTERNAL-DOCS/EXTERNAL-DOC")
+                odxrequire(ExternalDoc.from_et(ed, doc_frags)) for ed in et_element.iterfind("EXTERNAL-DOCS/EXTERNAL-DOC")
             ]
         return Description(text=text, text_identifier=text_identifier, external_docs=external_docs)
 

--- a/odxtools/templates/macros/printDescription.xml.jinja2
+++ b/odxtools/templates/macros/printDescription.xml.jinja2
@@ -9,7 +9,11 @@
 {%- if desc.external_docs %}
 <EXTERNAL-DOCS>
  {%- for ed in desc.external_docs %}
- <EXTERNAL-DOC HREF="{{ed}}" />
+ {%- if ed.description is none %}}
+ <EXTERNAL-DOC HREF="{{ed.href}}" />
+ {%- else %}}
+ <EXTERNAL-DOC HREF="{{ed.href}}">{{ed.description}}</EXTERNAL-DOC>
+ {%- endif %}}
  {%- endfor %}
 </EXTERNAL-DOCS>
 {%- endif -%}

--- a/odxtools/templates/macros/printService.xml.jinja2
+++ b/odxtools/templates/macros/printService.xml.jinja2
@@ -6,6 +6,36 @@
 {%- import('macros/printDiagComm.xml.jinja2') as pdc %}
 {%- import('macros/printComparamRef.xml.jinja2') as pcom %}
 
+{%- macro printPosResponseSuppressible(prs) -%}
+<POS-RESPONSE-SUPPRESSABLE>
+  <BIT-MASK>{{ hex(prs.bit_mask).lower() }}</BIT-MASK>
+  {%- if prs.coded_const_snref is not none %}
+  <CODED-CONST-SNREF SHORT-NAME="{{ prs.coded_const_snref }}" />
+  {%- endif %}
+  {%- if prs.coded_const_snpathref is not none %}
+  <CODED-CONST-SNPATHREF SHORT-PATH-NAME="{{ prs.coded_const_snpathref }}" />
+  {%- endif %}
+  {%- if prs.value_snref is not none %}
+  <VALUE-SNREF SHORT-NAME="{{ prs.value_snref }}" />
+  {%- endif %}
+  {%- if prs.value_snpathref is not none %}
+  <VALUE-SNPATHREF SHORT-PATH-NAME="{{ prs.value_snpathref }}" />
+  {%- endif %}
+  {%- if prs.phys_const_snref is not none %}
+  <PHYS-CONST-SNREF SHORT-NAME="{{ prs.phys_const_snref }}" />
+  {%- endif %}
+  {%- if prs.phys_const_snpathref is not none %}
+  <PHYS-CONST-SNPATHREF SHORT-PATH-NAME="{{ prs.phys_const_snpathref }}" />
+  {%- endif %}
+  {%- if prs.table_key_snref is not none %}
+  <TABLE-KEY-SNREF SHORT-NAME="{{ prs.table_key_snref }}" />
+  {%- endif %}
+  {%- if prs.table_key_snpathref is not none %}
+  <TABLE-KEY-SNPATHREF SHORT-PATH-NAME="{{ prs.table_key_snpathref }}" />
+  {%- endif %}
+</POS-RESPONSE-SUPPRESSABLE>
+{%- endmacro -%}
+
 {%- macro printService(service) -%}
 <DIAG-SERVICE {{pdc.printDiagCommAttribs(service) | indent(1) }}
  {{-make_bool_xml_attrib("IS-CYCLIC", service.is_cyclic_raw)}}

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -65,6 +65,20 @@
  <TABLE-ROW-REF ID-REF="{{ table_row.ref_id }}" />
  {%- endif %}
 {%- endfor %}
+ {%- if table_diag_comm_connectors %}
+ <TABLE-DIAG-COMM-CONNECTORS>
+ {%- for tdcc in table_diag_comm_connectors %}
+  <TABLE-DIAG-COMM-CONNECTOR>
+   <SEMANTIC>{{tdcc.semantic}}</SEMANTIC>
+   {%- if tdcc.diag_comm_ref %}
+   <DIAG-COMM-REF ID-REF="{{ tdcc.diag_comm_ref.ref_id }}" />
+   {%- elif tdcc.diag_comm_snref %}
+   <DIAG-COMM-SNREF SHORT-NAME="{{ tdcc.diag_comm_snref }}" />
+   {%- endif %}
+  </TABLE-DIAG-COMM-CONNECTOR>
+ {%- endfor %}
+ </TABLE-DIAG-COMM-CONNECTORS>
+ {%- endif %}
  {{- psd.printSpecialDataGroups(table.sdgs)|indent(1, first=True) }}
 </TABLE>
 {%- endmacro -%}

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -128,6 +128,7 @@ class TestIdentifyingService(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
 
@@ -206,6 +207,7 @@ class TestIdentifyingService(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req2.odx_id),
             pos_response_refs=[OdxLinkRef.from_id(resp2.odx_id)],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
 
@@ -333,6 +335,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -517,6 +520,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[OdxLinkRef.from_id(resp.odx_id)],
+            pos_response_suppressible=None,
             sdgs=[],
         )
 
@@ -688,6 +692,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -894,6 +899,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -1115,6 +1121,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -1441,6 +1448,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         service_eopdu = DiagService(
@@ -1469,6 +1477,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req_end_of_pdu.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -1756,6 +1765,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -2000,6 +2010,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -2190,6 +2201,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(
@@ -2401,6 +2413,7 @@ class TestDecoding(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[OdxLinkRef.from_id(pos_response.odx_id)],
             neg_response_refs=[OdxLinkRef.from_id(neg_response.odx_id)],
+            pos_response_suppressible=None,
             sdgs=[],
         )
         ecu_variant_raw = EcuVariantRaw(

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -200,6 +200,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     sdgs=[],
                 ),
             ],
+            table_diag_comm_connectors=[],
             sdgs=[],
         )
 

--- a/tests/test_ecu_variant_matching.py
+++ b/tests/test_ecu_variant_matching.py
@@ -88,6 +88,7 @@ def ident_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) -> 
         request_ref=OdxLinkRef.from_id(dummy_req.odx_id),
         pos_response_refs=[OdxLinkRef.from_id(dummy_response.odx_id)],
         neg_response_refs=[],
+        pos_response_suppressible=None,
         sdgs=[],
     )
 
@@ -138,6 +139,7 @@ def supplier_service(monkeypatch: pytest.MonkeyPatch, dummy_response: Response) 
         request_ref=OdxLinkRef.from_id(dummy_req.odx_id),
         pos_response_refs=[OdxLinkRef.from_id(dummy_response.odx_id)],
         neg_response_refs=[],
+        pos_response_suppressible=None,
         sdgs=[],
     )
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -699,6 +699,7 @@ class TestEncodeRequest(unittest.TestCase):
             request_ref=OdxLinkRef.from_id(req.odx_id),
             pos_response_refs=[],
             neg_response_refs=[OdxLinkRef.from_id(resp.odx_id)],
+            pos_response_suppressible=None,
             sdgs=[],
         )
 


### PR DESCRIPTION
This pull requests implements a few somewhat esoteric features defined by the ODX standard but so far missing in odxtools: TABLE-DIAG-COMM-CONNECTORS for tables, EXTERNAL-DOCS for descriptions, POS-RESPONSE-SUPPRESSABLE (sic!) for diag services and EXTERNAL-ACCESS-METHOD for state transitions.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 