### PR TITLE
Pass model version down for version dependent parsing

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -8,6 +8,8 @@ from itertools import chain
 from typing import Any
 from xml.etree import ElementTree
 
+from packaging.version import Version
+
 import odxtools.uds as uds
 from odxtools.additionalaudience import AdditionalAudience
 from odxtools.admindata import AdminData
@@ -44,6 +46,7 @@ from odxtools.exceptions import odxrequire
 from odxtools.functionalclass import FunctionalClass
 from odxtools.modification import Modification
 from odxtools.nameditemlist import NamedItemList
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
@@ -75,6 +78,8 @@ from odxtools.unitgroup import UnitGroup
 from odxtools.unitgroupcategory import UnitGroupCategory
 from odxtools.unitspec import UnitSpec
 from odxtools.xdoc import XDoc
+
+ODX_VERSION = Version("2.2.0")
 
 
 class SomersaultSID(IntEnum):
@@ -3020,14 +3025,14 @@ for odx_cs_filename in (
     odx_cs_root = ElementTree.parse(odx_cs_dir / odx_cs_filename).getroot()
     subset = odx_cs_root.find("COMPARAM-SUBSET")
     if subset is not None:
-        comparam_subsets.append(ComparamSubset.from_et(subset, []))
+        comparam_subsets.append(ComparamSubset.from_et(subset, OdxDocContext(ODX_VERSION, [])))
 
 comparam_specs = []
 for odx_c_filename in ("UDSOnCAN_CPS.odx-c",):
     odx_c_root = ElementTree.parse(odx_cs_dir / odx_c_filename).getroot()
     subset = odx_c_root.find("COMPARAM-SPEC")
     if subset is not None:
-        comparam_specs.append(ComparamSpec.from_et(subset, []))
+        comparam_specs.append(ComparamSpec.from_et(subset, OdxDocContext(ODX_VERSION, [])))
 
 # create a database object
 database = Database()

--- a/odxtools/additionalaudience.py
+++ b/odxtools/additionalaudience.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -16,9 +17,8 @@ class AdditionalAudience(IdentifiableElement):
     """
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "AdditionalAudience":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "AdditionalAudience":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         return AdditionalAudience(**kwargs)
 

--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .companydocinfo import CompanyDocInfo
 from .docrevision import DocRevision
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
@@ -17,7 +18,7 @@ class AdminData:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element | None,
-                doc_frags: list[OdxDocFragment]) -> Optional["AdminData"]:
+                context: OdxDocContext) -> Optional["AdminData"]:
 
         if et_element is None:
             return None
@@ -25,12 +26,12 @@ class AdminData:
         language = et_element.findtext("LANGUAGE")
 
         company_doc_infos = [
-            CompanyDocInfo.from_et(cdi_elem, doc_frags)
+            CompanyDocInfo.from_et(cdi_elem, context)
             for cdi_elem in et_element.iterfind("COMPANY-DOC-INFOS/COMPANY-DOC-INFO")
         ]
 
         doc_revisions = [
-            DocRevision.from_et(dr_elem, doc_frags)
+            DocRevision.from_et(dr_elem, context)
             for dr_elem in et_element.iterfind("DOC-REVISIONS/DOC-REVISION")
         ]
 

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .additionalaudience import AdditionalAudience
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 
@@ -50,15 +51,14 @@ class Audience:
         return self._disabled_audiences
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Audience":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Audience":
 
         enabled_audience_refs = [
-            OdxLinkRef.from_et(ref, doc_frags)
-            for ref in et_element.iterfind("ENABLED-AUDIENCE-REFS/"
-                                           "ENABLED-AUDIENCE-REF")
+            OdxLinkRef.from_et(ref, context) for ref in et_element.iterfind("ENABLED-AUDIENCE-REFS/"
+                                                                            "ENABLED-AUDIENCE-REF")
         ]
         disabled_audience_refs = [
-            OdxLinkRef.from_et(ref, doc_frags)
+            OdxLinkRef.from_et(ref, context)
             for ref in et_element.iterfind("DISABLED-AUDIENCE-REFS/"
                                            "DISABLED-AUDIENCE-REF")
         ]

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement
 from .exceptions import odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .standardizationlevel import StandardizationLevel
 from .usage import Usage
@@ -20,8 +21,8 @@ class BaseComparam(IdentifiableElement):
     cpusage: Usage | None  # Required in ODX 2.2, missing in ODX 2.0
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "BaseComparam":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BaseComparam":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         param_class = odxrequire(et_element.attrib.get("PARAM-CLASS"))
 

--- a/odxtools/basevariantpattern.py
+++ b/odxtools/basevariantpattern.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from .exceptions import odxassert
 from .matchingbasevariantparameter import MatchingBaseVariantParameter
 from .matchingparameter import MatchingParameter
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .variantpattern import VariantPattern
 
 
@@ -19,11 +19,10 @@ class BaseVariantPattern(VariantPattern):
     matching_base_variant_parameters: list[MatchingBaseVariantParameter]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "BaseVariantPattern":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BaseVariantPattern":
 
         matching_base_variant_parameters = [
-            MatchingBaseVariantParameter.from_et(mbvp_el, doc_frags)
+            MatchingBaseVariantParameter.from_et(mbvp_el, context)
             for mbvp_el in et_element.iterfind("MATCHING-BASE-VARIANT-PARAMETERS/"
                                                "MATCHING-BASE-VARIANT-PARAMETER")
         ]

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -14,7 +14,8 @@ from .decodestate import DecodeState
 from .encodestate import EncodeState
 from .exceptions import DecodeError, odxraise
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterValue
 from .parameters.createanyparameter import create_any_parameter_from_et
 from .parameters.parameter import Parameter
@@ -42,15 +43,14 @@ class BasicStructure(ComplexDop):
         return composite_codec_get_free_parameters(self)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "BasicStructure":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BasicStructure":
         """Read a BASIC-STRUCTURE."""
-        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, context))
 
         byte_size_str = et_element.findtext("BYTE-SIZE")
         byte_size = int(byte_size_str) if byte_size_str is not None else None
         parameters = NamedItemList([
-            create_any_parameter_from_et(et_parameter, doc_frags)
+            create_any_parameter_from_et(et_parameter, context)
             for et_parameter in et_element.iterfind("PARAMS/PARAM")
         ])
 

--- a/odxtools/commrelation.py
+++ b/odxtools/commrelation.py
@@ -9,7 +9,8 @@ from .description import Description
 from .diagcomm import DiagComm
 from .diagservice import DiagService
 from .exceptions import OdxWarning, odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .parameters.parameter import Parameter
 from .snrefcontext import SnRefContext
 
@@ -46,11 +47,11 @@ class CommRelation:
         return self.value_type_raw
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "CommRelation":
-        description = Description.from_et(et_element.find("DESC"), doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CommRelation":
+        description = Description.from_et(et_element.find("DESC"), context)
         relation_type = odxrequire(et_element.findtext("RELATION-TYPE"))
 
-        diag_comm_ref = OdxLinkRef.from_et(et_element.find("DIAG-COMM-REF"), doc_frags)
+        diag_comm_ref = OdxLinkRef.from_et(et_element.find("DIAG-COMM-REF"), context)
         diag_comm_snref = None
         if (diag_comm_snref_elem := et_element.find("DIAG-COMM-SNREF")) is not None:
             diag_comm_snref = odxrequire(diag_comm_snref_elem.get("SHORT-NAME"))

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -7,7 +7,8 @@ from .companyspecificinfo import CompanySpecificInfo
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .teammember import TeamMember
 from .utils import dataclass_fields_asdict
@@ -20,21 +21,20 @@ class CompanyData(IdentifiableElement):
     company_specific_info: CompanySpecificInfo | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "CompanyData":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CompanyData":
 
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         roles = []
         if (roles_elem := et_element.find("ROLES")) is not None:
             roles = [odxrequire(role.text) for role in roles_elem.iterfind("ROLE")]
         team_members = [
-            TeamMember.from_et(tm, doc_frags)
+            TeamMember.from_et(tm, context)
             for tm in et_element.iterfind("TEAM-MEMBERS/TEAM-MEMBER")
         ]
         company_specific_info = None
         if (company_specific_info_elem := et_element.find("COMPANY-SPECIFIC-INFO")) is not None:
-            company_specific_info = CompanySpecificInfo.from_et(company_specific_info_elem,
-                                                                doc_frags)
+            company_specific_info = CompanySpecificInfo.from_et(company_specific_info_elem, context)
 
         return CompanyData(
             roles=roles,

--- a/odxtools/companydocinfo.py
+++ b/odxtools/companydocinfo.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .companydata import CompanyData
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
 from .teammember import TeamMember
@@ -27,16 +28,13 @@ class CompanyDocInfo:
         return self._team_member
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "CompanyDocInfo":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CompanyDocInfo":
         # the company data reference is mandatory
         company_data_ref = odxrequire(
-            OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags))
-        team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
+            OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), context))
+        team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), context)
         doc_label = et_element.findtext("DOC-LABEL")
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return CompanyDocInfo(
             company_data_ref=company_data_ref,

--- a/odxtools/companyrevisioninfo.py
+++ b/odxtools/companyrevisioninfo.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .companydata import CompanyData
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
@@ -20,11 +21,10 @@ class CompanyRevisionInfo:
         return self._company_data
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "CompanyRevisionInfo":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CompanyRevisionInfo":
 
         company_data_ref = odxrequire(
-            OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags))
+            OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), context))
         revision_label = et_element.findtext("REVISION-LABEL")
         state = et_element.findtext("STATE")
 

--- a/odxtools/companyspecificinfo.py
+++ b/odxtools/companyspecificinfo.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from typing import Any
 from xml.etree import ElementTree
 
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .relateddoc import RelatedDoc
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
@@ -15,16 +16,13 @@ class CompanySpecificInfo:
     sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "CompanySpecificInfo":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CompanySpecificInfo":
         related_docs = [
-            RelatedDoc.from_et(rd, doc_frags)
+            RelatedDoc.from_et(rd, context)
             for rd in et_element.iterfind("RELATED-DOCS/RELATED-DOC")
         ]
 
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return CompanySpecificInfo(related_docs=related_docs, sdgs=sdgs)
 

--- a/odxtools/comparam.py
+++ b/odxtools/comparam.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .basecomparam import BaseComparam
 from .dataobjectproperty import DataObjectProperty
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import AtomicOdxType
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -27,11 +28,11 @@ class Comparam(BaseComparam):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Comparam":
-        kwargs = dataclass_fields_asdict(BaseComparam.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Comparam":
+        kwargs = dataclass_fields_asdict(BaseComparam.from_et(et_element, context))
 
         physical_default_value_raw = odxrequire(et_element.findtext("PHYSICAL-DEFAULT-VALUE"))
-        dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags))
+        dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), context))
 
         return Comparam(
             dop_ref=dop_ref, physical_default_value_raw=physical_default_value_raw, **kwargs)

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -9,7 +9,8 @@ from .comparam import Comparam
 from .complexcomparam import ComplexComparam, ComplexValue, create_complex_value_from_et
 from .description import Description
 from .exceptions import OdxWarning, odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
@@ -35,9 +36,8 @@ class ComparamInstance:
         return self.spec.short_name
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ComparamInstance":
-        spec_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ComparamInstance":
+        spec_ref = odxrequire(OdxLinkRef.from_et(et_element, context))
 
         # ODX standard v2.0.0 defined only VALUE. ODX v2.0.1 decided
         # to break things and change it to a choice between SIMPLE-VALUE
@@ -50,7 +50,7 @@ class ComparamInstance:
         else:
             value = create_complex_value_from_et(odxrequire(et_element.find("COMPLEX-VALUE")))
 
-        description = Description.from_et(et_element.find("DESC"), doc_frags)
+        description = Description.from_et(et_element.find("DESC"), context)
 
         protocol_snref = None
         if (psnref_elem := et_element.find("PROTOCOL-SNREF")) is not None:

--- a/odxtools/comparamspec.py
+++ b/odxtools/comparamspec.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .nameditemlist import NamedItemList
 from .odxcategory import OdxCategory
-from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import DocType, OdxLinkDatabase, OdxLinkId
 from .protstack import ProtStack
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -20,15 +21,13 @@ class ComparamSpec(OdxCategory):
     prot_stacks: NamedItemList[ProtStack]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ComparamSpec":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ComparamSpec":
 
-        base_obj = OdxCategory.category_from_et(
-            et_element, doc_frags, doc_type=DocType.COMPARAM_SPEC)
-        doc_frags = base_obj.odx_id.doc_fragments
+        base_obj = OdxCategory.category_from_et(et_element, context, doc_type=DocType.COMPARAM_SPEC)
         kwargs = dataclass_fields_asdict(base_obj)
 
         prot_stacks = NamedItemList([
-            ProtStack.from_et(dl_element, doc_frags)
+            ProtStack.from_et(dl_element, context)
             for dl_element in et_element.iterfind("PROT-STACKS/PROT-STACK")
         ])
 

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -34,9 +35,8 @@ class ComplexComparam(BaseComparam):
         return self.allow_multiple_values_raw is True
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ComplexComparam":
-        kwargs = dataclass_fields_asdict(BaseComparam.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ComplexComparam":
+        kwargs = dataclass_fields_asdict(BaseComparam.from_et(et_element, context))
 
         # to avoid a cyclic import, create_any_comparam_from_et cannot
         # be imported globally. TODO: figure out if this has
@@ -61,7 +61,7 @@ class ComplexComparam(BaseComparam):
             if elems[i].tag not in ("COMPARAM", "COMPLEX-COMPARAM"):
                 break
 
-            subparam = create_any_comparam_from_et(elems[i], doc_frags)
+            subparam = create_any_comparam_from_et(elems[i], context)
             subparams.append(subparam)
             i += 1
 

--- a/odxtools/compumethods/compucodecompumethod.py
+++ b/odxtools/compumethods/compucodecompumethod.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..progcode import ProgCode
 from ..utils import dataclass_fields_asdict
@@ -34,11 +34,11 @@ class CompuCodeCompuMethod(CompuMethod):
         return self.compu_phys_to_internal.prog_code
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "CompuCodeCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return CompuCodeCompuMethod(**kwargs)

--- a/odxtools/compumethods/compuinternaltophys.py
+++ b/odxtools/compumethods/compuinternaltophys.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from typing import Any
 from xml.etree import ElementTree
 
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import DataType
 from ..progcode import ProgCode
 from ..snrefcontext import SnRefContext
@@ -18,18 +19,18 @@ class CompuInternalToPhys:
     compu_default_value: CompuDefaultValue | None
 
     @staticmethod
-    def compu_internal_to_phys_from_et(et_element: ElementTree.Element,
-                                       doc_frags: list[OdxDocFragment], *, internal_type: DataType,
+    def compu_internal_to_phys_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
+                                       internal_type: DataType,
                                        physical_type: DataType) -> "CompuInternalToPhys":
         compu_scales = [
             CompuScale.compuscale_from_et(
-                cse, doc_frags, domain_type=internal_type, range_type=physical_type)
+                cse, context, domain_type=internal_type, range_type=physical_type)
             for cse in et_element.iterfind("COMPU-SCALES/COMPU-SCALE")
         ]
 
         prog_code = None
         if (pce := et_element.find("PROG-CODE")) is not None:
-            prog_code = ProgCode.from_et(pce, doc_frags)
+            prog_code = ProgCode.from_et(pce, context)
 
         compu_default_value = None
         if (cdve := et_element.find("COMPU-DEFAULT-VALUE")) is not None:

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import AtomicOdxType, DataType
 from ..snrefcontext import SnRefContext
 from .compucategory import CompuCategory
@@ -38,7 +39,7 @@ class CompuMethod:
     internal_type: DataType
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType, physical_type: DataType) -> "CompuMethod":
         cat_text = et_element.findtext("CATEGORY")
         if cat_text is None:
@@ -54,11 +55,11 @@ class CompuMethod:
         compu_internal_to_phys = None
         if (citp_elem := et_element.find("COMPU-INTERNAL-TO-PHYS")) is not None:
             compu_internal_to_phys = CompuInternalToPhys.compu_internal_to_phys_from_et(
-                citp_elem, doc_frags, internal_type=internal_type, physical_type=physical_type)
+                citp_elem, context, internal_type=internal_type, physical_type=physical_type)
         compu_phys_to_internal = None
         if (cpti_elem := et_element.find("COMPU-PHYS-TO-INTERNAL")) is not None:
             compu_phys_to_internal = CompuPhysToInternal.compu_phys_to_internal_from_et(
-                cpti_elem, doc_frags, internal_type=internal_type, physical_type=physical_type)
+                cpti_elem, context, internal_type=internal_type, physical_type=physical_type)
 
         return CompuMethod(
             category=category,

--- a/odxtools/compumethods/compuphystointernal.py
+++ b/odxtools/compumethods/compuphystointernal.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from typing import Any
 from xml.etree import ElementTree
 
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import DataType
 from ..progcode import ProgCode
 from ..snrefcontext import SnRefContext
@@ -18,18 +19,18 @@ class CompuPhysToInternal:
     compu_default_value: CompuDefaultValue | None
 
     @staticmethod
-    def compu_phys_to_internal_from_et(et_element: ElementTree.Element,
-                                       doc_frags: list[OdxDocFragment], *, internal_type: DataType,
+    def compu_phys_to_internal_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
+                                       internal_type: DataType,
                                        physical_type: DataType) -> "CompuPhysToInternal":
         compu_scales = [
             CompuScale.compuscale_from_et(
-                cse, doc_frags, domain_type=physical_type, range_type=internal_type)
+                cse, context, domain_type=physical_type, range_type=internal_type)
             for cse in et_element.iterfind("COMPU-SCALES/COMPU-SCALE")
         ]
 
         prog_code = None
         if (pce := et_element.find("PROG-CODE")) is not None:
-            prog_code = ProgCode.from_et(pce, doc_frags)
+            prog_code = ProgCode.from_et(pce, context)
 
         compu_default_value = None
         if (cdve := et_element.find("COMPU-DEFAULT-VALUE")) is not None:

--- a/odxtools/compumethods/compurationalcoeffs.py
+++ b/odxtools/compumethods/compurationalcoeffs.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import odxassert, odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import DataType
 
 
@@ -16,7 +16,7 @@ class CompuRationalCoeffs:
     denominators: list[int | float]
 
     @staticmethod
-    def coeffs_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def coeffs_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                        value_type: DataType) -> "CompuRationalCoeffs":
         odxassert(
             value_type

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from ..description import Description
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from .compuconst import CompuConst
 from .compuinversevalue import CompuInverseValue
@@ -37,15 +37,15 @@ class CompuScale:
     range_type: DataType
 
     @staticmethod
-    def compuscale_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compuscale_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                            domain_type: DataType, range_type: DataType) -> "CompuScale":
         short_label = et_element.findtext("SHORT-LABEL")
-        description = Description.from_et(et_element.find("DESC"), doc_frags)
+        description = Description.from_et(et_element.find("DESC"), context)
 
         lower_limit = Limit.limit_from_et(
-            et_element.find("LOWER-LIMIT"), doc_frags, value_type=domain_type)
+            et_element.find("LOWER-LIMIT"), context, value_type=domain_type)
         upper_limit = Limit.limit_from_et(
-            et_element.find("UPPER-LIMIT"), doc_frags, value_type=domain_type)
+            et_element.find("UPPER-LIMIT"), context, value_type=domain_type)
 
         compu_inverse_value = None
         if (cive := et_element.find("COMPU-INVERSE-VALUE")) is not None:
@@ -58,7 +58,7 @@ class CompuScale:
         compu_rational_coeffs: CompuRationalCoeffs | None = None
         if (crc_elem := et_element.find("COMPU-RATIONAL-COEFFS")) is not None:
             compu_rational_coeffs = CompuRationalCoeffs.coeffs_from_et(
-                crc_elem, doc_frags, value_type=range_type)
+                crc_elem, context, value_type=range_type)
 
         return CompuScale(
             short_label=short_label,

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -2,7 +2,7 @@
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise, odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import DataType
 from .compucodecompumethod import CompuCodeCompuMethod
 from .compumethod import CompuMethod
@@ -15,38 +15,38 @@ from .tabintpcompumethod import TabIntpCompuMethod
 from .texttablecompumethod import TexttableCompuMethod
 
 
-def create_any_compu_method_from_et(et_element: ElementTree.Element,
-                                    doc_frags: list[OdxDocFragment], *, internal_type: DataType,
+def create_any_compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
+                                    internal_type: DataType,
                                     physical_type: DataType) -> CompuMethod:
     compu_category = odxrequire(et_element.findtext("CATEGORY"))
 
     if compu_category == "IDENTICAL":
         return IdenticalCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "LINEAR":
         return LinearCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "SCALE-LINEAR":
         return ScaleLinearCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "RAT-FUNC":
         return RatFuncCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "SCALE-RAT-FUNC":
         return ScaleRatFuncCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "TEXTTABLE":
         return TexttableCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "COMPUCODE":
         return CompuCodeCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
     elif compu_category == "TAB-INTP":
         return TabIntpCompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
 
     # TODO: Implement all categories (never instantiate the CompuMethod base class!)
     odxraise(f"Warning: Computation category {compu_category} is not implemented!")
 
     return IdenticalCompuMethod.compu_method_from_et(
-        et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+        et_element, context, internal_type=internal_type, physical_type=physical_type)

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from ..exceptions import odxassert
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compumethod import CompuMethod
@@ -17,11 +17,11 @@ class IdenticalCompuMethod(CompuMethod):
     """
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "IdenticalCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         odxassert(

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -4,7 +4,7 @@ from typing import Optional, overload
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType, compare_odx_values
 from .intervaltype import IntervalType
 
@@ -21,18 +21,18 @@ class Limit:
 
     @staticmethod
     @overload
-    def limit_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment],
+    def limit_from_et(et_element: ElementTree.Element, context: OdxDocContext,
                       value_type: DataType | None) -> "Limit":
         ...
 
     @staticmethod
     @overload
