### PR TITLE
comparaminstance.spec property is not available during object creation

### DIFF
--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -138,4 +138,9 @@ class ComparamInstance:
 
     @property
     def short_name(self) -> str:
-        return self.spec.short_name
+        if self.spec:
+            return self.spec.short_name
+
+        # ODXLINK IDs allow dots and hyphens, but short names do not.
+        # (This should not happen anyway in a correct PDX...)
+        return self.spec_ref.ref_id.replace(".", "__").replace("-", "_")


### PR DESCRIPTION
Although I tested the changes introduced in https://github.com/mercedes-benz/odxtools/pull/386, after upgrading to the latest odxtools version 9.4.0, we got the issue:

![image](https://github.com/user-attachments/assets/8b5dcd83-8b8a-40ed-9349-b987b74100b1)

![image](https://github.com/user-attachments/assets/0b310378-7b31-46c2-a84f-48221fe64171)


I believe not encountering the issue during testing was due to a Git branching issue :( .