### PR TITLE
SnRefContext: Handle `ComparamSpec`s and `ComparamSubset`s like diaglayers

### DIFF
--- a/odxtools/comparamspec.py
+++ b/odxtools/comparamspec.py
@@ -51,7 +51,11 @@ class ComparamSpec(OdxCategory):
         super()._finalize_init(database, odxlinks)
 
     def _resolve_snrefs(self, context: SnRefContext) -> None:
+        context.comparam_spec = self
+
         super()._resolve_snrefs(context)
 
         for ps in self.prot_stacks:
             ps._resolve_snrefs(context)
+
+        context.comparam_spec = None

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -98,6 +98,8 @@ class ComparamSubset(OdxCategory):
         super()._finalize_init(database, odxlinks)
 
     def _resolve_snrefs(self, context: SnRefContext) -> None:
+        context.comparam_subset = self
+
         super()._resolve_snrefs(context)
 
         for dop in self.data_object_props:
@@ -111,3 +113,5 @@ class ComparamSubset(OdxCategory):
 
         if self.unit_spec:
             self.unit_spec._resolve_snrefs(context)
+
+        context.comparam_subset = None

--- a/odxtools/snrefcontext.py
+++ b/odxtools/snrefcontext.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
+    from .comparamspec import ComparamSpec
+    from .comparamsubset import ComparamSubset
     from .database import Database
     from .diaglayers.diaglayer import DiagLayer
     from .diagservice import DiagService
@@ -21,6 +23,8 @@ class SnRefContext:
 
     database: Optional["Database"] = None
     diag_layer: Optional["DiagLayer"] = None
+    comparam_spec: Optional["ComparamSpec"] = None
+    comparam_subset: Optional["ComparamSubset"] = None
     diag_service: Optional["DiagService"] = None
     single_ecu_job: Optional["SingleEcuJob"] = None
     request: Optional["Request"] = None


### PR DESCRIPTION
This is a spin-off PR of #400 proposed by [at]kayoub5: in principle, this allows to resolve SNREFs that are relative to the
`COMPARAM-{SPEC,SUBSET}`. There are currently no users for this, but since this is a pretty simple change and `COMPARAM-{SPEC,SUBSET}` are equivalent to the DIAG-LAYERs from a topological point of view, let's introduce this...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 