-    def limit_from_et(et_element: None, doc_frags: list[OdxDocFragment],
+    def limit_from_et(et_element: None, context: OdxDocContext,
                       value_type: DataType | None) -> None:
         ...
 
     @staticmethod
-    def limit_from_et(et_element: ElementTree.Element | None, doc_frags: list[OdxDocFragment],
+    def limit_from_et(et_element: ElementTree.Element | None, context: OdxDocContext,
                       value_type: DataType | None) -> Optional["Limit"]:
 
         if et_element is None:

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compucategory import CompuCategory
@@ -30,11 +30,11 @@ class LinearCompuMethod(CompuMethod):
         return self._segment
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "LinearCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return LinearCompuMethod(**kwargs)

--- a/odxtools/compumethods/ratfunccompumethod.py
+++ b/odxtools/compumethods/ratfunccompumethod.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compucategory import CompuCategory
@@ -34,11 +34,11 @@ class RatFuncCompuMethod(CompuMethod):
         return self._phys_to_int_segment
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "RatFuncCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return RatFuncCompuMethod(**kwargs)

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compucategory import CompuCategory
@@ -25,11 +25,11 @@ class ScaleLinearCompuMethod(CompuMethod):
         return self._segments
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "ScaleLinearCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return ScaleLinearCompuMethod(**kwargs)

--- a/odxtools/compumethods/scaleratfunccompumethod.py
+++ b/odxtools/compumethods/scaleratfunccompumethod.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compucategory import CompuCategory
@@ -28,11 +28,11 @@ class ScaleRatFuncCompuMethod(CompuMethod):
         return self._phys_to_int_segments
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "ScaleRatFuncCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return ScaleRatFuncCompuMethod(**kwargs)

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compucategory import CompuCategory
@@ -60,11 +60,11 @@ class TabIntpCompuMethod(CompuMethod):
         return self._physical_upper_limit
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "TabIntpCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return TabIntpCompuMethod(**kwargs)

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -4,7 +4,7 @@ from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import AtomicOdxType, DataType
 from ..utils import dataclass_fields_asdict
 from .compucategory import CompuCategory
@@ -22,11 +22,11 @@ class TexttableCompuMethod(CompuMethod):
     """
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              internal_type: DataType,
                              physical_type: DataType) -> "TexttableCompuMethod":
         cm = CompuMethod.compu_method_from_et(
-            et_element, doc_frags, internal_type=internal_type, physical_type=physical_type)
+            et_element, context, internal_type=internal_type, physical_type=physical_type)
         kwargs = dataclass_fields_asdict(cm)
 
         return TexttableCompuMethod(**kwargs)

--- a/odxtools/createanycomparam.py
+++ b/odxtools/createanycomparam.py
@@ -2,14 +2,14 @@ from xml.etree import ElementTree
 
 from .comparam import Comparam
 from .complexcomparam import ComplexComparam
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 
 
 def create_any_comparam_from_et(et_element: ElementTree.Element,
-                                doc_frags: list[OdxDocFragment]) -> Comparam | ComplexComparam:
+                                context: OdxDocContext) -> Comparam | ComplexComparam:
     if et_element.tag == "COMPARAM":
-        return Comparam.from_et(et_element, doc_frags)
+        return Comparam.from_et(et_element, context)
     elif et_element.tag == "COMPLEX-COMPARAM":
-        return ComplexComparam.from_et(et_element, doc_frags)
+        return ComplexComparam.from_et(et_element, context)
 
     raise RuntimeError(f"Unhandled communication parameter type {et_element.tag}")

--- a/odxtools/createanydiagcodedtype.py
+++ b/odxtools/createanydiagcodedtype.py
@@ -6,22 +6,22 @@ from .exceptions import odxraise
 from .globals import xsi
 from .leadinglengthinfotype import LeadingLengthInfoType
 from .minmaxlengthtype import MinMaxLengthType
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .paramlengthinfotype import ParamLengthInfoType
 from .standardlengthtype import StandardLengthType
 
 
 def create_any_diag_coded_type_from_et(et_element: ElementTree.Element,
-                                       doc_frags: list[OdxDocFragment]) -> DiagCodedType:
+                                       context: OdxDocContext) -> DiagCodedType:
     dct_type = et_element.get(f"{xsi}type")
     if dct_type == "LEADING-LENGTH-INFO-TYPE":
-        return LeadingLengthInfoType.from_et(et_element, doc_frags)
+        return LeadingLengthInfoType.from_et(et_element, context)
     elif dct_type == "MIN-MAX-LENGTH-TYPE":
-        return MinMaxLengthType.from_et(et_element, doc_frags)
+        return MinMaxLengthType.from_et(et_element, context)
     elif dct_type == "PARAM-LENGTH-INFO-TYPE":
-        return ParamLengthInfoType.from_et(et_element, doc_frags)
+        return ParamLengthInfoType.from_et(et_element, context)
     elif dct_type == "STANDARD-LENGTH-TYPE":
-        return StandardLengthType.from_et(et_element, doc_frags)
+        return StandardLengthType.from_et(et_element, context)
 
     odxraise(f"Unknown DIAG-CODED-TYPE {dct_type}", NotImplementedError)
-    return DiagCodedType.from_et(et_element, doc_frags)
+    return DiagCodedType.from_et(et_element, context)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -20,6 +20,7 @@ from .diaglayers.functionalgroup import FunctionalGroup
 from .diaglayers.protocol import Protocol
 from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList
+from .odxdoccontext import OdxDocContext
 from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
@@ -90,7 +91,7 @@ class Database:
 
         dlc = root.find("DIAG-LAYER-CONTAINER")
         if dlc is not None:
-            dlcs.append(DiagLayerContainer.from_et(dlc, []))
+            dlcs.append(DiagLayerContainer.from_et(dlc, OdxDocContext(model_version, [])))
 
         # In ODX 2.0 there was only COMPARAM-SPEC. In ODX 2.2 the
         # content of COMPARAM-SPEC was moved to COMPARAM-SUBSET
@@ -98,14 +99,17 @@ class Database:
         # a PROT-STACK references a list of COMPARAM-SUBSET
         cp_subset = root.find("COMPARAM-SUBSET")
         if cp_subset is not None:
-            comparam_subsets.append(ComparamSubset.from_et(cp_subset, []))
+            comparam_subsets.append(
+                ComparamSubset.from_et(cp_subset, OdxDocContext(model_version, [])))
 
         cp_spec = root.find("COMPARAM-SPEC")
         if cp_spec is not None:
             if model_version < Version("2.2"):
-                comparam_subsets.append(ComparamSubset.from_et(cp_spec, []))
+                comparam_subsets.append(
+                    ComparamSubset.from_et(cp_spec, OdxDocContext(model_version, [])))
             else:  # odx >= 2.2
-                comparam_specs.append(ComparamSpec.from_et(cp_spec, []))
+                comparam_specs.append(
+                    ComparamSpec.from_et(cp_spec, OdxDocContext(model_version, [])))
 
         self._diag_layer_containers.extend(dlcs)
         self._comparam_subsets.extend(comparam_subsets)

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from .exceptions import odxrequire
 from .externaldoc import ExternalDoc
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 
 
 @dataclass
@@ -16,7 +16,7 @@ class Description:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element | None,
-                doc_frags: list[OdxDocFragment]) -> Optional["Description"]:
+                context: OdxDocContext) -> Optional["Description"]:
         if et_element is None:
             return None
 
@@ -35,7 +35,7 @@ class Description:
 
         external_docs = \
             [
-                odxrequire(ExternalDoc.from_et(ed, doc_frags)) for ed in et_element.iterfind("EXTERNAL-DOCS/EXTERNAL-DOC")
+                odxrequire(ExternalDoc.from_et(ed, context)) for ed in et_element.iterfind("EXTERNAL-DOCS/EXTERNAL-DOC")
             ]
 
         text_identifier = et_element.attrib.get("TI")

--- a/odxtools/determinenumberofitems.py
+++ b/odxtools/determinenumberofitems.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .dataobjectproperty import DataObjectProperty
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
@@ -24,11 +25,11 @@ class DetermineNumberOfItems:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DetermineNumberOfItems":
+                context: OdxDocContext) -> "DetermineNumberOfItems":
         byte_position = int(odxrequire(et_element.findtext("BYTE-POSITION")))
         bit_position_str = et_element.findtext("BIT-POSITION")
         bit_position = int(bit_position_str) if bit_position_str is not None else None
-        dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags))
+        dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), context))
 
         return DetermineNumberOfItems(
             byte_position=byte_position,

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -7,7 +7,8 @@ from .decodestate import DecodeState
 from .encodestate import EncodeState
 from .encoding import Encoding
 from .exceptions import odxassert, odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import AtomicOdxType, DataType, odxstr_to_bool
 from .snrefcontext import SnRefContext
 
@@ -38,8 +39,7 @@ class DiagCodedType:
         return self.is_highlow_byte_order_raw in [None, True]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DiagCodedType":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagCodedType":
         base_type_encoding = None
         if (base_type_encoding_str := et_element.get("BASE-TYPE-ENCODING")) is not None:
             try:

--- a/odxtools/diagcomm.py
+++ b/odxtools/diagcomm.py
@@ -10,7 +10,8 @@ from .element import IdentifiableElement
 from .exceptions import odxraise, odxrequire
 from .functionalclass import FunctionalClass
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .odxtypes import odxstr_to_bool
 from .preconditionstateref import PreConditionStateRef
 from .relateddiagcommref import RelatedDiagCommRef
@@ -83,22 +84,20 @@ class DiagComm(IdentifiableElement):
         return self.is_final_raw is True
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagComm":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagComm":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         functional_class_refs = [
-            odxrequire(OdxLinkRef.from_et(el, doc_frags))
+            odxrequire(OdxLinkRef.from_et(el, context))
             for el in et_element.iterfind("FUNCT-CLASS-REFS/FUNCT-CLASS-REF")
         ]
 
         audience = None
         if (audience_elem := et_element.find("AUDIENCE")) is not None:
-            audience = Audience.from_et(audience_elem, doc_frags)
+            audience = Audience.from_et(audience_elem, context)
 
         protocol_snrefs = [
             odxrequire(el.get("SHORT-NAME"))
@@ -106,17 +105,17 @@ class DiagComm(IdentifiableElement):
         ]
 
         related_diag_comm_refs = [
-            RelatedDiagCommRef.from_et(el, doc_frags)
+            RelatedDiagCommRef.from_et(el, context)
             for el in et_element.iterfind("RELATED-DIAG-COMM-REFS/RELATED-DIAG-COMM-REF")
         ]
 
         pre_condition_state_refs = [
-            PreConditionStateRef.from_et(el, doc_frags)
+            PreConditionStateRef.from_et(el, context)
             for el in et_element.iterfind("PRE-CONDITION-STATE-REFS/PRE-CONDITION-STATE-REF")
         ]
 
         state_transition_refs = [
-            StateTransitionRef.from_et(el, doc_frags)
+            StateTransitionRef.from_et(el, context)
             for el in et_element.iterfind("STATE-TRANSITION-REFS/STATE-TRANSITION-REF")
         ]
 

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -15,7 +15,8 @@ from .environmentdata import EnvironmentData
 from .environmentdatadescription import EnvironmentDataDescription
 from .multiplexer import Multiplexer
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
 from .staticfield import StaticField
@@ -43,53 +44,53 @@ class DiagDataDictionarySpec:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DiagDataDictionarySpec":
+                context: OdxDocContext) -> "DiagDataDictionarySpec":
         admin_data = None
         if (admin_data_elem := et_element.find("ADMIN-DATA")) is not None:
-            admin_data = AdminData.from_et(admin_data_elem, doc_frags)
+            admin_data = AdminData.from_et(admin_data_elem, context)
 
         dtc_dops = NamedItemList([
-            DtcDop.from_et(dtc_dop_elem, doc_frags)
+            DtcDop.from_et(dtc_dop_elem, context)
             for dtc_dop_elem in et_element.iterfind("DTC-DOPS/DTC-DOP")
         ])
 
         env_data_descs = NamedItemList([
-            EnvironmentDataDescription.from_et(env_data_desc_element, doc_frags)
+            EnvironmentDataDescription.from_et(env_data_desc_element, context)
             for env_data_desc_element in et_element.iterfind("ENV-DATA-DESCS/ENV-DATA-DESC")
         ])
 
         data_object_props = NamedItemList([
-            DataObjectProperty.from_et(dop_element, doc_frags)
+            DataObjectProperty.from_et(dop_element, context)
             for dop_element in et_element.iterfind("DATA-OBJECT-PROPS/DATA-OBJECT-PROP")
         ])
 
         structures = NamedItemList([
-            Structure.from_et(structure_element, doc_frags)
+            Structure.from_et(structure_element, context)
             for structure_element in et_element.iterfind("STRUCTURES/STRUCTURE")
         ])
 
         static_fields = NamedItemList([
-            StaticField.from_et(dl_element, doc_frags)
+            StaticField.from_et(dl_element, context)
             for dl_element in et_element.iterfind("STATIC-FIELDS/STATIC-FIELD")
         ])
 
         dynamic_length_fields = NamedItemList([
-            DynamicLengthField.from_et(dl_element, doc_frags)
+            DynamicLengthField.from_et(dl_element, context)
             for dl_element in et_element.iterfind("DYNAMIC-LENGTH-FIELDS/DYNAMIC-LENGTH-FIELD")
         ])
 
         dynamic_endmarker_fields = NamedItemList([
-            DynamicEndmarkerField.from_et(dl_element, doc_frags) for dl_element in
+            DynamicEndmarkerField.from_et(dl_element, context) for dl_element in
             et_element.iterfind("DYNAMIC-ENDMARKER-FIELDS/DYNAMIC-ENDMARKER-FIELD")
         ])
 
         end_of_pdu_fields = NamedItemList([
-            EndOfPduField.from_et(eofp_element, doc_frags)
+            EndOfPduField.from_et(eofp_element, context)
             for eofp_element in et_element.iterfind("END-OF-PDU-FIELDS/END-OF-PDU-FIELD")
         ])
 
         muxs = NamedItemList([
-            Multiplexer.from_et(mux_element, doc_frags)
+            Multiplexer.from_et(mux_element, context)
             for mux_element in et_element.iterfind("MUXS/MUX")
         ])
 
@@ -99,23 +100,21 @@ class DiagDataDictionarySpec:
             et_element.iterfind("ENV-DATA-DESCS/ENV-DATA-DESC/ENV-DATAS/ENV-DATA"),
         )
         env_datas = NamedItemList([
-            EnvironmentData.from_et(env_data_element, doc_frags)
+            EnvironmentData.from_et(env_data_element, context)
             for env_data_element in env_data_elements
         ])
 
         if (spec_elem := et_element.find("UNIT-SPEC")) is not None:
-            unit_spec = UnitSpec.from_et(spec_elem, doc_frags)
+            unit_spec = UnitSpec.from_et(spec_elem, context)
         else:
             unit_spec = None
 
         tables = NamedItemList([
-            Table.from_et(table_element, doc_frags)
+            Table.from_et(table_element, context)
             for table_element in et_element.iterfind("TABLES/TABLE")
         ])
 
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return DiagDataDictionarySpec(
             admin_data=admin_data,

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -12,7 +12,8 @@ from .diaglayers.functionalgroup import FunctionalGroup
 from .diaglayers.protocol import Protocol
 from .nameditemlist import NamedItemList
 from .odxcategory import OdxCategory
-from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import DocType, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -40,31 +41,29 @@ class DiagLayerContainer(OdxCategory):
         return self.ecu_variants
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DiagLayerContainer":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagLayerContainer":
 
-        cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type=DocType.CONTAINER)
-        doc_frags = cat.odx_id.doc_fragments
+        cat = OdxCategory.category_from_et(et_element, context, doc_type=DocType.CONTAINER)
         kwargs = dataclass_fields_asdict(cat)
 
         protocols = NamedItemList([
-            Protocol.from_et(dl_element, doc_frags)
+            Protocol.from_et(dl_element, context)
             for dl_element in et_element.iterfind("PROTOCOLS/PROTOCOL")
         ])
         functional_groups = NamedItemList([
-            FunctionalGroup.from_et(dl_element, doc_frags)
+            FunctionalGroup.from_et(dl_element, context)
             for dl_element in et_element.iterfind("FUNCTIONAL-GROUPS/FUNCTIONAL-GROUP")
         ])
         ecu_shared_datas = NamedItemList([
-            EcuSharedData.from_et(dl_element, doc_frags)
+            EcuSharedData.from_et(dl_element, context)
             for dl_element in et_element.iterfind("ECU-SHARED-DATAS/ECU-SHARED-DATA")
         ])
         base_variants = NamedItemList([
-            BaseVariant.from_et(dl_element, doc_frags)
+            BaseVariant.from_et(dl_element, context)
             for dl_element in et_element.iterfind("BASE-VARIANTS/BASE-VARIANT")
         ])
         ecu_variants = NamedItemList([
-            EcuVariant.from_et(dl_element, doc_frags)
+            EcuVariant.from_et(dl_element, context)
             for dl_element in et_element.iterfind("ECU-VARIANTS/ECU-VARIANT")
         ])
 

--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -12,7 +12,8 @@ from ..diagvariable import DiagVariable
 from ..dyndefinedspec import DynDefinedSpec
 from ..exceptions import odxassert
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import VariableGroup
 from .basevariantraw import BaseVariantRaw
@@ -68,8 +69,8 @@ class BaseVariant(HierarchyElement):
     #######
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "BaseVariant":
-        base_variant_raw = BaseVariantRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BaseVariant":
+        base_variant_raw = BaseVariantRaw.from_et(et_element, context)
 
         return BaseVariant(diag_layer_raw=base_variant_raw)
 

--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -8,7 +8,8 @@ from ..diagvariable import DiagVariable
 from ..dyndefinedspec import DynDefinedSpec
 from ..exceptions import odxraise
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..parentref import ParentRef
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
@@ -32,44 +33,42 @@ class BaseVariantRaw(HierarchyElementRaw):
         return self._diag_variables
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "BaseVariantRaw":
-        # objects contained by diagnostic layers exibit an additional
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BaseVariantRaw":
+        # objects contained by diagnostic layers exhibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
         # contained objects.
-        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        her = HierarchyElementRaw.from_et(et_element, context)
         kwargs = dataclass_fields_asdict(her)
-        doc_frags = her.odx_id.doc_fragments
 
         diag_variables_raw: list[DiagVariable | OdxLinkRef] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:
             for dv_proxy_elem in dv_elems:
                 dv_proxy: OdxLinkRef | DiagVariable
                 if dv_proxy_elem.tag == "DIAG-VARIABLE-REF":
-                    dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, doc_frags)
+                    dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, context)
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
-                    dv_proxy = DiagVariable.from_et(dv_proxy_elem, doc_frags)
+                    dv_proxy = DiagVariable.from_et(dv_proxy_elem, context)
                 else:
                     odxraise()
 
                 diag_variables_raw.append(dv_proxy)
 
         variable_groups = NamedItemList([
-            VariableGroup.from_et(vg_elem, doc_frags)
+            VariableGroup.from_et(vg_elem, context)
             for vg_elem in et_element.iterfind("VARIABLE-GROUPS/VARIABLE-GROUP")
         ])
 
         dyn_defined_spec = None
         if (dds_elem := et_element.find("DYN-DEFINED-SPEC")) is not None:
-            dyn_defined_spec = DynDefinedSpec.from_et(dds_elem, doc_frags)
+            dyn_defined_spec = DynDefinedSpec.from_et(dds_elem, context)
 
         base_variant_pattern = None
         if (bvp_elem := et_element.find("BASE-VARIANT-PATTERN")) is not None:
-            base_variant_pattern = BaseVariantPattern.from_et(bvp_elem, doc_frags)
+            base_variant_pattern = BaseVariantPattern.from_et(bvp_elem, context)
 
         parent_refs = [
-            ParentRef.from_et(pr_elem, doc_frags)
+            ParentRef.from_et(pr_elem, context)
             for pr_elem in et_element.iterfind("PARENT-REFS/PARENT-REF")
         ]
 

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -17,7 +17,8 @@ from ..exceptions import DecodeError, odxassert, odxraise
 from ..library import Library
 from ..message import Message
 from ..nameditemlist import NamedItemList, TNamed
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..parentref import ParentRef
 from ..request import Request
 from ..response import Response
@@ -45,8 +46,8 @@ class DiagLayer:
     diag_layer_raw: DiagLayerRaw
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagLayer":
-        diag_layer_raw = DiagLayerRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagLayer":
+        diag_layer_raw = DiagLayerRaw.from_et(et_element, context)
 
         # Create DiagLayer
         return DiagLayer(diag_layer_raw=diag_layer_raw)

--- a/odxtools/diaglayers/ecushareddata.py
+++ b/odxtools/diaglayers/ecushareddata.py
@@ -7,14 +7,15 @@ from xml.etree import ElementTree
 from ..diagvariable import DiagVariable
 from ..exceptions import odxassert
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..snrefcontext import SnRefContext
 from ..variablegroup import VariableGroup
 from .diaglayer import DiagLayer
 from .ecushareddataraw import EcuSharedDataRaw
 
 if TYPE_CHECKING:
-    from .database import Database
+    from ..database import Database
 
 
 @dataclass
@@ -39,9 +40,8 @@ class EcuSharedData(DiagLayer):
         return self.ecu_shared_data_raw.variable_groups
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "EcuSharedData":
-        ecu_shared_data_raw = EcuSharedDataRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EcuSharedData":
+        ecu_shared_data_raw = EcuSharedDataRaw.from_et(et_element, context)
 
         return EcuSharedData(diag_layer_raw=ecu_shared_data_raw)
 

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -12,7 +12,8 @@ from ..dyndefinedspec import DynDefinedSpec
 from ..ecuvariantpattern import EcuVariantPattern
 from ..exceptions import odxassert
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import HasVariableGroups, VariableGroup
 from .basevariant import BaseVariant
@@ -75,8 +76,8 @@ class EcuVariant(HierarchyElement):
     #######
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "EcuVariant":
-        ecu_variant_raw = EcuVariantRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EcuVariant":
+        ecu_variant_raw = EcuVariantRaw.from_et(et_element, context)
 
         return EcuVariant(diag_layer_raw=ecu_variant_raw)
 

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -10,7 +10,8 @@ from typing_extensions import override
 from ..diagvariable import DiagVariable
 from ..exceptions import odxassert
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import VariableGroup
 from .diaglayer import DiagLayer
@@ -44,9 +45,8 @@ class FunctionalGroup(HierarchyElement):
         return self.functional_group_raw.parent_refs
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "FunctionalGroup":
-        functional_group_raw = FunctionalGroupRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "FunctionalGroup":
+        functional_group_raw = FunctionalGroupRaw.from_et(et_element, context)
 
         return FunctionalGroup(diag_layer_raw=functional_group_raw)
 

--- a/odxtools/diaglayers/functionalgroupraw.py
+++ b/odxtools/diaglayers/functionalgroupraw.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from ..diagvariable import DiagVariable
 from ..exceptions import odxraise
 from ..nameditemlist import NamedItemList
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from ..parentref import ParentRef
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
@@ -28,36 +29,34 @@ class FunctionalGroupRaw(HierarchyElementRaw):
         return self._diag_variables
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "FunctionalGroupRaw":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "FunctionalGroupRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
         # contained objects.
-        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        her = HierarchyElementRaw.from_et(et_element, context)
         kwargs = dataclass_fields_asdict(her)
-        doc_frags = her.odx_id.doc_fragments
 
         diag_variables_raw: list[DiagVariable | OdxLinkRef] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:
             for dv_proxy_elem in dv_elems:
                 dv_proxy: OdxLinkRef | DiagVariable
                 if dv_proxy_elem.tag == "DIAG-VARIABLE-REF":
-                    dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, doc_frags)
+                    dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, context)
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
-                    dv_proxy = DiagVariable.from_et(dv_proxy_elem, doc_frags)
+                    dv_proxy = DiagVariable.from_et(dv_proxy_elem, context)
                 else:
                     odxraise()
 
                 diag_variables_raw.append(dv_proxy)
 
         variable_groups = NamedItemList([
-            VariableGroup.from_et(vg_elem, doc_frags)
+            VariableGroup.from_et(vg_elem, context)
             for vg_elem in et_element.iterfind("VARIABLE-GROUPS/VARIABLE-GROUP")
         ])
 
         parent_refs = [
-            ParentRef.from_et(pr_elem, doc_frags)
+            ParentRef.from_et(pr_elem, context)
             for pr_elem in et_element.iterfind("PARENT-REFS/PARENT-REF")
         ]
 

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -17,7 +17,8 @@ from ..diagservice import DiagService
 from ..exceptions import OdxWarning, odxassert, odxraise
 from ..functionalclass import FunctionalClass
 from ..nameditemlist import NamedItemList, OdxNamed
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..parentref import ParentRef
 from ..response import Response
 from ..singleecujob import SingleEcuJob
@@ -46,9 +47,8 @@ class HierarchyElement(DiagLayer):
         return cast(HierarchyElementRaw, self.diag_layer_raw)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "HierarchyElement":
-        hierarchy_element_raw = HierarchyElementRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "HierarchyElement":
+        hierarchy_element_raw = HierarchyElementRaw.from_et(et_element, context)
 
         return HierarchyElement(diag_layer_raw=hierarchy_element_raw)
 

--- a/odxtools/diaglayers/hierarchyelementraw.py
+++ b/odxtools/diaglayers/hierarchyelementraw.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from ..comparaminstance import ComparamInstance
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
 from .diaglayerraw import DiagLayerRaw
@@ -20,18 +21,16 @@ class HierarchyElementRaw(DiagLayerRaw):
     comparam_refs: list[ComparamInstance]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "HierarchyElementRaw":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "HierarchyElementRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
         # contained objects.
-        dlr = DiagLayerRaw.from_et(et_element, doc_frags)
+        dlr = DiagLayerRaw.from_et(et_element, context)
         kwargs = dataclass_fields_asdict(dlr)
-        doc_frags = dlr.odx_id.doc_fragments
 
         comparam_refs = [
-            ComparamInstance.from_et(el, doc_frags)
+            ComparamInstance.from_et(el, context)
             for el in et_element.iterfind("COMPARAM-REFS/COMPARAM-REF")
         ]
 

--- a/odxtools/diaglayers/protocol.py
+++ b/odxtools/diaglayers/protocol.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 
 from ..comparamspec import ComparamSpec
 from ..exceptions import odxassert
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..protstack import ProtStack
 from .hierarchyelement import HierarchyElement
 from .protocolraw import ProtocolRaw
@@ -33,8 +33,8 @@ class Protocol(HierarchyElement):
         return self.protocol_raw.prot_stack
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Protocol":
-        protocol_raw = ProtocolRaw.from_et(et_element, doc_frags)
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Protocol":
+        protocol_raw = ProtocolRaw.from_et(et_element, context)
 
         return Protocol(diag_layer_raw=protocol_raw)
 

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -5,12 +5,12 @@ from xml.etree import ElementTree
 
 from ..comparamspec import ComparamSpec
 from ..exceptions import odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from ..parentref import ParentRef
 from ..protstack import ProtStack
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
-#from .comparaminstance import ComparamInstance
 from .hierarchyelementraw import HierarchyElementRaw
 
 
@@ -36,24 +36,23 @@ class ProtocolRaw(HierarchyElementRaw):
         return self._prot_stack
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ProtocolRaw":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ProtocolRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
         # contained objects.
-        her = HierarchyElementRaw.from_et(et_element, doc_frags)
+        her = HierarchyElementRaw.from_et(et_element, context)
         kwargs = dataclass_fields_asdict(her)
-        doc_frags = her.odx_id.doc_fragments
 
         comparam_spec_ref = OdxLinkRef.from_et(
-            odxrequire(et_element.find("COMPARAM-SPEC-REF")), doc_frags)
+            odxrequire(et_element.find("COMPARAM-SPEC-REF")), context)
 
         prot_stack_snref = None
         if (prot_stack_snref_elem := et_element.find("PROT-STACK-SNREF")) is not None:
             prot_stack_snref = odxrequire(prot_stack_snref_elem.get("SHORT-NAME"))
 
         parent_refs = [
-            ParentRef.from_et(pr_el, doc_frags)
+            ParentRef.from_et(pr_el, context)
             for pr_el in et_element.iterfind("PARENT-REFS/PARENT-REF")
         ]
 

--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
@@ -28,19 +29,16 @@ class DiagnosticTroubleCode(IdentifiableElement):
         return self.is_temporary_raw is True
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DiagnosticTroubleCode":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagnosticTroubleCode":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         trouble_code = int(odxrequire(et_element.findtext("TROUBLE-CODE")))
         display_trouble_code = et_element.findtext("DISPLAY-TROUBLE-CODE")
-        text = Text.from_et(odxrequire(et_element.find("TEXT")), doc_frags)
+        text = Text.from_et(odxrequire(et_element.find("TEXT")), context)
         level = None
         if (level_str := et_element.findtext("LEVEL")) is not None:
             level = int(level_str)
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         is_temporary_raw = odxstr_to_bool(et_element.attrib.get("IS-TEMPORARY"))
 

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -9,7 +9,8 @@ from .diagcomm import DiagComm
 from .exceptions import DecodeError, DecodeMismatch, odxassert, odxraise, odxrequire
 from .message import Message
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import ParameterValue, odxstr_to_bool
 from .parameters.parameter import Parameter
 from .posresponsesuppressible import PosResponseSuppressible
@@ -76,30 +77,30 @@ class DiagService(DiagComm):
         return self.request.free_parameters if self.request is not None else []
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagService":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagService":
 
-        kwargs = dataclass_fields_asdict(DiagComm.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(DiagComm.from_et(et_element, context))
 
         comparam_refs = [
-            ComparamInstance.from_et(el, doc_frags)
+            ComparamInstance.from_et(el, context)
             for el in et_element.iterfind("COMPARAM-REFS/COMPARAM-REF")
         ]
 
-        request_ref = odxrequire(OdxLinkRef.from_et(et_element.find("REQUEST-REF"), doc_frags))
+        request_ref = odxrequire(OdxLinkRef.from_et(et_element.find("REQUEST-REF"), context))
 
         pos_response_refs = [
-            odxrequire(OdxLinkRef.from_et(el, doc_frags))
+            odxrequire(OdxLinkRef.from_et(el, context))
             for el in et_element.iterfind("POS-RESPONSE-REFS/POS-RESPONSE-REF")
         ]
 
         neg_response_refs = [
-            odxrequire(OdxLinkRef.from_et(el, doc_frags))
+            odxrequire(OdxLinkRef.from_et(el, context))
             for el in et_element.iterfind("NEG-RESPONSE-REFS/NEG-RESPONSE-REF")
         ]
 
         pos_response_suppressible = None
         if (prs_elem := et_element.find("POS-RESPONSE-SUPPRESSABLE")) is not None:
-            pos_response_suppressible = PosResponseSuppressible.from_et(prs_elem, doc_frags)
+            pos_response_suppressible = PosResponseSuppressible.from_et(prs_elem, context)
 
         is_cyclic_raw = odxstr_to_bool(et_element.get("IS-CYCLIC"))
         is_multiple_raw = odxstr_to_bool(et_element.get("IS-MULTIPLE"))

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -9,7 +9,8 @@ from .commrelation import CommRelation
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
@@ -66,17 +67,17 @@ class DiagVariable(IdentifiableElement):
         return self.is_read_before_write_raw is True
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagVariable":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DiagVariable":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
-        variable_group_ref = OdxLinkRef.from_et(et_element.find("VARIABLE-GROUP-REF"), doc_frags)
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
+        variable_group_ref = OdxLinkRef.from_et(et_element.find("VARIABLE-GROUP-REF"), context)
         sw_variables = NamedItemList([
-            SwVariable.from_et(swv_elem, doc_frags)
+            SwVariable.from_et(swv_elem, context)
             for swv_elem in et_element.iterfind("SW-VARIABLES/SW-VARIABLE")
         ])
         comm_relations = [
-            CommRelation.from_et(cr_elem, doc_frags)
+            CommRelation.from_et(cr_elem, context)
             for cr_elem in et_element.iterfind("COMM-RELATIONS/COMM-RELATION")
         ]
 
@@ -89,9 +90,7 @@ class DiagVariable(IdentifiableElement):
             table_row_snref_elem = odxrequire(snref_to_tablerow_elem.find("TABLE-ROW-SNREF"))
             table_row_snref = odxrequire(table_row_snref_elem.attrib.get("SHORT-NAME"))
 
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         is_read_before_write_raw = odxstr_to_bool(et_element.get("IS-READ-BEFORE-WRITE"))
 

--- a/odxtools/docrevision.py
+++ b/odxtools/docrevision.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .companyrevisioninfo import CompanyRevisionInfo
 from .exceptions import odxrequire
 from .modification import Modification
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .teammember import TeamMember
 
@@ -30,22 +31,22 @@ class DocRevision:
         return self._team_member
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DocRevision":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DocRevision":
 
-        team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
+        team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), context)
         revision_label = et_element.findtext("REVISION-LABEL")
         state = et_element.findtext("STATE")
         date = odxrequire(et_element.findtext("DATE"))
         tool = et_element.findtext("TOOL")
 
         company_revision_infos = [
-            CompanyRevisionInfo.from_et(cri_elem, doc_frags)
+            CompanyRevisionInfo.from_et(cri_elem, context)
             for cri_elem in et_element.iterfind("COMPANY-REVISION-INFOS/"
                                                 "COMPANY-REVISION-INFO")
         ]
 
         modifications = [
-            Modification.from_et(mod_elem, doc_frags)
+            Modification.from_et(mod_elem, context)
             for mod_elem in et_element.iterfind("MODIFICATIONS/MODIFICATION")
         ]
 

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -7,7 +7,8 @@ from .admindata import AdminData
 from .decodestate import DecodeState
 from .element import IdentifiableElement
 from .encodestate import EncodeState
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterValue
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
@@ -28,17 +29,15 @@ class DopBase(IdentifiableElement):
     sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DopBase":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DopBase":
 
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         admin_data = None
         if (admin_data_elem := et_element.find("ADMIN-DATA")) is not None:
-            admin_data = AdminData.from_et(admin_data_elem, doc_frags)
+            admin_data = AdminData.from_et(admin_data_elem, context)
 
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return DopBase(admin_data=admin_data, sdgs=sdgs, **kwargs)
 

--- a/odxtools/dtcconnector.py
+++ b/odxtools/dtcconnector.py
@@ -7,7 +7,8 @@ from .diagnostictroublecode import DiagnosticTroubleCode
 from .dtcdop import DtcDop
 from .element import NamedElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -26,10 +27,10 @@ class DtcConnector(NamedElement):
         return self._dtc
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DtcConnector":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DtcConnector":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
-        dtc_dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DTC-DOP-REF"), doc_frags))
+        dtc_dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DTC-DOP-REF"), context))
         dtc_snref_el = odxrequire(et_element.find("DTC-SNREF"))
         dtc_snref = odxrequire(dtc_snref_el.get("SHORT-NAME"))
 

--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -12,7 +12,8 @@ from .dynenddopref import DynEndDopRef
 from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
 from .field import Field
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import AtomicOdxType, ParameterValue
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -33,14 +34,13 @@ class DynamicEndmarkerField(Field):
         return self._termination_value
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DynamicEndmarkerField":
-        kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynamicEndmarkerField":
+        kwargs = dataclass_fields_asdict(Field.from_et(et_element, context))
 
         # ODX 2.0 uses DATA-OBJECT-PROP-REF
         # ODX 2.2 uses DYN-END-DOP-REF
         dop_ref = et_element.find("DYN-END-DOP-REF") or et_element.find("DATA-OBJECT-PROP-REF")
-        dyn_end_dop_ref = DynEndDopRef.from_et(odxrequire(dop_ref), doc_frags)
+        dyn_end_dop_ref = DynEndDopRef.from_et(odxrequire(dop_ref), context)
 
         return DynamicEndmarkerField(dyn_end_dop_ref=dyn_end_dop_ref, **kwargs)
 

--- a/odxtools/dynamiclengthfield.py
+++ b/odxtools/dynamiclengthfield.py
@@ -11,7 +11,8 @@ from .determinenumberofitems import DetermineNumberOfItems
 from .encodestate import EncodeState
 from .exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
 from .field import Field
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterValue
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -24,14 +25,13 @@ class DynamicLengthField(Field):
     determine_number_of_items: DetermineNumberOfItems
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DynamicLengthField":
-        kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynamicLengthField":
+        kwargs = dataclass_fields_asdict(Field.from_et(et_element, context))
 
         offset = int(odxrequire(et_element.findtext('OFFSET')))
         determine_number_of_items = DetermineNumberOfItems.from_et(
             odxrequire(et_element.find('DETERMINE-NUMBER-OF-ITEMS')),
-            doc_frags,
+            context,
         )
 
         return DynamicLengthField(

--- a/odxtools/dyndefinedspec.py
+++ b/odxtools/dyndefinedspec.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .dyniddefmodeinfo import DynIdDefModeInfo
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
@@ -13,10 +14,9 @@ class DynDefinedSpec:
     dyn_id_def_mode_infos: list[DynIdDefModeInfo]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DynDefinedSpec":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynDefinedSpec":
         dyn_id_def_mode_infos = [
-            DynIdDefModeInfo.from_et(x, doc_frags)
+            DynIdDefModeInfo.from_et(x, context)
             for x in et_element.iterfind("DYN-ID-DEF-MODE-INFOS/DYN-ID-DEF-MODE-INFO")
         ]
         return DynDefinedSpec(dyn_id_def_mode_infos=dyn_id_def_mode_infos)

--- a/odxtools/dynenddopref.py
+++ b/odxtools/dynenddopref.py
@@ -4,7 +4,8 @@ from typing import Optional, overload
 from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkRef
 from .utils import dataclass_fields_asdict
 
 
@@ -14,24 +15,23 @@ class DynEndDopRef(OdxLinkRef):
 
     @staticmethod
     @overload
-    def from_et(et_element: None, source_doc_frags: list[OdxDocFragment]) -> None:
+    def from_et(et_element: None, context: OdxDocContext) -> None:
         ...
 
     @staticmethod
     @overload
-    def from_et(et_element: ElementTree.Element,
-                source_doc_frags: list[OdxDocFragment]) -> "DynEndDopRef":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynEndDopRef":
         ...
 
     @staticmethod
     def from_et(et_element: ElementTree.Element | None,
-                source_doc_frags: list[OdxDocFragment]) -> Optional["DynEndDopRef"]:
+                context: OdxDocContext) -> Optional["DynEndDopRef"]:
 
         if et_element is None:
             odxraise("Mandatory DYN-END-DOP-REF tag is missing")
             return None
 
-        kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, source_doc_frags))
+        kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, context))
 
         termination_value_raw = odxrequire(et_element.findtext("TERMINATION-VALUE"))
 

--- a/odxtools/dyniddefmodeinfo.py
+++ b/odxtools/dyniddefmodeinfo.py
@@ -7,7 +7,8 @@ from .diagclasstype import DiagClassType
 from .diagcomm import DiagComm
 from .exceptions import odxassert, odxraise, odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 from .table import Table
 
@@ -45,23 +46,22 @@ class DynIdDefModeInfo:
         return self._selection_tables
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DynIdDefModeInfo":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynIdDefModeInfo":
         def_mode = odxrequire(et_element.findtext("DEF-MODE"))
 
         clear_dyn_def_message_ref = OdxLinkRef.from_et(
-            et_element.find("CLEAR-DYN-DEF-MESSAGE-REF"), doc_frags)
+            et_element.find("CLEAR-DYN-DEF-MESSAGE-REF"), context)
         clear_dyn_def_message_snref = None
         if (snref_elem := et_element.find("CLEAR-DYN-DEF-MESSAGE-SNREF")) is not None:
             clear_dyn_def_message_snref = odxrequire(snref_elem.attrib.get("SHORT-NAME"))
 
         read_dyn_def_message_ref = OdxLinkRef.from_et(
-            et_element.find("READ-DYN-DEF-MESSAGE-REF"), doc_frags)
+            et_element.find("READ-DYN-DEF-MESSAGE-REF"), context)
         read_dyn_def_message_snref = None
         if (snref_elem := et_element.find("READ-DYN-DEF-MESSAGE-SNREF")) is not None:
             read_dyn_def_message_snref = odxrequire(snref_elem.attrib.get("SHORT-NAME"))
 
-        dyn_def_message_ref = OdxLinkRef.from_et(et_element.find("DYN-DEF-MESSAGE-REF"), doc_frags)
+        dyn_def_message_ref = OdxLinkRef.from_et(et_element.find("DYN-DEF-MESSAGE-REF"), context)
         dyn_def_message_snref = None
         if (snref_elem := et_element.find("DYN-DEF-MESSAGE-SNREF")) is not None:
             dyn_def_message_snref = odxrequire(snref_elem.attrib.get("SHORT-NAME"))
@@ -75,7 +75,7 @@ class DynIdDefModeInfo:
         if (st_elems := et_element.find("SELECTION-TABLE-REFS")) is not None:
             for st_elem in st_elems:
                 if st_elem.tag == "SELECTION-TABLE-REF":
-                    selection_table_refs.append(OdxLinkRef.from_et(st_elem, doc_frags))
+                    selection_table_refs.append(OdxLinkRef.from_et(st_elem, context))
                 elif st_elem.tag == "SELECTION-TABLE-SNREF":
                     selection_table_refs.append(odxrequire(st_elem.get("SHORT-NAME")))
                 else:

--- a/odxtools/ecuvariantpattern.py
+++ b/odxtools/ecuvariantpattern.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from .exceptions import odxassert
 from .matchingbasevariantparameter import MatchingBaseVariantParameter
 from .matchingparameter import MatchingParameter
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .variantpattern import VariantPattern
 
 
@@ -24,11 +24,10 @@ class EcuVariantPattern(VariantPattern):
         return self.matching_parameters
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "EcuVariantPattern":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EcuVariantPattern":
 
         matching_parameters = [
-            MatchingParameter.from_et(mp_el, doc_frags)
+            MatchingParameter.from_et(mp_el, context)
             for mp_el in et_element.iterfind("MATCHING-PARAMETERS/"
                                              "MATCHING-PARAMETER")
         ]

--- a/odxtools/element.py
+++ b/odxtools/element.py
@@ -3,7 +3,8 @@ from xml.etree import ElementTree
 
 from .description import Description
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkId
 from .utils import dataclass_fields_asdict
 
 
@@ -14,12 +15,12 @@ class NamedElement:
     description: Description | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "NamedElement":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "NamedElement":
 
         return NamedElement(
             short_name=odxrequire(et_element.findtext("SHORT-NAME")),
             long_name=et_element.findtext("LONG-NAME"),
-            description=Description.from_et(et_element.find("DESC"), doc_frags),
+            description=Description.from_et(et_element.find("DESC"), context),
         )
 
 
@@ -29,12 +30,11 @@ class IdentifiableElement(NamedElement):
     oid: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "IdentifiableElement":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "IdentifiableElement":
 
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
-        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, context))
         oid = et_element.get("OID")
 
         return IdentifiableElement(**kwargs, odx_id=odx_id, oid=oid)

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -9,7 +9,7 @@ from .decodestate import DecodeState
 from .encodestate import EncodeState
 from .exceptions import EncodeError, odxassert, odxraise
 from .field import Field
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import ParameterValue
 from .utils import dataclass_fields_asdict
 
@@ -21,9 +21,8 @@ class EndOfPduField(Field):
     min_number_of_items: int | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "EndOfPduField":
-        kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EndOfPduField":
+        kwargs = dataclass_fields_asdict(Field.from_et(et_element, context))
 
         if (max_n_str := et_element.findtext("MAX-NUMBER-OF-ITEMS")) is not None:
             max_number_of_items = int(max_n_str)

--- a/odxtools/envdataconnector.py
+++ b/odxtools/envdataconnector.py
@@ -7,7 +7,8 @@ from .element import NamedElement
 from .environmentdata import EnvironmentData
 from .environmentdatadescription import EnvironmentDataDescription
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -26,12 +27,11 @@ class EnvDataConnector(NamedElement):
         return self._env_data
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "EnvDataConnector":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EnvDataConnector":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
         env_data_desc_ref = odxrequire(
-            OdxLinkRef.from_et(et_element.find("ENV-DATA-DESC-REF"), doc_frags))
+            OdxLinkRef.from_et(et_element.find("ENV-DATA-DESC-REF"), context))
         env_data_snref_el = odxrequire(et_element.find("ENV-DATA-SNREF"))
         env_data_snref = odxrequire(env_data_snref_el.get("SHORT-NAME"))
 

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .utils import dataclass_fields_asdict
 
 
@@ -23,10 +23,9 @@ class EnvironmentData(BasicStructure):
     dtc_values: list[int]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "EnvironmentData":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EnvironmentData":
         """Reads Environment Data from Diag Layer."""
-        kwargs = dataclass_fields_asdict(BasicStructure.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(BasicStructure.from_et(et_element, context))
 
         all_value_elem = et_element.find("ALL-VALUE")
         all_value = None if all_value_elem is None else True

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -13,7 +13,8 @@ from .encodestate import EncodeState
 from .environmentdata import EnvironmentData
 from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import DataType, ParameterValue, ParameterValueDict
 from .parameters.codedconstparameter import CodedConstParameter
 from .parameters.parameter import Parameter
@@ -46,9 +47,9 @@ class EnvironmentDataDescription(ComplexDop):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "EnvironmentDataDescription":
+                context: OdxDocContext) -> "EnvironmentDataDescription":
         """Reads Environment Data Description from Diag Layer."""
-        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, context))
 
         param_snref = None
         if (param_snref_elem := et_element.find("PARAM-SNREF")) is not None:
@@ -63,11 +64,11 @@ class EnvironmentDataDescription(ComplexDop):
         # empty and one non-empty list here. (Which is which depends
         # on the version of the standard used by the file.)
         env_datas = NamedItemList([
-            EnvironmentData.from_et(env_data_elem, doc_frags)
+            EnvironmentData.from_et(env_data_elem, context)
             for env_data_elem in et_element.iterfind("ENV-DATAS/ENV-DATA")
         ])
         env_data_refs = [
-            odxrequire(OdxLinkRef.from_et(env_data_ref, doc_frags))
+            odxrequire(OdxLinkRef.from_et(env_data_ref, context))
             for env_data_ref in et_element.iterfind("ENV-DATA-REFS/ENV-DATA-REF")
         ]
 

--- a/odxtools/externalaccessmethod.py
+++ b/odxtools/externalaccessmethod.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .utils import dataclass_fields_asdict
 
 
@@ -13,9 +13,8 @@ class ExternalAccessMethod(IdentifiableElement):
     method: str
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ExternalAccessMethod":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ExternalAccessMethod":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         method = odxrequire(et_element.findtext("METHOD"))
 

--- a/odxtools/externaldoc.py
+++ b/odxtools/externaldoc.py
@@ -3,7 +3,7 @@ from typing import Optional
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 
 
 @dataclass
@@ -13,7 +13,7 @@ class ExternalDoc:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element | None,
-                doc_frags: list[OdxDocFragment]) -> Optional["ExternalDoc"]:
+                context: OdxDocContext) -> Optional["ExternalDoc"]:
         if et_element is None:
             return None
 

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -6,7 +6,8 @@ from .basicstructure import BasicStructure
 from .complexdop import ComplexDop
 from .environmentdatadescription import EnvironmentDataDescription
 from .exceptions import odxassert, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkRef, resolve_snref
 from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -30,15 +31,15 @@ class Field(ComplexDop):
         return self.is_visible_raw in (None, True)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Field":
-        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Field":
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, context))
 
-        structure_ref = OdxLinkRef.from_et(et_element.find("BASIC-STRUCTURE-REF"), doc_frags)
+        structure_ref = OdxLinkRef.from_et(et_element.find("BASIC-STRUCTURE-REF"), context)
         structure_snref = None
         if (edsnr_elem := et_element.find("BASIC-STRUCTURE-SNREF")) is not None:
             structure_snref = edsnr_elem.get("SHORT-NAME")
 
-        env_data_desc_ref = OdxLinkRef.from_et(et_element.find("ENV-DATA-DESC-REF"), doc_frags)
+        env_data_desc_ref = OdxLinkRef.from_et(et_element.find("ENV-DATA-DESC-REF"), context)
         env_data_desc_snref = None
         if (edsnr_elem := et_element.find("ENV-DATA-DESC-SNREF")) is not None:
             env_data_desc_snref = edsnr_elem.get("SHORT-NAME")

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .element import IdentifiableElement
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -19,12 +20,11 @@ class FunctionalClass(IdentifiableElement):
     admin_data: AdminData | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "FunctionalClass":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "FunctionalClass":
 
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
 
         return FunctionalClass(admin_data=admin_data, **kwargs)
 

--- a/odxtools/inputparam.py
+++ b/odxtools/inputparam.py
@@ -8,7 +8,8 @@ from deprecation import deprecated
 from .dopbase import DopBase
 from .element import NamedElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -30,11 +31,11 @@ class InputParam(NamedElement):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "InputParam":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "InputParam":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
         physical_default_value = et_element.findtext("PHYSICAL-DEFAULT-VALUE")
-        dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags))
+        dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), context))
 
         oid = et_element.get("OID")
         semantic = et_element.get("SEMANTIC")

--- a/odxtools/internalconstr.py
+++ b/odxtools/internalconstr.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .compumethods.limit import Limit
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import DataType
 from .scaleconstr import ScaleConstr
 
@@ -22,16 +22,16 @@ class InternalConstr:
     value_type: DataType
 
     @staticmethod
-    def constr_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def constr_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                        value_type: DataType) -> "InternalConstr":
 
         lower_limit = Limit.limit_from_et(
-            et_element.find("LOWER-LIMIT"), doc_frags, value_type=value_type)
+            et_element.find("LOWER-LIMIT"), context, value_type=value_type)
         upper_limit = Limit.limit_from_et(
-            et_element.find("UPPER-LIMIT"), doc_frags, value_type=value_type)
+            et_element.find("UPPER-LIMIT"), context, value_type=value_type)
 
         scale_constrs = [
-            ScaleConstr.scale_constr_from_et(sc_el, doc_frags, value_type=value_type)
+            ScaleConstr.scale_constr_from_et(sc_el, context, value_type=value_type)
             for sc_el in et_element.iterfind("SCALE-CONSTRS/SCALE-CONSTR")
         ]
 

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -8,7 +8,7 @@ from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .exceptions import EncodeError, odxassert, odxraise, odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import AtomicOdxType, DataType
 from .utils import dataclass_fields_asdict
 
@@ -28,9 +28,8 @@ class LeadingLengthInfoType(DiagCodedType):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "LeadingLengthInfoType":
-        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "LeadingLengthInfoType":
+        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, context))
 
         bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
 

--- a/odxtools/library.py
+++ b/odxtools/library.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement
 from .exceptions import odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -29,9 +30,9 @@ class Library(IdentifiableElement):
         return self._code
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Library":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Library":
 
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         code_file = odxrequire(et_element.findtext("CODE-FILE"))
         encryption = et_element.findtext("ENCRYPTION")

--- a/odxtools/linkeddtcdop.py
+++ b/odxtools/linkeddtcdop.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .diagnostictroublecode import DiagnosticTroubleCode
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 
 if TYPE_CHECKING:
@@ -31,14 +32,14 @@ class LinkedDtcDop:
         return self._dtc_dop.short_name
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "LinkedDtcDop":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "LinkedDtcDop":
         not_inherited_dtc_snrefs = [
             odxrequire(el.get("SHORT-NAME"))
             for el in et_element.iterfind("NOT-INHERITED-DTC-SNREFS/"
                                           "NOT-INHERITED-DTC-SNREF")
         ]
 
-        dtc_dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DTC-DOP-REF"), doc_frags))
+        dtc_dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DTC-DOP-REF"), context))
 
         return LinkedDtcDop(
             not_inherited_dtc_snrefs=not_inherited_dtc_snrefs, dtc_dop_ref=dtc_dop_ref)

--- a/odxtools/matchingbasevariantparameter.py
+++ b/odxtools/matchingbasevariantparameter.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .matchingparameter import MatchingParameter
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import odxstr_to_bool
 from .utils import dataclass_fields_asdict
 
@@ -25,9 +25,9 @@ class MatchingBaseVariantParameter(MatchingParameter):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MatchingBaseVariantParameter":
+                context: OdxDocContext) -> "MatchingBaseVariantParameter":
 
-        kwargs = dataclass_fields_asdict(MatchingParameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(MatchingParameter.from_et(et_element, context))
 
         use_physical_addressing_raw = odxstr_to_bool(et_element.findtext("USE-PHYSICAL-ADDRESSING"))
 

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -7,7 +7,8 @@ from .diaglayers.diaglayer import DiagLayer
 from .diagnostictroublecode import DiagnosticTroubleCode
 from .diagservice import DiagService
 from .exceptions import odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, resolve_snref
 from .odxtypes import BytesTypes, ParameterValue, ParameterValueDict
 from .snrefcontext import SnRefContext
 
@@ -38,8 +39,7 @@ class MatchingParameter:
     out_param_if_snpathref: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MatchingParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "MatchingParameter":
 
         expected_value = odxrequire(et_element.findtext("EXPECTED-VALUE"))
         diag_comm_snref = odxrequire(

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -10,7 +10,7 @@ from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .encoding import get_string_encoding
 from .exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import AtomicOdxType, BytesTypes, DataType
 from .termination import Termination
 from .utils import dataclass_fields_asdict
@@ -28,9 +28,8 @@ class MinMaxLengthType(DiagCodedType):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MinMaxLengthType":
-        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "MinMaxLengthType":
+        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, context))
 
         max_length = None
         if et_element.find("MAX-LENGTH") is not None:

--- a/odxtools/modification.py
+++ b/odxtools/modification.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
@@ -14,7 +15,7 @@ class Modification:
     reason: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Modification":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Modification":
         change = odxrequire(et_element.findtext("CHANGE"))
         reason = et_element.findtext("REASON")
 

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -13,7 +13,8 @@ from .multiplexercase import MultiplexerCase
 from .multiplexerdefaultcase import MultiplexerDefaultCase
 from .multiplexerswitchkey import MultiplexerSwitchKey
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import AtomicOdxType, ParameterValue, odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -40,20 +41,20 @@ class Multiplexer(ComplexDop):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Multiplexer":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Multiplexer":
         """Reads a Multiplexer from Diag Layer."""
-        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, context))
 
         byte_position = int(et_element.findtext("BYTE-POSITION", "0"))
         switch_key = MultiplexerSwitchKey.from_et(
-            odxrequire(et_element.find("SWITCH-KEY")), doc_frags)
+            odxrequire(et_element.find("SWITCH-KEY")), context)
 
         default_case = None
         if (dc_elem := et_element.find("DEFAULT-CASE")) is not None:
-            default_case = MultiplexerDefaultCase.from_et(dc_elem, doc_frags)
+            default_case = MultiplexerDefaultCase.from_et(dc_elem, context)
 
         cases = NamedItemList(
-            [MultiplexerCase.from_et(el, doc_frags) for el in et_element.iterfind("CASES/CASE")])
+            [MultiplexerCase.from_et(el, context) for el in et_element.iterfind("CASES/CASE")])
 
         is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
 

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .compumethods.limit import Limit
 from .element import NamedElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .odxtypes import AtomicOdxType, DataType
 from .snrefcontext import SnRefContext
 from .structure import Structure
@@ -27,23 +28,22 @@ class MultiplexerCase(NamedElement):
         return self._structure
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MultiplexerCase":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "MultiplexerCase":
         """Reads a case for a Multiplexer."""
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
-        structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
+        structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), context)
         structure_snref = None
         if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:
             structure_snref = odxrequire(structure_snref_elem.get("SHORT-NAME"))
 
         lower_limit = Limit.limit_from_et(
             odxrequire(et_element.find("LOWER-LIMIT")),
-            doc_frags,
+            context,
             value_type=None,
         )
         upper_limit = Limit.limit_from_et(
             odxrequire(et_element.find("UPPER-LIMIT")),
-            doc_frags,
+            context,
             value_type=None,
         )
 

--- a/odxtools/multiplexerdefaultcase.py
+++ b/odxtools/multiplexerdefaultcase.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import NamedElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 from .structure import Structure
 from .utils import dataclass_fields_asdict
@@ -23,11 +24,11 @@ class MultiplexerDefaultCase(NamedElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MultiplexerDefaultCase":
+                context: OdxDocContext) -> "MultiplexerDefaultCase":
         """Reads a default case for a multiplexer."""
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
-        structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
+        structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), context)
         structure_snref = None
         if (structure_snref_elem := et_element.find("STRUCTURE-SNREF")) is not None:
             structure_snref = odxrequire(structure_snref_elem.get("SHORT-NAME"))

--- a/odxtools/multiplexerswitchkey.py
+++ b/odxtools/multiplexerswitchkey.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .dataobjectproperty import DataObjectProperty
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
@@ -23,12 +24,11 @@ class MultiplexerSwitchKey:
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MultiplexerSwitchKey":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "MultiplexerSwitchKey":
         byte_position = int(odxrequire(et_element.findtext("BYTE-POSITION")))
         bit_position_str = et_element.findtext("BIT-POSITION")
         bit_position = int(bit_position_str) if bit_position_str is not None else None
-        dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), doc_frags))
+        dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DATA-OBJECT-PROP-REF"), context))
 
         return MultiplexerSwitchKey(
             byte_position=byte_position,

--- a/odxtools/negoutputparam.py
+++ b/odxtools/negoutputparam.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .dopbase import DopBase
 from .element import NamedElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -21,11 +22,10 @@ class NegOutputParam(NamedElement):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "NegOutputParam":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "NegOutputParam":
 
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
-        dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags))
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
+        dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), context))
 
         return NegOutputParam(dop_base_ref=dop_base_ref, **kwargs)
 

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -8,6 +8,7 @@ from .companydata import CompanyData
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
+from .odxdoccontext import OdxDocContext
 from .odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
@@ -26,28 +27,26 @@ class OdxCategory(IdentifiableElement):
     sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "OdxCategory":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "OdxCategory":
         raise Exception("Calling `._from_et()` is not allowed for OdxCategory. "
                         "Use `OdxCategory.category_from_et()`!")
 
     @staticmethod
-    def category_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def category_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                          doc_type: DocType) -> "OdxCategory":
 
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
         # create the current ODX "document fragment" (description of the
         # current document for references and IDs)
-        doc_frags = [OdxDocFragment(short_name, doc_type)]
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        context.doc_fragments.append(OdxDocFragment(short_name, doc_type))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
         company_datas = NamedItemList([
-            CompanyData.from_et(cde, doc_frags)
+            CompanyData.from_et(cde, context)
             for cde in et_element.iterfind("COMPANY-DATAS/COMPANY-DATA")
         ])
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return OdxCategory(admin_data=admin_data, company_datas=company_datas, sdgs=sdgs, **kwargs)
 

--- a/odxtools/odxdoccontext.py
+++ b/odxtools/odxdoccontext.py
@@ -1,0 +1,11 @@
+from typing import TYPE_CHECKING, NamedTuple
+
+from packaging.version import Version
+
+if TYPE_CHECKING:
+    from odxtools.odxlink import OdxDocFragment
+
+
+class OdxDocContext(NamedTuple):
+    version: Version
+    doc_fragments: list["OdxDocFragment"]

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -8,6 +8,7 @@ from xml.etree import ElementTree
 
 from .exceptions import OdxWarning, odxassert, odxraise, odxrequire
 from .nameditemlist import OdxNamed, TNamed
+from .odxdoccontext import OdxDocContext
 
 
 class DocType(Enum):
@@ -68,8 +69,7 @@ class OdxLinkId:
         return f"OdxLinkId('{self.local_id}')"
 
     @staticmethod
-    def from_et(et: ElementTree.Element,
-                doc_fragments: list[OdxDocFragment]) -> Optional["OdxLinkId"]:
+    def from_et(et: ElementTree.Element, context: OdxDocContext) -> Optional["OdxLinkId"]:
         """Construct an OdxLinkId for a given XML node (ElementTree object).
 
         Returns None if the given XML node does not exhibit an ID.
@@ -79,7 +79,7 @@ class OdxLinkId:
         if local_id is None:
             return None
 
-        return OdxLinkId(local_id, doc_fragments)
+        return OdxLinkId(local_id, context.doc_fragments)
 
 
 @dataclass
@@ -103,17 +103,16 @@ class OdxLinkRef:
 
     @overload
     @staticmethod
-    def from_et(et: None, source_doc_frags: list[OdxDocFragment]) -> None:
+    def from_et(et: None, context: OdxDocContext) -> None:
         ...
 
     @overload
     @staticmethod
-    def from_et(et: ElementTree.Element, source_doc_frags: list[OdxDocFragment]) -> "OdxLinkRef":
+    def from_et(et: ElementTree.Element, context: OdxDocContext) -> "OdxLinkRef":
         ...
 
     @staticmethod
-    def from_et(et: ElementTree.Element | None,
-                source_doc_frags: list[OdxDocFragment]) -> Optional["OdxLinkRef"]:
+    def from_et(et: ElementTree.Element | None, context: OdxDocContext) -> Optional["OdxLinkRef"]:
         """Construct an OdxLinkRef for a given XML node (ElementTree object).
 
         Returns None if the given XML node does not represent a reference.
@@ -147,7 +146,7 @@ class OdxLinkRef:
         if docref is not None:
             doc_frags = [OdxDocFragment(docref, odxrequire(doctype))]
         else:
-            doc_frags = source_doc_frags
+            doc_frags = context.doc_fragments
 
         return OdxLinkRef(id_ref, doc_frags)
 

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -8,7 +8,8 @@ from deprecation import deprecated
 from .dopbase import DopBase
 from .element import IdentifiableElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -27,11 +28,11 @@ class OutputParam(IdentifiableElement):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "OutputParam":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "OutputParam":
 
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
-        dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags))
+        dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), context))
         semantic = et_element.get("SEMANTIC")
 
         return OutputParam(dop_base_ref=dop_base_ref, semantic=semantic, **kwargs)

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -11,7 +11,8 @@ from ..decodestate import DecodeState
 from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkId
 from ..odxtypes import AtomicOdxType, DataType, ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
@@ -44,14 +45,13 @@ class CodedConstParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "CodedConstParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CodedConstParameter":
 
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
         coded_value_raw = odxrequire(et_element.findtext("CODED-VALUE"))
         dct_elem = odxrequire(et_element.find("DIAG-CODED-TYPE"))
-        diag_coded_type = create_any_diag_coded_type_from_et(dct_elem, doc_frags)
+        diag_coded_type = create_any_diag_coded_type_from_et(dct_elem, context)
 
         return CodedConstParameter(
             coded_value_raw=coded_value_raw, diag_coded_type=diag_coded_type, **kwargs)

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -3,7 +3,7 @@ from xml.etree import ElementTree
 
 from ..exceptions import odxraise
 from ..globals import xsi
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from .codedconstparameter import CodedConstParameter
 from .dynamicparameter import DynamicParameter
 from .lengthkeyparameter import LengthKeyParameter
@@ -20,35 +20,35 @@ from .valueparameter import ValueParameter
 
 
 def create_any_parameter_from_et(et_element: ElementTree.Element,
-                                 doc_frags: list[OdxDocFragment]) \
+                                 context: OdxDocContext) \
                                  -> Parameter:
     parameter_type = et_element.get(f"{xsi}type")
 
     # Which attributes are set depends on the type of the parameter.
     if parameter_type == "VALUE":
-        return ValueParameter.from_et(et_element, doc_frags)
+        return ValueParameter.from_et(et_element, context)
     elif parameter_type == "CODED-CONST":
-        return CodedConstParameter.from_et(et_element, doc_frags)
+        return CodedConstParameter.from_et(et_element, context)
     elif parameter_type == "PHYS-CONST":
-        return PhysicalConstantParameter.from_et(et_element, doc_frags)
+        return PhysicalConstantParameter.from_et(et_element, context)
     elif parameter_type == "SYSTEM":
-        return SystemParameter.from_et(et_element, doc_frags)
+        return SystemParameter.from_et(et_element, context)
     elif parameter_type == "LENGTH-KEY":
-        return LengthKeyParameter.from_et(et_element, doc_frags)
+        return LengthKeyParameter.from_et(et_element, context)
     elif parameter_type == "NRC-CONST":
-        return NrcConstParameter.from_et(et_element, doc_frags)
+        return NrcConstParameter.from_et(et_element, context)
     elif parameter_type == "RESERVED":
-        return ReservedParameter.from_et(et_element, doc_frags)
+        return ReservedParameter.from_et(et_element, context)
     elif parameter_type == "MATCHING-REQUEST-PARAM":
-        return MatchingRequestParameter.from_et(et_element, doc_frags)
+        return MatchingRequestParameter.from_et(et_element, context)
     elif parameter_type == "DYNAMIC":
-        return DynamicParameter.from_et(et_element, doc_frags)
+        return DynamicParameter.from_et(et_element, context)
     elif parameter_type == "TABLE-STRUCT":
-        return TableStructParameter.from_et(et_element, doc_frags)
+        return TableStructParameter.from_et(et_element, context)
     elif parameter_type == "TABLE-KEY":
-        return TableKeyParameter.from_et(et_element, doc_frags)
+        return TableKeyParameter.from_et(et_element, context)
     elif parameter_type == "TABLE-ENTRY":
-        return TableEntryParameter.from_et(et_element, doc_frags)
+        return TableEntryParameter.from_et(et_element, context)
 
     odxraise(f"I don't know about parameters of type {parameter_type}", NotImplementedError)
-    return Parameter.from_et(et_element, doc_frags)
+    return Parameter.from_et(et_element, context)

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -6,7 +6,7 @@ from typing_extensions import override
 
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
@@ -32,10 +32,9 @@ class DynamicParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "DynamicParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynamicParameter":
 
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
         return DynamicParameter(**kwargs)
 

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -8,7 +8,8 @@ from typing_extensions import final, override
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkId
 from ..odxtypes import ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import ParameterType
@@ -48,12 +49,11 @@ class LengthKeyParameter(ParameterWithDOP):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "LengthKeyParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "LengthKeyParameter":
 
-        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, context))
 
-        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, context))
 
         return LengthKeyParameter(odx_id=odx_id, **kwargs)
 

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import DataType, ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
@@ -36,9 +36,9 @@ class MatchingRequestParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "MatchingRequestParameter":
+                context: OdxDocContext) -> "MatchingRequestParameter":
 
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
         request_byte_position = int(odxrequire(et_element.findtext("REQUEST-BYTE-POS")))
         byte_length = int(odxrequire(et_element.findtext("BYTE-LENGTH")))

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -10,7 +10,8 @@ from ..decodestate import DecodeState
 from ..diagcodedtype import DiagCodedType
 from ..encodestate import EncodeState
 from ..exceptions import DecodeMismatch, EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkId
 from ..odxtypes import AtomicOdxType, DataType, ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
@@ -62,16 +63,15 @@ class NrcConstParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "NrcConstParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "NrcConstParameter":
 
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
         coded_values_raw = [
             odxrequire(x.text) for x in et_element.iterfind("CODED-VALUES/CODED-VALUE")
         ]
         dct_elem = odxrequire(et_element.find("DIAG-CODED-TYPE"))
-        diag_coded_type = create_any_diag_coded_type_from_et(dct_elem, doc_frags)
+        diag_coded_type = create_any_diag_coded_type_from_et(dct_elem, context)
 
         return NrcConstParameter(
             coded_values_raw=coded_values_raw, diag_coded_type=diag_coded_type, **kwargs)

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -8,7 +8,8 @@ from typing_extensions import final, override
 from ..decodestate import DecodeState
 from ..element import NamedElement
 from ..encodestate import EncodeState
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import ParameterValue
 from ..snrefcontext import SnRefContext
 from ..specialdatagroup import SpecialDataGroup
@@ -78,13 +79,11 @@ class Parameter(NamedElement):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Parameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Parameter":
 
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
         semantic = et_element.attrib.get("SEMANTIC")
         oid = et_element.attrib.get("OID")
         byte_position_str = et_element.findtext("BYTE-POSITION")

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -11,7 +11,8 @@ from ..dopbase import DopBase
 from ..dtcdop import DtcDop
 from ..encodestate import EncodeState
 from ..exceptions import odxassert, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from ..odxtypes import AtomicOdxType, ParameterValue
 from ..physicaltype import PhysicalType
 from ..snrefcontext import SnRefContext
@@ -32,12 +33,11 @@ class ParameterWithDOP(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ParameterWithDOP":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ParameterWithDOP":
 
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
-        dop_ref = OdxLinkRef.from_et(et_element.find("DOP-REF"), doc_frags)
+        dop_ref = OdxLinkRef.from_et(et_element.find("DOP-REF"), context)
         dop_snref = None
         if (dop_snref_elem := et_element.find("DOP-SNREF")) is not None:
             dop_snref = odxrequire(dop_snref_elem.get("SHORT-NAME"))

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -9,7 +9,8 @@ from ..dataobjectproperty import DataObjectProperty
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import ParameterValue
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
@@ -43,9 +44,9 @@ class PhysicalConstantParameter(ParameterWithDOP):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "PhysicalConstantParameter":
+                context: OdxDocContext) -> "PhysicalConstantParameter":
 
-        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, context))
 
         physical_constant_value_raw = odxrequire(et_element.findtext("PHYS-CONSTANT-VALUE"))
 

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import DataType, ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
@@ -34,9 +34,8 @@ class ReservedParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ReservedParameter":
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ReservedParameter":
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
         bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
 

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 
 from ..encodestate import EncodeState
 from ..exceptions import odxraise, odxrequire
-from ..odxlink import OdxDocFragment
+from ..odxdoccontext import OdxDocContext
 from ..odxtypes import ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import ParameterType
@@ -48,9 +48,8 @@ class SystemParameter(ParameterWithDOP):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "SystemParameter":
-        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SystemParameter":
+        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, context))
 
         sysparam = odxrequire(et_element.get("SYSPARAM"))
 

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -8,7 +8,8 @@ from typing_extensions import override
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkRef
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..odxtypes import ParameterValue
 from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
@@ -44,9 +45,8 @@ class TableEntryParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "TableEntryParameter":
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "TableEntryParameter":
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
         target_str = odxrequire(et_element.findtext("TARGET"))
         try:
@@ -54,7 +54,7 @@ class TableEntryParameter(Parameter):
         except ValueError:
             odxraise(f"Encountered unknown target '{target_str}'")
             target = cast(RowFragment, None)
-        table_row_ref = odxrequire(OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), doc_frags))
+        table_row_ref = odxrequire(OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), context))
 
         return TableEntryParameter(target=target, table_row_ref=table_row_ref, **kwargs)
 

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -8,7 +8,8 @@ from typing_extensions import final, override
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from ..odxtypes import ParameterValue
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
@@ -36,18 +37,17 @@ class TableKeyParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "TableKeyParameter":
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "TableKeyParameter":
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
-        odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
+        odx_id = odxrequire(OdxLinkId.from_et(et_element, context))
 
-        table_ref = OdxLinkRef.from_et(et_element.find("TABLE-REF"), doc_frags)
+        table_ref = OdxLinkRef.from_et(et_element.find("TABLE-REF"), context)
         table_snref = None
         if (table_snref_elem := et_element.find("TABLE-SNREF")) is not None:
             table_snref = odxrequire(table_snref_elem.get("SHORT-NAME"))
 
-        table_row_ref = OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), doc_frags)
+        table_row_ref = OdxLinkRef.from_et(et_element.find("TABLE-ROW-REF"), context)
         table_row_snref = None
         if (table_row_snref_elem := et_element.find("TABLE-ROW-SNREF")) is not None:
             table_row_snref = odxrequire(table_row_snref_elem.get("SHORT-NAME"))

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -8,7 +8,8 @@ from typing_extensions import override
 from ..decodestate import DecodeState
 from ..encodestate import EncodeState
 from ..exceptions import DecodeError, EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from ..odxtypes import ParameterValue
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
@@ -49,12 +50,11 @@ class TableStructParameter(Parameter):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "TableStructParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "TableStructParameter":
 
-        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, context))
 
-        table_key_ref = OdxLinkRef.from_et(et_element.find("TABLE-KEY-REF"), doc_frags)
+        table_key_ref = OdxLinkRef.from_et(et_element.find("TABLE-KEY-REF"), context)
         table_key_snref = None
         if (table_key_snref_elem := et_element.find("TABLE-KEY-SNREF")) is not None:
             table_key_snref = odxrequire(table_key_snref_elem.get("SHORT-NAME"))

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -8,7 +8,8 @@ from typing_extensions import override
 from ..dataobjectproperty import DataObjectProperty
 from ..encodestate import EncodeState
 from ..exceptions import EncodeError, odxraise, odxrequire
-from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from ..odxdoccontext import OdxDocContext
+from ..odxlink import OdxLinkDatabase, OdxLinkId
 from ..odxtypes import AtomicOdxType, ParameterValue
 from ..snrefcontext import SnRefContext
 from ..utils import dataclass_fields_asdict
@@ -41,10 +42,9 @@ class ValueParameter(ParameterWithDOP):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ValueParameter":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ValueParameter":
 
-        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, context))
 
         physical_default_value_raw = et_element.findtext("PHYSICAL-DEFAULT-VALUE")
 

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -9,7 +9,8 @@ from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .exceptions import EncodeError, odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import AtomicOdxType, DataType
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -32,12 +33,10 @@ class ParamLengthInfoType(DiagCodedType):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "ParamLengthInfoType":
-        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ParamLengthInfoType":
+        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, context))
 
-        length_key_ref = odxrequire(
-            OdxLinkRef.from_et(et_element.find("LENGTH-KEY-REF"), doc_frags))
+        length_key_ref = odxrequire(OdxLinkRef.from_et(et_element.find("LENGTH-KEY-REF"), context))
 
         return ParamLengthInfoType(length_key_ref=length_key_ref, **kwargs)
 

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -27,9 +28,9 @@ class ParentRef:
         return self._layer
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ParentRef":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ParentRef":
 
-        layer_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
+        layer_ref = odxrequire(OdxLinkRef.from_et(et_element, context))
 
         not_inherited_diag_comms = [
             odxrequire(el.get("SHORT-NAME"))

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -50,9 +51,8 @@ class PhysicalDimension(IdentifiableElement):
     luminous_intensity_exp: int | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "PhysicalDimension":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "PhysicalDimension":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         def read_optional_int(element: ElementTree.Element, name: str) -> int | None:
             if (val_str := element.findtext(name)) is not None:

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .exceptions import odxraise
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import DataType
 from .radix import Radix
 
@@ -44,7 +44,7 @@ class PhysicalType:
     """
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "PhysicalType":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "PhysicalType":
         precision_str = et_element.findtext("PRECISION")
         precision = int(precision_str) if precision_str is not None else None
 

--- a/odxtools/posresponsesuppressible.py
+++ b/odxtools/posresponsesuppressible.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .utils import read_hex_binary
 
 
@@ -27,7 +27,7 @@ class PosResponseSuppressible:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "PosResponseSuppressible":
+                context: OdxDocContext) -> "PosResponseSuppressible":
 
         bit_mask = odxrequire(read_hex_binary(et_element.find("BIT-MASK")))
 

--- a/odxtools/preconditionstateref.py
+++ b/odxtools/preconditionstateref.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .odxtypes import ParameterValueDict
 from .parameters.parameter import Parameter
 from .snrefcontext import SnRefContext
@@ -32,9 +33,8 @@ class PreConditionStateRef(OdxLinkRef):
 
     @staticmethod
     def from_et(  # type: ignore[override]
-            et_element: ElementTree.Element,
-            doc_frags: list[OdxDocFragment]) -> "PreConditionStateRef":
-        kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, doc_frags))
+            et_element: ElementTree.Element, context: OdxDocContext) -> "PreConditionStateRef":
+        kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, context))
 
         value = et_element.findtext("VALUE")
 

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .exceptions import odxraise, odxrequire
 from .library import Library
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
@@ -29,7 +30,7 @@ class ProgCode:
         return self._libraries
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ProgCode":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ProgCode":
         code_file = odxrequire(et_element.findtext("CODE-FILE"))
         encryption = et_element.findtext("ENCRYPTION")
         syntax = odxrequire(et_element.findtext("SYNTAX"))
