### PR TITLE
Fix tag name for PosResponseSuppressible.bit_mask

### DIFF
--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -53,7 +53,7 @@ class PosResponseSuppressible:
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "PosResponseSuppressible":
 
-        bit_mask = int(odxrequire(et_element.findtext("BITMASK")))
+        bit_mask = int(odxrequire(et_element.findtext("BIT-MASK")))
 
         coded_const_snref = None
         if (cc_snref_elem := et_element.find("CODED-CONST-SNREF")) is not None:


### PR DESCRIPTION
According to the specification, the bit mask property for `PosResponseSuppressible` is defined using the tag name **BIT-MASK**, not **BITMASK**.


odxtools version: 9.5.0