### PR TITLE
DataObjectProperty.decode_from_pdu: support returning the default value when the internal value is invalid

### DIFF
--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -143,7 +143,6 @@ class DataObjectProperty(DopBase):
         if default_value is not None:
             return str(default_value)
 
-        # TODO: How to prevent this?
         odxraise(f"DOP {self.short_name} could not convert the coded value "
                  f"{repr(internal)} to physical type {self.physical_type.base_data_type}.")
 

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -137,15 +137,14 @@ class DataObjectProperty(DopBase):
         if self.compu_method.is_valid_internal_value(internal):
             return self.compu_method.convert_internal_to_physical(internal)
 
-        default_value = self.compu_method.compu_internal_to_phys.compu_default_value
+        default_value = getattr(self.compu_method.compu_internal_to_phys, "compu_default_value",
+                                None)
         if default_value is not None:
-            return default_value.value
+            return str(default_value)
 
         # TODO: How to prevent this?
-        raise DecodeError(
-            f"DOP {self.short_name} could not convert the coded value "
-            f"{repr(internal)} to physical type {self.physical_type.base_data_type}."
-        )
+        raise DecodeError(f"DOP {self.short_name} could not convert the coded value "
+                          f"{repr(internal)} to physical type {self.physical_type.base_data_type}.")
 
     def is_valid_physical_value(self, physical_value: ParameterValue) -> bool:
         return self.compu_method.is_valid_physical_value(cast(AtomicOdxType, physical_value))

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -143,8 +143,10 @@ class DataObjectProperty(DopBase):
             return str(default_value)
 
         # TODO: How to prevent this?
-        raise DecodeError(f"DOP {self.short_name} could not convert the coded value "
+        odxraise(f"DOP {self.short_name} could not convert the coded value "
                           f"{repr(internal)} to physical type {self.physical_type.base_data_type}.")
+
+        return None
 
     def is_valid_physical_value(self, physical_value: ParameterValue) -> bool:
         return self.compu_method.is_valid_physical_value(cast(AtomicOdxType, physical_value))

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -137,8 +137,9 @@ class DataObjectProperty(DopBase):
         if self.compu_method.is_valid_internal_value(internal):
             return self.compu_method.convert_internal_to_physical(internal)
 
-        default_value = getattr(self.compu_method.compu_internal_to_phys, "compu_default_value",
-                                None)
+        internal_to_phys = self.compu_method.compu_internal_to_phys
+        default_value = internal_to_phys.compu_default_value if internal_to_phys else None
+
         if default_value is not None:
             return str(default_value)
 

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -136,11 +136,16 @@ class DataObjectProperty(DopBase):
 
         if self.compu_method.is_valid_internal_value(internal):
             return self.compu_method.convert_internal_to_physical(internal)
-        else:
-            # TODO: How to prevent this?
-            raise DecodeError(
-                f"DOP {self.short_name} could not convert the coded value "
-                f" {repr(internal)} to physical type {self.physical_type.base_data_type}.")
+
+        default_value = self.compu_method.compu_internal_to_phys.compu_default_value
+        if default_value is not None:
+            return default_value.value
+
+        # TODO: How to prevent this?
+        raise DecodeError(
+            f"DOP {self.short_name} could not convert the coded value "
+            f"{repr(internal)} to physical type {self.physical_type.base_data_type}."
+        )
 
     def is_valid_physical_value(self, physical_value: ParameterValue) -> bool:
         return self.compu_method.is_valid_physical_value(cast(AtomicOdxType, physical_value))

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -10,7 +10,7 @@ from .decodestate import DecodeState
 from .diagcodedtype import DiagCodedType
 from .dopbase import DopBase
 from .encodestate import EncodeState
-from .exceptions import DecodeError, EncodeError, odxraise, odxrequire
+from .exceptions import EncodeError, odxraise, odxrequire
 from .internalconstr import InternalConstr
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import AtomicOdxType, ParameterValue
@@ -144,7 +144,7 @@ class DataObjectProperty(DopBase):
 
         # TODO: How to prevent this?
         odxraise(f"DOP {self.short_name} could not convert the coded value "
-                          f"{repr(internal)} to physical type {self.physical_type.base_data_type}.")
+                 f"{repr(internal)} to physical type {self.physical_type.base_data_type}.")
 
         return None
 


### PR DESCRIPTION
This merge request adds support for returning the default value when the internal value is invalid. If the internal value is not defined, the method will check for a defined default value and return it; otherwise, it will raise an exception.

odxtools version: 9.2.0