@@ -37,7 +38,7 @@ class ProgCode:
         entrypoint = et_element.findtext("ENTRYPOINT")
 
         library_refs = [
-            odxrequire(OdxLinkRef.from_et(el, doc_frags))
+            odxrequire(OdxLinkRef.from_et(el, context))
             for el in et_element.iterfind("LIBRARY-REFS/LIBRARY-REF")
         ]
 

--- a/odxtools/protstack.py
+++ b/odxtools/protstack.py
@@ -7,7 +7,8 @@ from .comparamsubset import ComparamSubset
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -24,13 +25,13 @@ class ProtStack(IdentifiableElement):
         return self._comparam_subsets
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ProtStack":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ProtStack":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         pdu_protocol_type = odxrequire(et_element.findtext("PDU-PROTOCOL-TYPE"))
         physical_link_type = odxrequire(et_element.findtext("PHYSICAL-LINK-TYPE"))
         comparam_subset_refs = [
-            OdxLinkRef.from_et(csr_element, doc_frags)
+            OdxLinkRef.from_et(csr_element, context)
             for csr_element in et_element.iterfind("COMPARAM-SUBSET-REFS/"
                                                    "COMPARAM-SUBSET-REF")
         ]

--- a/odxtools/relateddiagcommref.py
+++ b/odxtools/relateddiagcommref.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkRef
 from .utils import dataclass_fields_asdict
 
 
