### PR TITLE
implement the TEXT tag

### DIFF
--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -9,13 +9,14 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
+from .text import Text
 from .utils import dataclass_fields_asdict
 
 
 @dataclass
 class DiagnosticTroubleCode(IdentifiableElement):
     trouble_code: int
-    text: str
+    text: Text
     display_trouble_code: Optional[str]
     level: Optional[int]
     is_temporary_raw: Optional[bool]
@@ -30,7 +31,7 @@ class DiagnosticTroubleCode(IdentifiableElement):
                 doc_frags: List[OdxDocFragment]) -> "DiagnosticTroubleCode":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
         display_trouble_code = et_element.findtext("DISPLAY-TROUBLE-CODE")
-
+        text = Text.from_et(odxrequire(et_element.find("TEXT")), doc_frags)
         level = None
         if (level_str := et_element.findtext("LEVEL")) is not None:
             level = int(level_str)
@@ -42,7 +43,7 @@ class DiagnosticTroubleCode(IdentifiableElement):
 
         return DiagnosticTroubleCode(
             trouble_code=int(odxrequire(et_element.findtext("TROUBLE-CODE"))),
-            text=odxrequire(et_element.findtext("TEXT")),
+            text=text,
             display_trouble_code=display_trouble_code,
             level=level,
             is_temporary_raw=is_temporary_raw,

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -136,7 +136,7 @@
   {%- if dtc.display_trouble_code is not none   %}
    <DISPLAY-TROUBLE-CODE>{{dtc.display_trouble_code}}</DISPLAY-TROUBLE-CODE>
   {%- endif %}
-   <TEXT>{{dtc.text|e}}</TEXT>
+   <TEXT {{- make_xml_attrib("TI", dtc.text.text_identifier) }}>{{dtc.text|e}}</TEXT>
   {%- if not dtc.level is none   %}
    <LEVEL>{{dtc.level}}</LEVEL>
   {%- endif %}

--- a/odxtools/text.py
+++ b/odxtools/text.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import List, Optional
+from xml.etree import ElementTree
+
+from .odxlink import OdxDocFragment
+
+
+@dataclass
+class Text:
+    text: str
+    text_identifier: Optional[str]
+
+    @staticmethod
+    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Text":
+        # Extract the contents of the tag as a string.
+        raw_string = et_element.text or ""
+        for e in et_element:
+            raw_string += ElementTree.tostring(e, encoding="unicode")
+
+        # remove white spaces at the beginning and at the end of all
+        # extracted lines
+        stripped_lines = [x.strip() for x in raw_string.split("\n")]
+
+        text = "\n".join(stripped_lines).strip()
+
+        text_identifier = et_element.get("TI")
+
+        return Text(text=text, text_identifier=text_identifier)
+
+    @staticmethod
+    def from_string(text: str) -> "Text":
+        return Text(text=text, text_identifier=None)
+
+    def __str__(self) -> str:
+        return self.text

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -43,6 +43,7 @@ from odxtools.snrefcontext import SnRefContext
 from odxtools.standardlengthtype import StandardLengthType
 from odxtools.staticfield import StaticField
 from odxtools.structure import Structure
+from odxtools.text import Text
 
 doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
@@ -2505,7 +2506,7 @@ class TestDecoding(unittest.TestCase):
             long_name=None,
             description=None,
             trouble_code=0x34,
-            text="Error encountered",
+            text=Text.from_string("Error encountered"),
             display_trouble_code="P34",
             level=None,
             is_temporary_raw=None,
@@ -2519,7 +2520,7 @@ class TestDecoding(unittest.TestCase):
             long_name=None,
             description=None,
             trouble_code=0x56,
-            text="Crashed into wall",
+            text=Text.from_string("Crashed into wall"),
             display_trouble_code="P56",
             level=None,
             is_temporary_raw=None,

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -28,6 +28,7 @@ from odxtools.standardlengthtype import StandardLengthType
 from odxtools.structure import Structure
 from odxtools.table import Table
 from odxtools.tablerow import TableRow
+from odxtools.text import Text
 
 # the document fragment which is used throughout the test
 doc_frags = [OdxDocFragment("DiagDataDictionarySpecTest", DocType.CONTAINER)]
@@ -71,7 +72,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
                     long_name=None,
                     description=None,
                     trouble_code=0x10,
-                    text="Something exploded.",
+                    text=Text.from_string("Something exploded."),
                     display_trouble_code="X10",
                     level=None,
                     is_temporary_raw=None,

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -39,6 +39,7 @@ from odxtools.request import Request
 from odxtools.response import Response, ResponseType
 from odxtools.snrefcontext import SnRefContext
 from odxtools.standardlengthtype import StandardLengthType
+from odxtools.text import Text
 
 doc_frags = [OdxDocFragment("UnitTest", DocType.CONTAINER)]
 
@@ -898,7 +899,7 @@ class TestEncodeRequest(unittest.TestCase):
                     long_name=None,
                     description=None,
                     trouble_code=0x112233,
-                    text="The first trouble is the deepest",
+                    text=Text.from_string("The first trouble is the deepest"),
                     display_trouble_code="Z123",
                     level=None,
                     is_temporary_raw=None,
@@ -910,7 +911,7 @@ class TestEncodeRequest(unittest.TestCase):
                     long_name=None,
                     description=None,
                     trouble_code=0x445566,
-                    text="",
+                    text=Text.from_string(""),
                     display_trouble_code="Y456",
                     level=None,
                     is_temporary_raw=None,
@@ -922,7 +923,7 @@ class TestEncodeRequest(unittest.TestCase):
                     long_name=None,
                     description=None,
                     trouble_code=0xf00de5,
-                    text="",
+                    text=Text.from_string(""),
                     display_trouble_code="SCREW",
                     level=None,
                     is_temporary_raw=None,


### PR DESCRIPTION
This is a tag containing an ordinary string but the tag itself has an additional `TI` (text identifier) attribute. The only user is the `DTC` tag and it also seems to be very unusual to specify a text identifier there.

This is the last missing tag type that can be specified inside `DIAG-LAYER-CONTAINER`, `COMPARAM-SUBSET` or `COMPARAM-SPEC`, i.e., after this commit the diagnostics related functionality of the ODX standard should be fully covered by odxtools... (modulo bugs)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 