### PR TITLE
Fix SupportsBytes Behavior Change in Python 3.12

### DIFF
--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -17,7 +17,7 @@ from .odxtypes import AtomicOdxType, ParameterValue
 from .physicaltype import PhysicalType
 from .snrefcontext import SnRefContext
 from .unit import Unit
-from .utils import dataclass_fields_asdict
+from .utils import BytesTypes, dataclass_fields_asdict
 
 
 @dataclass
@@ -120,7 +120,7 @@ class DataObjectProperty(DopBase):
                 f"The value {repr(physical_value)} of type {type(physical_value).__name__}"
                 f" is not a valid.")
 
-        if not isinstance(physical_value, (int, float, str, bytes, bytearray)):
+        if not isinstance(physical_value, (int, float, str, BytesTypes)):
             odxraise(f"Invalid type '{type(physical_value).__name__}' for physical value. "
                      f"(Expect atomic type!)")
         internal_value = self.compu_method.convert_physical_to_internal(physical_value)

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, SupportsBytes, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from .encoding import Encoding, get_string_encoding
 from .exceptions import EncodeError, OdxWarning, odxassert, odxraise
 from .odxtypes import AtomicOdxType, DataType, ParameterValue
+from .utils import BytesTypes
 
 try:
     import bitstruct.c as bitstruct
@@ -97,7 +98,7 @@ class EncodeState:
 
         # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
-            if not isinstance(internal_value, (bytes, bytearray, SupportsBytes)):
+            if not isinstance(internal_value, BytesTypes):
                 odxraise(f"{internal_value!r} is not a bytefield", EncodeError)
                 return
 

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, SupportsBytes, cast
+from typing import Any, Dict, List, Optional, cast
 from xml.etree import ElementTree
 
 from .diaglayers.diaglayer import DiagLayer
@@ -10,6 +10,7 @@ from .exceptions import odxraise, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, resolve_snref
 from .odxtypes import ParameterValue, ParameterValueDict
 from .snrefcontext import SnRefContext
+from .utils import BytesTypes
 
 
 @dataclass
@@ -104,7 +105,7 @@ class MatchingParameter:
                 # allow a slight tolerance if the expected value is
                 # floating point
                 return abs(float(self.expected_value) - parameter_value) < 1e-8
-            elif isinstance(parameter_value, (bytearray, SupportsBytes)):
+            elif isinstance(parameter_value, BytesTypes):
                 return parameter_value.hex().upper() == self.expected_value.upper()
             elif isinstance(parameter_value, DiagnosticTroubleCode):
                 # TODO: what happens if non-numerical DTCs like

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -10,8 +10,7 @@ from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .encoding import get_string_encoding
-from .exceptions import (DecodeError, EncodeError, odxassert, odxraise,
-                         odxrequire)
+from .exceptions import (DecodeError, EncodeError, odxassert, odxraise, odxrequire)
 from .odxlink import OdxDocFragment
 from .odxtypes import AtomicOdxType, DataType
 from .utils import BytesTypes, dataclass_fields_asdict

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -10,10 +10,11 @@ from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .encoding import get_string_encoding
-from .exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
+from .exceptions import (DecodeError, EncodeError, odxassert, odxraise,
+                         odxrequire)
 from .odxlink import OdxDocFragment
 from .odxtypes import AtomicOdxType, DataType
-from .utils import dataclass_fields_asdict
+from .utils import BytesTypes, dataclass_fields_asdict
 
 
 class Termination(Enum):
@@ -83,7 +84,7 @@ class MinMaxLengthType(DiagCodedType):
     @override
     def encode_into_pdu(self, internal_value: AtomicOdxType, encode_state: EncodeState) -> None:
 
-        if not isinstance(internal_value, (bytes, str, bytearray)):
+        if not isinstance(internal_value, (str, BytesTypes)):
             odxraise("MinMaxLengthType is currently only implemented for strings and byte arrays",
                      EncodeError)
 

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional,
-                    Tuple, Type, Union, overload)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union,
+                    overload)
 from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxraise, odxrequire

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union,
-                    overload)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional,
+                    Tuple, Type, Union, overload)
 from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxraise, odxrequire
+from .utils import BytesTypes
 
 if TYPE_CHECKING:
     from odxtools.diagnostictroublecode import DiagnosticTroubleCode
@@ -135,8 +136,8 @@ def compare_odx_values(a: AtomicOdxType, b: AtomicOdxType) -> int:
 
     # bytefields are treated like long integers: to pad the shorter
     # object with zeros and treat the results like strings.
-    if isinstance(a, (bytes, bytearray)):
-        if not isinstance(b, (bytes, bytearray)):
+    if isinstance(a, BytesTypes):
+        if not isinstance(b, BytesTypes):
             odxraise()
 
         obj_len = max(len(a), len(b))
@@ -237,7 +238,7 @@ class DataType(Enum):
             return True
         elif expected_type is float and isinstance(value, (int, float)):
             return True
-        elif self == DataType.A_BYTEFIELD and isinstance(value, (bytearray, bytes)):
+        elif self == DataType.A_BYTEFIELD and isinstance(value, BytesTypes):
             return True
         else:
             return False

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List, Literal, Optional
 from xml.etree import ElementTree
 
-from typing_extensions import SupportsBytes, override
+from typing_extensions import override
 
 from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