@@ -13,9 +14,8 @@ class RelatedDiagCommRef(OdxLinkRef):
 
     @staticmethod
     def from_et(  # type: ignore[override]
-            et_element: ElementTree.Element,
-            doc_frags: list[OdxDocFragment]) -> "RelatedDiagCommRef":
-        kwargs = dataclass_fields_asdict(odxrequire(OdxLinkRef.from_et(et_element, doc_frags)))
+            et_element: ElementTree.Element, context: OdxDocContext) -> "RelatedDiagCommRef":
+        kwargs = dataclass_fields_asdict(odxrequire(OdxLinkRef.from_et(et_element, context)))
 
         relation_type = odxrequire(et_element.findtext("RELATION-TYPE"))
 

--- a/odxtools/relateddoc.py
+++ b/odxtools/relateddoc.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .description import Description
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .xdoc import XDoc
 
@@ -15,11 +16,11 @@ class RelatedDoc:
     description: Description | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "RelatedDoc":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "RelatedDoc":
         xdoc: XDoc | None = None
         if (xdoc_elem := et_element.find("XDOC")) is not None:
-            xdoc = XDoc.from_et(xdoc_elem, doc_frags)
-        description = Description.from_et(et_element.find("DESC"), doc_frags)
+            xdoc = XDoc.from_et(xdoc_elem, context)
+        description = Description.from_et(et_element.find("DESC"), context)
 
         return RelatedDoc(
             xdoc=xdoc,

--- a/odxtools/request.py
+++ b/odxtools/request.py
@@ -14,7 +14,8 @@ from .element import IdentifiableElement
 from .encodestate import EncodeState
 from .exceptions import odxraise
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterValue, ParameterValueDict
 from .parameters.createanyparameter import create_any_parameter_from_et
 from .parameters.parameter import Parameter
@@ -42,17 +43,15 @@ class Request(IdentifiableElement):
         return composite_codec_get_free_parameters(self)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Request":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Request":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
         parameters = NamedItemList([
-            create_any_parameter_from_et(et_parameter, doc_frags)
+            create_any_parameter_from_et(et_parameter, context)
             for et_parameter in et_element.iterfind("PARAMS/PARAM")
         ])
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return Request(admin_data=admin_data, parameters=parameters, sdgs=sdgs, **kwargs)
 

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -15,7 +15,8 @@ from .element import IdentifiableElement
 from .encodestate import EncodeState
 from .exceptions import odxraise
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterValue, ParameterValueDict
 from .parameters.createanyparameter import create_any_parameter_from_et
 from .parameters.parameter import Parameter
@@ -44,9 +45,9 @@ class Response(IdentifiableElement):
     sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Response":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Response":
         """Reads a response."""
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         try:
             response_type = ResponseType(et_element.tag)
@@ -54,14 +55,12 @@ class Response(IdentifiableElement):
             response_type = cast(ResponseType, None)
             odxraise(f"Encountered unknown response type '{et_element.tag}'")
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
         parameters = NamedItemList([
-            create_any_parameter_from_et(et_parameter, doc_frags)
+            create_any_parameter_from_et(et_parameter, context)
             for et_parameter in et_element.iterfind("PARAMS/PARAM")
         ])
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return Response(
             response_type=response_type,

--- a/odxtools/scaleconstr.py
+++ b/odxtools/scaleconstr.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 from .compumethods.limit import Limit
 from .description import Description
 from .exceptions import odxraise, odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import DataType
 from .validtype import ValidType
 
@@ -23,14 +23,14 @@ class ScaleConstr:
     value_type: DataType
 
     @staticmethod
-    def scale_constr_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
+    def scale_constr_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,
                              value_type: DataType) -> "ScaleConstr":
         short_label = et_element.findtext("SHORT-LABEL")
-        description = Description.from_et(et_element.find("DESC"), doc_frags)
+        description = Description.from_et(et_element.find("DESC"), context)
         lower_limit = Limit.limit_from_et(
-            odxrequire(et_element.find("LOWER-LIMIT")), doc_frags, value_type=value_type)
+            odxrequire(et_element.find("LOWER-LIMIT")), context, value_type=value_type)
         upper_limit = Limit.limit_from_et(
-            odxrequire(et_element.find("UPPER-LIMIT")), doc_frags, value_type=value_type)
+            odxrequire(et_element.find("UPPER-LIMIT")), context, value_type=value_type)
 
         validity_str = odxrequire(et_element.get("VALIDITY"))
         try:

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -7,7 +7,8 @@ from .diagcomm import DiagComm
 from .inputparam import InputParam
 from .nameditemlist import NamedItemList
 from .negoutputparam import NegOutputParam
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .outputparam import OutputParam
 from .progcode import ProgCode
 from .snrefcontext import SnRefContext
