### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3"
 
       - name: Setup up YaPF formatting linter
         run: |
@@ -38,7 +38,7 @@ jobs:
       matrix:
         # restrict the matrix to the oldest and the latest Python
         # version being supported by odxtools
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3"]
 
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         # restrict the matrix to the oldest and the latest Python
         # version being supported by odxtools
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3"]
 
         # due to the slow windows runners, we refrain from testing every python
         # version on windows-latest

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -13,11 +13,11 @@ from .encodestate import EncodeState
 from .exceptions import EncodeError, odxraise, odxrequire
 from .internalconstr import InternalConstr
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
-from .odxtypes import AtomicOdxType, ParameterValue
+from .odxtypes import AtomicOdxType, BytesTypes, ParameterValue
 from .physicaltype import PhysicalType
 from .snrefcontext import SnRefContext
 from .unit import Unit
-from .utils import BytesTypes, dataclass_fields_asdict
+from .utils import dataclass_fields_asdict
 
 
 @dataclass

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from .encoding import Encoding, get_string_encoding
 from .exceptions import EncodeError, OdxWarning, odxassert, odxraise
-from .odxtypes import AtomicOdxType, DataType, ParameterValue
-from .utils import BytesTypes
+from .odxtypes import AtomicOdxType, BytesTypes, DataType, ParameterValue
 
 try:
     import bitstruct.c as bitstruct

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -8,9 +8,8 @@ from .diagnostictroublecode import DiagnosticTroubleCode
 from .diagservice import DiagService
 from .exceptions import odxraise, odxrequire
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, resolve_snref
-from .odxtypes import ParameterValue, ParameterValueDict
+from .odxtypes import BytesTypes, ParameterValue, ParameterValueDict
 from .snrefcontext import SnRefContext
-from .utils import BytesTypes
 
 
 @dataclass

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -10,10 +10,10 @@ from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .encoding import get_string_encoding
-from .exceptions import (DecodeError, EncodeError, odxassert, odxraise, odxrequire)
+from .exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
 from .odxlink import OdxDocFragment
-from .odxtypes import AtomicOdxType, DataType
-from .utils import BytesTypes, dataclass_fields_asdict
+from .odxtypes import AtomicOdxType, BytesTypes, DataType
+from .utils import dataclass_fields_asdict
 
 
 class Termination(Enum):

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union,
-                    overload)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, SupportsBytes, Tuple,
+                    Type, Union, overload)
 from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxraise, odxrequire
-from .utils import BytesTypes
 
 if TYPE_CHECKING:
     from odxtools.diagnostictroublecode import DiagnosticTroubleCode
@@ -17,7 +16,8 @@ def bytefield_to_bytearray(bytefield: str) -> bytearray:
     return bytearray([int(x, 16) for x in bytes_string])
 
 
-AtomicOdxType = Union[str, int, float, bytes]
+BytesTypes = (bytearray, bytes, SupportsBytes)
+AtomicOdxType = Union[str, int, float, bytearray, bytes]
 
 # dictionary mapping short names to a Parameter that needs to be
 # specified. Complex parameters (structures) may contain

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -14,6 +14,9 @@ from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
 from .tablekeyparameter import TableKeyParameter
+
+if TYPE_CHECKING:
+    from ..table import Table
 
 
 @dataclass
@@ -68,6 +71,10 @@ class TableStructParameter(Parameter):
     @property
     def table_key(self) -> TableKeyParameter:
         return self._table_key
+
+    @property
+    def table(self) -> "Table":
+        return self._table_key.table
 
     @property
     @override

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -10,8 +10,8 @@ from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .exceptions import odxassert, odxraise, odxrequire
 from .odxlink import OdxDocFragment
-from .odxtypes import AtomicOdxType, DataType, odxstr_to_bool
-from .utils import BytesTypes, dataclass_fields_asdict
+from .odxtypes import AtomicOdxType, BytesTypes, DataType, odxstr_to_bool
+from .utils import dataclass_fields_asdict
 
 
 @dataclass

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -3,14 +3,10 @@ import dataclasses
 import re
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from typing_extensions import SupportsBytes
-
 if TYPE_CHECKING:
     from .database import Database
     from .diaglayers.diaglayer import DiagLayer
     from .snrefcontext import SnRefContext
-
-BytesTypes = (bytearray, bytes, SupportsBytes)
 
 
 def retarget_snrefs(database: "Database",


### PR DESCRIPTION
This PR moves the `BytesTypes` alias from `utils.py` to `odxtypes.py` and adds a `.table` property to `TableStructParameter`s. (Both patches are drive-by fixes for a more substantial change I am currently working on.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 