@@ -11,7 +11,7 @@ from .encodestate import EncodeState
 from .exceptions import odxassert, odxraise, odxrequire
 from .odxlink import OdxDocFragment
 from .odxtypes import AtomicOdxType, DataType, odxstr_to_bool
-from .utils import dataclass_fields_asdict
+from .utils import BytesTypes, dataclass_fields_asdict
 
 
 @dataclass
@@ -91,7 +91,7 @@ class StandardLengthType(DiagCodedType):
             return used_mask.to_bytes((bit_sz + 7) // 8, endianness)
 
         sz: int
-        if isinstance(internal_value, (bytearray, SupportsBytes)):
+        if isinstance(internal_value, BytesTypes):
             sz = len(bytes(internal_value))
         else:
             sz = (odxrequire(self.get_static_bit_length()) + 7) // 8
@@ -107,7 +107,7 @@ class StandardLengthType(DiagCodedType):
 
         if self.is_condensed:
             int_value: int
-            if isinstance(internal_value, (bytearray, SupportsBytes)):
+            if isinstance(internal_value, BytesTypes):
                 int_value = int.from_bytes(internal_value, 'big')
             elif isinstance(internal_value, int):
                 int_value = internal_value
@@ -126,14 +126,14 @@ class StandardLengthType(DiagCodedType):
 
                 mask_bit += 1
 
-            if isinstance(internal_value, (bytearray, SupportsBytes)):
+            if isinstance(internal_value, BytesTypes):
                 return result.to_bytes(len(internal_value), 'big')
 
             return result
 
         if isinstance(internal_value, int):
             return internal_value & self.bit_mask
-        if isinstance(internal_value, (bytearray, SupportsBytes)):
+        if isinstance(internal_value, BytesTypes):
             int_value = int.from_bytes(internal_value, 'big')
             int_value &= self.bit_mask
             return int_value.to_bytes(len(bytes(internal_value)), 'big')
@@ -146,7 +146,7 @@ class StandardLengthType(DiagCodedType):
             return raw_value
         if self.is_condensed:
             int_value: int
-            if isinstance(raw_value, (bytearray, SupportsBytes)):
+            if isinstance(raw_value, BytesTypes):
                 int_value = int.from_bytes(raw_value, 'big')
             elif isinstance(raw_value, int):
                 int_value = raw_value
@@ -164,16 +164,16 @@ class StandardLengthType(DiagCodedType):
 
                 mask_bit += 1
 
-            if isinstance(raw_value, (bytearray, SupportsBytes)):
+            if isinstance(raw_value, BytesTypes):
                 return result.to_bytes(len(raw_value), 'big')
 
             return result
         if isinstance(raw_value, int):
             return raw_value & self.bit_mask
-        if isinstance(raw_value, (bytearray, SupportsBytes)):
+        if isinstance(raw_value, BytesTypes):
             int_value = int.from_bytes(raw_value, 'big')
             int_value &= self.bit_mask
-            return int_value
+            return int_value.to_bytes(len(raw_value), 'big')
 
         odxraise(f'Can not apply a bit_mask on a value of type {type(raw_value)}')
         return raw_value

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -3,10 +3,14 @@ import dataclasses
 import re
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from typing_extensions import SupportsBytes
+
 if TYPE_CHECKING:
     from .database import Database
     from .diaglayers.diaglayer import DiagLayer
     from .snrefcontext import SnRefContext
+
+BytesTypes = (bytearray, bytes, SupportsBytes)
 
 
 def retarget_snrefs(database: "Database",


### PR DESCRIPTION
The `SupportsBytes` protocol only recognizes types that explicitly implement `__bytes__()`.
Python 3.12 implements `__bytes__()`, but Python 3.9 does not.

![image](https://github.com/user-attachments/assets/684fe841-d550-479b-a405-f7c5a468828f)  ![image](https://github.com/user-attachments/assets/c0a1d89c-cf10-4798-b5ee-afe9828d8af7)

This change affects the behavior of `isinstance(obj, SupportsBytes)`, which previously returned `False` for bytes in Python 3.9 but now returns `True` in Python 3.12.

**### Impact `on standardlengthtype.__unapply_mask`:**
This change has impacted the behavior of the `standardlengthtype.__unapply_mask(self, raw_value: AtomicOdxType)` method.

- When `raw_value` is of type bytes, Python 3.9 raises an odxraise and returns raw_value as-is (in bytes) in non-strict mode.

- In Python 3.12, the condition at [this line](https://github.com/mercedes-benz/odxtools/blob/5cc2c95ab238d482fc1ffc3819d45814f007871d/odxtools/standardlengthtype.py#L173) evaluates to True, causing the method to return an integer instead of bytes.

- Returning an integer in this case is incorrect, leading to the following exception:

![image](https://github.com/user-attachments/assets/6b98df3e-bd81-4ff9-9754-1e9a9a7708ed)

**### Fix Implemented in This Merge Request:**
To ensure compatibility across Python versions, the following changes have been made:

- Introduced `BytesTypes` in utils.py, which includes `(bytearray, bytes, SupportsBytes)`.

- Updated `standardlengthtype.__unapply_mask` to correctly return bytes when` isinstance(raw_value, BytesTypes) == True`.

odxtools==9.4.1