@@ -36,24 +37,24 @@ class SingleEcuJob(DiagComm):
     neg_output_params: NamedItemList[NegOutputParam]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SingleEcuJob":
-        kwargs = dataclass_fields_asdict(DiagComm.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SingleEcuJob":
+        kwargs = dataclass_fields_asdict(DiagComm.from_et(et_element, context))
 
         prog_codes = [
-            ProgCode.from_et(pc_elem, doc_frags)
+            ProgCode.from_et(pc_elem, context)
             for pc_elem in et_element.iterfind("PROG-CODES/PROG-CODE")
         ]
 
         input_params = NamedItemList([
-            InputParam.from_et(el, doc_frags)
+            InputParam.from_et(el, context)
             for el in et_element.iterfind("INPUT-PARAMS/INPUT-PARAM")
         ])
         output_params = NamedItemList([
-            OutputParam.from_et(el, doc_frags)
+            OutputParam.from_et(el, context)
             for el in et_element.iterfind("OUTPUT-PARAMS/OUTPUT-PARAM")
         ])
         neg_output_params = NamedItemList([
-            NegOutputParam.from_et(el, doc_frags)
+            NegOutputParam.from_et(el, context)
             for el in et_element.iterfind("NEG-OUTPUT-PARAMS/NEG-OUTPUT-PARAM")
         ])
 

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from typing import Any
 from xml.etree import ElementTree
 
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
@@ -15,7 +16,7 @@ class SpecialData:
     value: str
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SpecialData":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SpecialData":
         semantic_info = et_element.get("SI")
         text_identifier = et_element.get("TI")
         value = et_element.text or ""

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from typing import Any, Union
 from xml.etree import ElementTree
 
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .specialdata import SpecialData
 from .specialdatagroupcaption import SpecialDataGroupCaption
@@ -18,16 +19,15 @@ class SpecialDataGroup:
     semantic_info: str | None  # the "SI" attribute
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "SpecialDataGroup":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SpecialDataGroup":
 
         sdg_caption = None
         if caption_elem := et_element.find("SDG-CAPTION"):
-            sdg_caption = SpecialDataGroupCaption.from_et(caption_elem, doc_frags)
+            sdg_caption = SpecialDataGroupCaption.from_et(caption_elem, context)
 
         sdg_caption_ref = None
         if (caption_ref_elem := et_element.find("SDG-CAPTION-REF")) is not None:
-            sdg_caption_ref = OdxLinkRef.from_et(caption_ref_elem, doc_frags)
+            sdg_caption_ref = OdxLinkRef.from_et(caption_ref_elem, context)
 
         semantic_info = et_element.get("SI")
 
@@ -35,9 +35,9 @@ class SpecialDataGroup:
         for value_elem in et_element:
             next_entry: SpecialData | SpecialDataGroup | None = None
             if value_elem.tag == "SDG":
-                next_entry = SpecialDataGroup.from_et(value_elem, doc_frags)
+                next_entry = SpecialDataGroup.from_et(value_elem, context)
             elif value_elem.tag == "SD":
-                next_entry = SpecialData.from_et(value_elem, doc_frags)
+                next_entry = SpecialData.from_et(value_elem, context)
 
             if next_entry is not None:
                 values.append(next_entry)

--- a/odxtools/specialdatagroupcaption.py
+++ b/odxtools/specialdatagroupcaption.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -14,8 +15,8 @@ class SpecialDataGroupCaption(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "SpecialDataGroupCaption":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+                context: OdxDocContext) -> "SpecialDataGroupCaption":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         return SpecialDataGroupCaption(**kwargs)
 

--- a/odxtools/standardlengthtype.py
+++ b/odxtools/standardlengthtype.py
@@ -9,7 +9,7 @@ from .decodestate import DecodeState
 from .diagcodedtype import DctType, DiagCodedType
 from .encodestate import EncodeState
 from .exceptions import odxassert, odxraise, odxrequire
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import AtomicOdxType, BytesTypes, DataType, odxstr_to_bool
 from .utils import dataclass_fields_asdict, read_hex_binary
 
@@ -31,9 +31,8 @@ class StandardLengthType(DiagCodedType):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "StandardLengthType":
-        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "StandardLengthType":
+        kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, context))
 
         bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
         bit_mask = read_hex_binary(et_element.find("BIT-MASK"))

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -16,8 +17,8 @@ class State(IdentifiableElement):
     """
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "State":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "State":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         return State(**kwargs)
 

--- a/odxtools/statechart.py
+++ b/odxtools/statechart.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, resolve_snref
 from .snrefcontext import SnRefContext
 from .state import State
 from .statetransition import StateTransition
@@ -28,13 +29,13 @@ class StateChart(IdentifiableElement):
         return self._start_state
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "StateChart":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "StateChart":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         semantic: str = odxrequire(et_element.findtext("SEMANTIC"))
 
         state_transitions = [
-            StateTransition.from_et(st_elem, doc_frags)
+            StateTransition.from_et(st_elem, context)
             for st_elem in et_element.iterfind("STATE-TRANSITIONS/STATE-TRANSITION")
         ]
 
@@ -42,7 +43,7 @@ class StateChart(IdentifiableElement):
         start_state_snref = start_state_snref_elem.attrib["SHORT-NAME"]
 
         states = [
-            State.from_et(st_elem, doc_frags) for st_elem in et_element.iterfind("STATES/STATE")
+            State.from_et(st_elem, context) for st_elem in et_element.iterfind("STATES/STATE")
         ]
 
         return StateChart(

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .element import IdentifiableElement
 from .exceptions import odxrequire
 from .externalaccessmethod import ExternalAccessMethod
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, resolve_snref
 from .snrefcontext import SnRefContext
 from .state import State
 from .utils import dataclass_fields_asdict
@@ -30,10 +31,9 @@ class StateTransition(IdentifiableElement):
         return self._target_state
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "StateTransition":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "StateTransition":
 
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         source_snref_elem = odxrequire(et_element.find("SOURCE-SNREF"))
         source_snref = odxrequire(source_snref_elem.attrib["SHORT-NAME"])
@@ -43,7 +43,7 @@ class StateTransition(IdentifiableElement):
 
         external_access_method = None
         if (eam_elem := et_element.find("EXTERNAL-ACCESS-METHOD")) is not None:
-            external_access_method = ExternalAccessMethod.from_et(eam_elem, doc_frags)
+            external_access_method = ExternalAccessMethod.from_et(eam_elem, context)
         return StateTransition(
             source_snref=source_snref,
             target_snref=target_snref,

--- a/odxtools/statetransitionref.py
+++ b/odxtools/statetransitionref.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .basicstructure import BasicStructure
 from .dataobjectproperty import DataObjectProperty
 from .exceptions import odxassert, odxraise, odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .odxtypes import ParameterValue, ParameterValueDict
 from .parameters.codedconstparameter import CodedConstParameter
 from .parameters.parameter import Parameter
@@ -170,9 +171,8 @@ class StateTransitionRef(OdxLinkRef):
 
     @staticmethod
     def from_et(  # type: ignore[override]
-            et_element: ElementTree.Element,
-            doc_frags: list[OdxDocFragment]) -> "StateTransitionRef":
-        kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, doc_frags))
+            et_element: ElementTree.Element, context: OdxDocContext) -> "StateTransitionRef":
+        kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, context))
 
         value = et_element.findtext("VALUE")
 

--- a/odxtools/staticfield.py
+++ b/odxtools/staticfield.py
@@ -10,7 +10,8 @@ from .decodestate import DecodeState
 from .encodestate import EncodeState
 from .exceptions import odxassert, odxraise, odxrequire
 from .field import Field
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .odxtypes import ParameterValue
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -24,8 +25,8 @@ class StaticField(Field):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "StaticField":
-        kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "StaticField":
+        kwargs = dataclass_fields_asdict(Field.from_et(et_element, context))
 
         fixed_number_of_items = int(odxrequire(et_element.findtext('FIXED-NUMBER-OF-ITEMS')))
         item_byte_size = int(odxrequire(et_element.findtext('ITEM-BYTE-SIZE')))

--- a/odxtools/structure.py
+++ b/odxtools/structure.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .odxtypes import odxstr_to_bool
 from .utils import dataclass_fields_asdict
 
@@ -17,9 +17,9 @@ class Structure(BasicStructure):
         return self.is_visible_raw in (True, None)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Structure":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Structure":
         """Read a STRUCTURE element from XML."""
-        kwargs = dataclass_fields_asdict(BasicStructure.from_et(et_element, doc_frags))
+        kwargs = dataclass_fields_asdict(BasicStructure.from_et(et_element, context))
 
         is_visible_raw = odxstr_to_bool(et_element.get("IS-VISIBLE"))
 

--- a/odxtools/subcomponent.py
+++ b/odxtools/subcomponent.py
@@ -7,7 +7,8 @@ from .dtcconnector import DtcConnector
 from .element import IdentifiableElement
 from .envdataconnector import EnvDataConnector
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .subcomponentparamconnector import SubComponentParamConnector
 from .subcomponentpattern import SubComponentPattern
@@ -34,29 +35,29 @@ class SubComponent(IdentifiableElement):
     semantic: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SubComponent":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SubComponent":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         semantic = et_element.get("SEMANTIC")
 
         sub_component_patterns = [
-            SubComponentPattern.from_et(el, doc_frags)
+            SubComponentPattern.from_et(el, context)
             for el in et_element.iterfind("SUB-COMPONENT-PATTERNS/SUB-COMPONENT-PATTERN")
         ]
         sub_component_param_connectors = [
-            SubComponentParamConnector.from_et(el, doc_frags) for el in et_element.iterfind(
+            SubComponentParamConnector.from_et(el, context) for el in et_element.iterfind(
                 "SUB-COMPONENT-PARAM-CONNECTORS/SUB-COMPONENT-PARAM-CONNECTOR")
         ]
         table_row_connectors = [
-            TableRowConnector.from_et(el, doc_frags)
+            TableRowConnector.from_et(el, context)
             for el in et_element.iterfind("TABLE-ROW-CONNECTORS/TABLE-ROW-CONNECTOR")
         ]
         env_data_connectors = [
-            EnvDataConnector.from_et(el, doc_frags)
+            EnvDataConnector.from_et(el, context)
             for el in et_element.iterfind("ENV-DATA-CONNECTORS/ENV-DATA-CONNECTOR")
         ]
         dtc_connectors = [
-            DtcConnector.from_et(el, doc_frags)
+            DtcConnector.from_et(el, context)
             for el in et_element.iterfind("DTC-CONNECTORS/DTC-CONNECTOR")
         ]
 

--- a/odxtools/subcomponentparamconnector.py
+++ b/odxtools/subcomponentparamconnector.py
@@ -7,7 +7,8 @@ from .diagservice import DiagService
 from .element import IdentifiableElement
 from .exceptions import odxassert, odxraise, odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, resolve_snref
 from .parameters.parameter import Parameter
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -35,8 +36,8 @@ class SubComponentParamConnector(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "SubComponentParamConnector":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+                context: OdxDocContext) -> "SubComponentParamConnector":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         diag_comm_snref = odxrequire(
             odxrequire(et_element.find("DIAG-COMM-SNREF")).get("SHORT-NAME"))

--- a/odxtools/subcomponentpattern.py
+++ b/odxtools/subcomponentpattern.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 if TYPE_CHECKING:
@@ -15,12 +16,11 @@ class SubComponentPattern:
     matching_parameters: list["MatchingParameter"]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "SubComponentPattern":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SubComponentPattern":
         from .matchingparameter import MatchingParameter
 
         matching_parameters = [
-            MatchingParameter.from_et(el, doc_frags)
+            MatchingParameter.from_et(el, context)
             for el in et_element.iterfind("MATCHING-PARAMETERS/MATCHING-PARAMETER")
         ]
 

--- a/odxtools/swvariable.py
+++ b/odxtools/swvariable.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 from .element import NamedElement
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .utils import dataclass_fields_asdict
 
 
@@ -13,8 +13,8 @@ class SwVariable(NamedElement):
     oid: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SwVariable":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SwVariable":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
         origin = et_element.findtext("ORIGIN")
         oid = et_element.attrib.get("OID")

--- a/odxtools/tablediagcommconnector.py
+++ b/odxtools/tablediagcommconnector.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .diagcomm import DiagComm
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 
 
@@ -22,11 +23,11 @@ class TableDiagCommConnector:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "TableDiagCommConnector":
+                context: OdxDocContext) -> "TableDiagCommConnector":
 
         semantic = odxrequire(et_element.findtext("SEMANTIC"))
 
-        diag_comm_ref = OdxLinkRef.from_et(et_element.find("DIAG-COMM-REF"), doc_frags)
+        diag_comm_ref = OdxLinkRef.from_et(et_element.find("DIAG-COMM-REF"), context)
         diag_comm_snref = None
         if (dc_snref_elem := et_element.find("DIAG-COMM-SNREF")) is not None:
             diag_comm_snref = odxrequire(dc_snref_elem.get("SHORT-NAME"))

--- a/odxtools/tablerowconnector.py
+++ b/odxtools/tablerowconnector.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import NamedElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef, resolve_snref
 from .snrefcontext import SnRefContext
 from .table import Table
 from .tablerow import TableRow
@@ -26,11 +27,10 @@ class TableRowConnector(NamedElement):
         return self._table_row
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "TableRowConnector":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "TableRowConnector":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
-        table_ref = odxrequire(OdxLinkRef.from_et(et_element.find("TABLE-REF"), doc_frags))
+        table_ref = odxrequire(OdxLinkRef.from_et(et_element.find("TABLE-REF"), context))
         table_row_snref_el = odxrequire(et_element.find("TABLE-ROW-SNREF"))
         table_row_snref = odxrequire(table_row_snref_el.get("SHORT-NAME"))
 

--- a/odxtools/teammember.py
+++ b/odxtools/teammember.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -22,8 +23,8 @@ class TeamMember(IdentifiableElement):
     email: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "TeamMember":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "TeamMember":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         roles = [odxrequire(role_elem.text) for role_elem in et_element.iterfind("ROLES/ROLE")]
         department = et_element.findtext("DEPARTMENT")

--- a/odxtools/text.py
+++ b/odxtools/text.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from xml.etree import ElementTree
 
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 
 
 @dataclass
@@ -10,7 +10,7 @@ class Text:
     text_identifier: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Text":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Text":
         # Extract the contents of the tag as a string.
         raw_string = et_element.text or ""
         for e in et_element:

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement
 from .exceptions import odxrequire
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .physicaldimension import PhysicalDimension
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
@@ -62,8 +63,8 @@ class Unit(IdentifiableElement):
         return self._physical_dimension
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Unit":
-        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Unit":
+        kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, context))
 
         display_name = odxrequire(et_element.findtext("DISPLAY-NAME"))
 
@@ -76,7 +77,7 @@ class Unit(IdentifiableElement):
         factor_si_to_unit = read_optional_float(et_element, "FACTOR-SI-TO-UNIT")
         offset_si_to_unit = read_optional_float(et_element, "OFFSET-SI-TO-UNIT")
         physical_dimension_ref = OdxLinkRef.from_et(
-            et_element.find("PHYSICAL-DIMENSION-REF"), doc_frags)
+            et_element.find("PHYSICAL-DIMENSION-REF"), context)
 
         return Unit(
             display_name=display_name,

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from .element import NamedElement
 from .exceptions import odxraise, odxrequire
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 from .unit import Unit
 from .unitgroupcategory import UnitGroupCategory
@@ -28,8 +29,8 @@ class UnitGroup(NamedElement):
         return self._units
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "UnitGroup":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "UnitGroup":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
         category_str = odxrequire(et_element.findtext("CATEGORY"))
         try:
@@ -39,7 +40,7 @@ class UnitGroup(NamedElement):
             odxraise(f"Encountered unknown unit group category '{category_str}'")
 
         unit_refs = [
-            odxrequire(OdxLinkRef.from_et(el, doc_frags))
+            odxrequire(OdxLinkRef.from_et(el, context))
             for el in et_element.iterfind("UNIT-REFS/UNIT-REF")
         ]
         oid = et_element.get("OID")

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 
 from .admindata import AdminData
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .physicaldimension import PhysicalDimension
 from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
@@ -37,21 +38,19 @@ class UnitSpec:
         self.physical_dimensions = NamedItemList(self.physical_dimensions)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "UnitSpec":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "UnitSpec":
 
-        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
+        admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), context)
         unit_groups = NamedItemList([
-            UnitGroup.from_et(el, doc_frags) for el in et_element.iterfind("UNIT-GROUPS/UNIT-GROUP")
+            UnitGroup.from_et(el, context) for el in et_element.iterfind("UNIT-GROUPS/UNIT-GROUP")
         ])
         units = NamedItemList(
-            [Unit.from_et(el, doc_frags) for el in et_element.iterfind("UNITS/UNIT")])
+            [Unit.from_et(el, context) for el in et_element.iterfind("UNITS/UNIT")])
         physical_dimensions = NamedItemList([
-            PhysicalDimension.from_et(el, doc_frags)
+            PhysicalDimension.from_et(el, context)
             for el in et_element.iterfind("PHYSICAL-DIMENSIONS/PHYSICAL-DIMENSION")
         ])
-        sdgs = [
-            SpecialDataGroup.from_et(sdge, doc_frags) for sdge in et_element.iterfind("SDGS/SDG")
-        ]
+        sdgs = [SpecialDataGroup.from_et(sdge, context) for sdge in et_element.iterfind("SDGS/SDG")]
 
         return UnitSpec(
             admin_data=admin_data,

--- a/odxtools/variablegroup.py
+++ b/odxtools/variablegroup.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 
 from .element import IdentifiableElement, NamedElement
 from .nameditemlist import NamedItemList
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 from .utils import dataclass_fields_asdict
 
 if TYPE_CHECKING:
@@ -25,8 +25,7 @@ class HasVariableGroups(typing.Protocol):
 class VariableGroup(IdentifiableElement):
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "VariableGroup":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "VariableGroup":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
 
         return VariableGroup(**kwargs)

--- a/odxtools/variantpattern.py
+++ b/odxtools/variantpattern.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 
 from .exceptions import odxraise
 from .matchingparameter import MatchingParameter
-from .odxlink import OdxDocFragment
+from .odxdoccontext import OdxDocContext
 
 if TYPE_CHECKING:
     from .matchingbasevariantparameter import MatchingBaseVariantParameter
@@ -33,6 +33,5 @@ class VariantPattern:
         return []
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element,
-                doc_frags: list[OdxDocFragment]) -> "VariantPattern":
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "VariantPattern":
         return VariantPattern()

--- a/odxtools/xdoc.py
+++ b/odxtools/xdoc.py
@@ -4,7 +4,8 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .element import NamedElement
-from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
+from .odxdoccontext import OdxDocContext
+from .odxlink import OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
@@ -19,8 +20,8 @@ class XDoc(NamedElement):
     position: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "XDoc":
-        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
+    def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "XDoc":
+        kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, context))
         number = et_element.findtext("NUMBER")
         state = et_element.findtext("STATE")
         date = et_element.findtext("DATE")

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -5,6 +5,7 @@ import unittest
 from xml.etree import ElementTree
 
 import jinja2
+from packaging.version import Version
 
 import odxtools
 from odxtools.compumethods.compucategory import CompuCategory
@@ -22,6 +23,7 @@ from odxtools.compumethods.ratfunccompumethod import RatFuncCompuMethod
 from odxtools.compumethods.scaleratfunccompumethod import ScaleRatFuncCompuMethod
 from odxtools.compumethods.tabintpcompumethod import TabIntpCompuMethod
 from odxtools.exceptions import DecodeError, EncodeError, OdxError
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment
 from odxtools.odxtypes import DataType
 from odxtools.progcode import ProgCode
@@ -108,7 +110,7 @@ class TestLinearCompuMethod(unittest.TestCase):
         et_element = ElementTree.fromstring(self.linear_compumethod_xml)
         actual = create_any_compu_method_from_et(
             et_element,
-            doc_frags,
+            OdxDocContext(Version("2.2.0"), doc_frags),
             internal_type=expected.internal_type,
             physical_type=expected.physical_type)
         self.assertIsInstance(actual, LinearCompuMethod)
@@ -888,7 +890,7 @@ class TestTabIntpCompuMethod(unittest.TestCase):
         et_element = ElementTree.fromstring(self.tab_intp_compumethod_xml)
         actual = create_any_compu_method_from_et(
             et_element,
-            doc_frags,
+            OdxDocContext(Version("2.2.0"), doc_frags),
             internal_type=expected.internal_type,
             physical_type=expected.physical_type)
         self.assertIsInstance(actual, TabIntpCompuMethod)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -2,6 +2,8 @@
 import unittest
 from xml.etree import ElementTree
 
+from packaging.version import Version
+
 import odxtools.uds as uds
 from odxtools.compumethods.compucategory import CompuCategory
 from odxtools.compumethods.compuinternaltophys import CompuInternalToPhys
@@ -24,6 +26,7 @@ from odxtools.exceptions import DecodeError, EncodeError, OdxError, odxrequire
 from odxtools.leadinglengthinfotype import LeadingLengthInfoType
 from odxtools.minmaxlengthtype import MinMaxLengthType
 from odxtools.nameditemlist import NamedItemList
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
@@ -1036,7 +1039,8 @@ class TestMinMaxLengthType(unittest.TestCase):
         odx_element = ElementTree.fromstring(diagcodedtype_odx)
         diag_coded_type_element = odxrequire(odx_element.find("DIAG-CODED-TYPE"))
 
-        actual = create_any_diag_coded_type_from_et(diag_coded_type_element, doc_frags)
+        actual = create_any_diag_coded_type_from_et(diag_coded_type_element,
+                                                    OdxDocContext(Version("2.2.0"), doc_frags))
 
         self.assertIsInstance(actual, MinMaxLengthType)
         assert isinstance(actual, MinMaxLengthType)

--- a/tests/test_readparameters.py
+++ b/tests/test_readparameters.py
@@ -2,6 +2,9 @@
 import unittest
 from xml.etree import ElementTree
 
+from packaging.version import Version
+
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment
 from odxtools.odxtypes import DataType
 from odxtools.parameters.createanyparameter import create_any_parameter_from_et
@@ -28,7 +31,7 @@ class TestReadNrcParam(unittest.TestCase):
         </PARAM>
         """
         root = ElementTree.fromstring(ODX)
