### PR TITLE
centralize parsing of `xsd:hexBinary` values

### DIFF
--- a/odxtools/posresponsesuppressible.py
+++ b/odxtools/posresponsesuppressible.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .odxlink import OdxDocFragment
+from .utils import read_hex_binary
 
 
 # note that the spec has a typo here: it calls the corresponding
@@ -29,7 +30,7 @@ class PosResponseSuppressible:
     def from_et(et_element: ElementTree.Element,
                 doc_frags: List[OdxDocFragment]) -> "PosResponseSuppressible":
 
-        bit_mask = int(odxrequire(et_element.findtext("BIT-MASK")))
+        bit_mask = odxrequire(read_hex_binary(et_element.find("BIT-MASK")))
 
         coded_const_snref = None
         if (cc_snref_elem := et_element.find("CODED-CONST-SNREF")) is not None:

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -11,7 +11,7 @@ from .encodestate import EncodeState
 from .exceptions import odxassert, odxraise, odxrequire
 from .odxlink import OdxDocFragment
 from .odxtypes import AtomicOdxType, BytesTypes, DataType, odxstr_to_bool
-from .utils import dataclass_fields_asdict
+from .utils import dataclass_fields_asdict, read_hex_binary
 
 
 @dataclass
@@ -36,16 +36,7 @@ class StandardLengthType(DiagCodedType):
         kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
 
         bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
-        bit_mask = None
-        if (bit_mask_str := et_element.findtext("BIT-MASK")) is not None:
-            # The XSD uses the type xsd:hexBinary
-            # xsd:hexBinary allows for leading/trailing whitespace, empty strings, and it only allows an even
-            # number of hex digits, while some of the examples shown in the  ODX specification exhibit an
-            # odd number of hex digits.
-            # This causes a validation paradox, so we try to be flexible
-            bit_mask_str = bit_mask_str.strip()
-            if len(bit_mask_str):
-                bit_mask = int(bit_mask_str, 16)
+        bit_mask = read_hex_binary(et_element.find("BIT-MASK"))
         is_condensed_raw = odxstr_to_bool(et_element.get("IS-CONDENSED"))
 
         return StandardLengthType(

--- a/odxtools/templates/macros/printService.xml.jinja2
+++ b/odxtools/templates/macros/printService.xml.jinja2
@@ -8,7 +8,8 @@
 
 {%- macro printPosResponseSuppressible(prs) -%}
 <POS-RESPONSE-SUPPRESSABLE>
-  <BIT-MASK>{{ hex(prs.bit_mask).lower() }}</BIT-MASK>
+  {%- set num_nibbles = (prs.bit_mask.bit_length() + 7) // 8 * 2 %}
+  <BIT-MASK>{{ ("%%0%dX" | format(num_nibbles | int)) | format(prs.bit_mask | int) }}</BIT-MASK>
   {%- if prs.coded_const_snref is not none %}
   <CODED-CONST-SNREF SHORT-NAME="{{ prs.coded_const_snref }}" />
   {%- endif %}

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -2,11 +2,38 @@
 import dataclasses
 import re
 from typing import TYPE_CHECKING, Any, Dict, Optional
+from xml.etree import ElementTree
+
+from .exceptions import odxraise
 
 if TYPE_CHECKING:
     from .database import Database
     from .diaglayers.diaglayer import DiagLayer
     from .snrefcontext import SnRefContext
+
+
+def read_hex_binary(et_element: Optional[ElementTree.Element]) -> Optional[int]:
+    """Convert the contents of an xsd:hexBinary to a `bytes` object"""
+    if et_element is None:
+        return None
+
+    if (bytes_str := et_element.text) is None:
+        odxraise(f"Element {et_element.tag} has no content")
+        return None
+
+    # The XSD uses the type xsd:hexBinary and xsd:hexBinary allows for
+    # leading/trailing whitespace and empty strings whilst `int(x,
+    # 16)` raises an exception if one of these things happen.
+    bytes_str = bytes_str.strip()
+    if len(bytes_str) == 0:
+        return 0
+
+    try:
+        return int(bytes_str, 16)
+    except Exception as e:
+        odxraise(f"Caught exception while parsing hex string `{bytes_str}`"
+                 f" of {et_element.tag}: {e}")
+        return None
 
 
 def retarget_snrefs(database: "Database",

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -13,13 +13,15 @@ if TYPE_CHECKING:
 
 
 def read_hex_binary(et_element: Optional[ElementTree.Element]) -> Optional[int]:
-    """Convert the contents of an xsd:hexBinary to a `bytes` object"""
+    """Convert the contents of an xsd:hexBinary to an integer
+    """
     if et_element is None:
         return None
 
     if (bytes_str := et_element.text) is None:
-        odxraise(f"Element {et_element.tag} has no content")
-        return None
+        # tag exists but is immediately terminated ("<FOO />"). we
+        # treat this like an empty string.
+        return 0
 
     # The XSD uses the type xsd:hexBinary and xsd:hexBinary allows for
     # leading/trailing whitespace and empty strings whilst `int(x,


### PR DESCRIPTION
This is a follow-up of https://github.com/mercedes-benz/odxtools/pull/402 proposed by @kayoub5. Besides eliminating a few lines of copy-and-pasted code, a surprising number of things can go wrong here, so it makes sense to centralize this.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