-        param = create_any_parameter_from_et(root, doc_frags=doc_frags)
+        param = create_any_parameter_from_et(root, OdxDocContext(Version("2.2.0"), doc_frags))
 
         self.assertIsInstance(param, NrcConstParameter)
         assert isinstance(param, NrcConstParameter)

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -7,6 +7,7 @@ from typing import NamedTuple, cast
 from xml.etree import ElementTree
 
 import jinja2
+from packaging.version import Version
 
 import odxtools
 from odxtools.additionalaudience import AdditionalAudience
@@ -31,6 +32,7 @@ from odxtools.inputparam import InputParam
 from odxtools.library import Library
 from odxtools.nameditemlist import NamedItemList
 from odxtools.negoutputparam import NegOutputParam
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.outputparam import OutputParam
@@ -358,7 +360,7 @@ class TestSingleEcuJob(unittest.TestCase):
         expected = self.singleecujob_object
         sample_single_ecu_job_odx = self.singleecujob_odx
         et_element = ElementTree.fromstring(sample_single_ecu_job_odx)
-        sej = SingleEcuJob.from_et(et_element, doc_frags)
+        sej = SingleEcuJob.from_et(et_element, OdxDocContext(Version("2.2.0"), doc_frags))
         self.assertEqual(expected.prog_codes, sej.prog_codes)
         self.assertEqual(expected.output_params, sej.output_params)
         self.assertEqual(expected.neg_output_params, sej.neg_output_params)
@@ -395,7 +397,8 @@ class TestSingleEcuJob(unittest.TestCase):
 
         # Assert equality of objects
         # This tests the idempotency of read-write
-        sej = SingleEcuJob.from_et(ElementTree.fromstring(rawodx), doc_frags)
+        sej = SingleEcuJob.from_et(
+            ElementTree.fromstring(rawodx), OdxDocContext(Version("2.2.0"), doc_frags))
         self.assertEqual(self.singleecujob_object, sej)
 
     def test_default_lists(self) -> None:

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -2,6 +2,8 @@
 import unittest
 from xml.etree import ElementTree
 
+from packaging.version import Version
+
 from odxtools.compumethods.compucategory import CompuCategory
 from odxtools.compumethods.identicalcompumethod import IdenticalCompuMethod
 from odxtools.database import Database
@@ -12,6 +14,7 @@ from odxtools.diaglayers.ecuvariant import EcuVariant
 from odxtools.diaglayers.ecuvariantraw import EcuVariantRaw
 from odxtools.exceptions import odxrequire
 from odxtools.nameditemlist import NamedItemList
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.odxtypes import DataType
 from odxtools.parameters.codedconstparameter import CodedConstParameter
@@ -84,7 +87,7 @@ class TestUnitSpec(unittest.TestCase):
             </UNIT-SPEC>
         """
         et_element = ElementTree.fromstring(sample_unit_spec_odx)
-        spec = UnitSpec.from_et(et_element, doc_frags)
+        spec = UnitSpec.from_et(et_element, OdxDocContext(Version("2.2.0"), doc_frags))
         self.assertEqual(expected.units, spec.units)
         self.assertEqual(expected.physical_dimensions, spec.physical_dimensions)
         self.assertEqual(expected.unit_groups, spec.unit_groups)

--- a/tests/test_variant_patterns.py
+++ b/tests/test_variant_patterns.py
@@ -2,10 +2,12 @@
 from xml.etree import ElementTree
 
 import pytest
+from packaging.version import Version
 
 from odxtools.basevariantpattern import BaseVariantPattern
 from odxtools.ecuvariantpattern import EcuVariantPattern
 from odxtools.exceptions import OdxError
+from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment
 
 doc_frags = [OdxDocFragment(doc_name="pytest", doc_type=DocType.CONTAINER)]
@@ -92,7 +94,7 @@ def invalid_evp_et() -> ElementTree.Element:
 
 def test_create_bvp_from_et(valid_bvp_et: ElementTree.Element) -> None:
     base_variant_patterns = [
-        BaseVariantPattern.from_et(elem, doc_frags)
+        BaseVariantPattern.from_et(elem, OdxDocContext(Version("2.2.0"), doc_frags))
         for elem in valid_bvp_et.iterfind("BASE-VARIANT-PATTERN")
     ]
     assert len(base_variant_patterns) == 2
@@ -124,7 +126,7 @@ def test_create_bvp_from_et(valid_bvp_et: ElementTree.Element) -> None:
 
 def test_create_evp_from_et(valid_evp_et: ElementTree.Element) -> None:
     ecu_variant_patterns = [
-        EcuVariantPattern.from_et(elem, doc_frags)
+        EcuVariantPattern.from_et(elem, OdxDocContext(Version("2.2.0"), doc_frags))
         for elem in valid_evp_et.iterfind("ECU-VARIANT-PATTERN")
     ]
     assert len(ecu_variant_patterns) == 2
@@ -139,4 +141,4 @@ def test_create_evp_from_et(valid_evp_et: ElementTree.Element) -> None:
 def test_create_invalid_evp_from_et(invalid_evp_et: ElementTree.Element) -> None:
     with pytest.raises(OdxError):
         for x in invalid_evp_et.iterfind("ECU-VARIANT-PATTERN"):
-            EcuVariantPattern.from_et(x, doc_frags)
+            EcuVariantPattern.from_et(x, OdxDocContext(Version("2.2.0"), doc_frags))


### PR DESCRIPTION
To enable version dependent parsing and in hope of better ODX 2.1.0 support, i added the `version` parameter to each `from_et` method.

Sorry for the big diff, but it's the same simple change in every file.