### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         # restrict the matrix to the oldest and the latest Python
         # version being supported by odxtools
-        python-version: ["3.8", "3"]
+        python-version: ["3.10", "3"]
 
     steps:
       - uses: actions/checkout@v3
@@ -57,10 +57,6 @@ jobs:
 
       - name: Static type checking (mypy)
         run: |
-          # remove '# type:' comments in version.py which mypy-3.8
-          # stumbles over. for some reason, mypy cannot be
-          # instructed to ignore 'version.py'
-          sed -i "s/# type:.*//" odxtools/version.py
           python -m mypy .
 
       - name: Lint code quality (ruff)
@@ -73,13 +69,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         # restrict the matrix to the oldest and the latest Python
         # version being supported by odxtools
-        python-version: ["3.8", "3"]
+        python-version: ["3.10", "3"]
 
         # due to the slow windows runners, we refrain from testing every python
         # version on windows-latest
         exclude:
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.10"
 
     runs-on: ${{matrix.os}}
 

--- a/examples/mksomersaultmodifiedpdx.py
+++ b/examples/mksomersaultmodifiedpdx.py
@@ -6,7 +6,7 @@
 # modified programatically. Note that this is pretty hacky...
 import argparse
 from copy import deepcopy
-from typing import List, TypeVar
+from typing import TypeVar
 
 import odxtools
 import odxtools.uds as uds
@@ -25,7 +25,7 @@ from odxtools.response import Response, ResponseType
 T = TypeVar("T")
 
 
-def find_named_object(item_list: List[T], name: str) -> T:
+def find_named_object(item_list: list[T], name: str) -> T:
     for x in item_list:
         if getattr(x, "short_name", None) == name:
             return x

--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -5,7 +5,7 @@ import pathlib
 from enum import IntEnum
 from io import BytesIO
 from itertools import chain
-from typing import Any, Dict
+from typing import Any
 from xml.etree import ElementTree
 
 import odxtools.uds as uds
@@ -440,7 +440,7 @@ somersault_unit_groups = {
 }
 
 # computation methods
-somersault_compumethods: Dict[str, CompuMethod] = {
+somersault_compumethods: dict[str, CompuMethod] = {
     "int_passthrough":
         IdenticalCompuMethod(
             category=CompuCategory.IDENTICAL,

--- a/examples/somersaultlazy.py
+++ b/examples/somersaultlazy.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import random
 from socket import socket
-from typing import List, Optional, Union, cast
+from typing import cast
 
 import isotp
 import isotp.tpsock
@@ -26,19 +26,18 @@ tester_logger = logging.getLogger("somersault_lazy_tester")
 ecu_logger = logging.getLogger("somersault_lazy_ecu")
 
 is_sterile = False
-can_channel: Optional[str] = None
+can_channel: str | None = None
 somersault_lazy_diag_layer = somersaultdatabase.ecus.somersault_lazy
 
 # the raw payload data of the telegrams received by the ECU and by the
 # tester when in sterile mode (unittest without a CAN channel)
-sterile_rx_ecu: List[bytes] = []
-sterile_rx_ecu_event: Optional[asyncio.Event] = None
-sterile_rx_tester: List[bytes] = []
-sterile_rx_tester_event: Optional[asyncio.Event] = None
+sterile_rx_ecu: list[bytes] = []
+sterile_rx_ecu_event: asyncio.Event | None = None
+sterile_rx_tester: list[bytes] = []
+sterile_rx_tester_event: asyncio.Event | None = None
 
 
-def create_isotp_socket(channel: Optional[str], rxid: int,
-                        txid: int) -> Optional[isotp.tpsock.socket]:
+def create_isotp_socket(channel: str | None, rxid: int, txid: int) -> isotp.tpsock.socket | None:
     if is_sterile:
         return None
 
@@ -66,7 +65,7 @@ def create_isotp_socket(channel: Optional[str], rxid: int,
     return result_socket
 
 
-async def ecu_send(isotp_socket: Optional[isotp.tpsock.socket], payload: bytes) -> None:
+async def ecu_send(isotp_socket: isotp.tpsock.socket | None, payload: bytes) -> None:
     """
     ECU sends a message, either in "sterile" or in "live" mode.
     """
@@ -87,7 +86,7 @@ async def ecu_send(isotp_socket: Optional[isotp.tpsock.socket], payload: bytes) 
         await loop.sock_sendall(cast(socket, isotp_socket), payload)
 
 
-async def ecu_recv(isotp_socket: Optional[isotp.tpsock.socket]) -> bytes:
+async def ecu_recv(isotp_socket: isotp.tpsock.socket | None) -> bytes:
     """
     ECU receives a message, either in "sterile" or in "live" mode.
     """
@@ -113,7 +112,7 @@ async def ecu_recv(isotp_socket: Optional[isotp.tpsock.socket]) -> bytes:
         return await loop.sock_recv(cast(socket, isotp_socket), 4095)
 
 
-async def tester_send(isotp_socket: Optional[isotp.tpsock.socket], payload: bytes) -> None:
+async def tester_send(isotp_socket: isotp.tpsock.socket | None, payload: bytes) -> None:
     """
     Tester sends a message, either in "sterile" or in "live" mode.
     """
@@ -133,7 +132,7 @@ async def tester_send(isotp_socket: Optional[isotp.tpsock.socket], payload: byte
         await loop.sock_sendall(cast(socket, isotp_socket), payload)
 
 
-async def tester_recv(isotp_socket: Optional[isotp.tpsock.socket]) -> bytes:
+async def tester_recv(isotp_socket: isotp.tpsock.socket | None) -> bytes:
     """
     Tester receives a message, either in "sterile" or in "live" mode.
     """
@@ -360,9 +359,9 @@ class SomersaultLazyEcu:
                 continue
 
 
-async def tester_await_response(isotp_socket: Optional[isotp.tpsock.socket],
+async def tester_await_response(isotp_socket: isotp.tpsock.socket | None,
                                 raw_message: bytes,
-                                timeout: float = 0.5) -> Union[bytes, ParameterValueDict]:
+                                timeout: float = 0.5) -> bytes | ParameterValueDict:
     # await the answer from the server (be aware that the maximum
     # length of ISO-TP telegrams over the CAN bus is 4095 bytes)
     raw_response = await tester_recv(isotp_socket)

--- a/odxtools/additionalaudience.py
+++ b/odxtools/additionalaudience.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -17,12 +17,12 @@ class AdditionalAudience(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "AdditionalAudience":
+                doc_frags: list[OdxDocFragment]) -> "AdditionalAudience":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         return AdditionalAudience(**kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from xml.etree import ElementTree
 
 from .companydocinfo import CompanyDocInfo
@@ -11,13 +11,13 @@ from .snrefcontext import SnRefContext
 
 @dataclass
 class AdminData:
-    language: Optional[str]
-    company_doc_infos: List[CompanyDocInfo]
-    doc_revisions: List[DocRevision]
+    language: str | None
+    company_doc_infos: list[CompanyDocInfo]
+    doc_revisions: list[DocRevision]
 
     @staticmethod
-    def from_et(et_element: Optional[ElementTree.Element],
-                doc_frags: List[OdxDocFragment]) -> Optional["AdminData"]:
+    def from_et(et_element: ElementTree.Element | None,
+                doc_frags: list[OdxDocFragment]) -> Optional["AdminData"]:
 
         if et_element is None:
             return None
@@ -37,8 +37,8 @@ class AdminData:
         return AdminData(
             language=language, company_doc_infos=company_doc_infos, doc_revisions=doc_revisions)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result: Dict[OdxLinkId, Any] = {}
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
+        result: dict[OdxLinkId, Any] = {}
 
         for cdi in self.company_doc_infos:
             result.update(cdi._build_odxlinks())

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .additionalaudience import AdditionalAudience
@@ -12,14 +12,14 @@ from .snrefcontext import SnRefContext
 
 @dataclass
 class Audience:
-    enabled_audience_refs: List[OdxLinkRef]
-    disabled_audience_refs: List[OdxLinkRef]
+    enabled_audience_refs: list[OdxLinkRef]
+    disabled_audience_refs: list[OdxLinkRef]
 
-    is_supplier_raw: Optional[bool]
-    is_development_raw: Optional[bool]
-    is_manufacturing_raw: Optional[bool]
-    is_aftersales_raw: Optional[bool]
-    is_aftermarket_raw: Optional[bool]
+    is_supplier_raw: bool | None
+    is_development_raw: bool | None
+    is_manufacturing_raw: bool | None
+    is_aftersales_raw: bool | None
+    is_aftermarket_raw: bool | None
 
     @property
     def is_supplier(self) -> bool:
@@ -50,7 +50,7 @@ class Audience:
         return self._disabled_audiences
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Audience":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Audience":
 
         enabled_audience_refs = [
             OdxLinkRef.from_et(ref, doc_frags)
@@ -78,7 +78,7 @@ class Audience:
             is_aftermarket_raw=is_aftermarket_raw,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -16,11 +16,11 @@ from .utils import dataclass_fields_asdict
 class BaseComparam(IdentifiableElement):
     param_class: str
     cptype: StandardizationLevel
-    display_level: Optional[int]
-    cpusage: Optional[Usage]  # Required in ODX 2.2, missing in ODX 2.0
+    display_level: int | None
+    cpusage: Usage | None  # Required in ODX 2.2, missing in ODX 2.0
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "BaseComparam":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "BaseComparam":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         param_class = odxrequire(et_element.attrib.get("PARAM-CLASS"))
@@ -52,7 +52,7 @@ class BaseComparam(IdentifiableElement):
             cpusage=cpusage,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/basevariantpattern.py
+++ b/odxtools/basevariantpattern.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Union
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -17,11 +16,11 @@ class BaseVariantPattern(VariantPattern):
     """Base variant patterns are variant patterns used to identify the
     base variant of an ECU.
     """
-    matching_base_variant_parameters: List[MatchingBaseVariantParameter]
+    matching_base_variant_parameters: list[MatchingBaseVariantParameter]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "BaseVariantPattern":
+                doc_frags: list[OdxDocFragment]) -> "BaseVariantPattern":
 
         matching_base_variant_parameters = [
             MatchingBaseVariantParameter.from_et(mbvp_el, doc_frags)
@@ -33,6 +32,6 @@ class BaseVariantPattern(VariantPattern):
         return BaseVariantPattern(matching_base_variant_parameters=matching_base_variant_parameters)
 
     @override
-    def get_matching_parameters(
-            self) -> Union[List[MatchingParameter], List[MatchingBaseVariantParameter]]:
+    def get_matching_parameters(self
+                               ) -> list[MatchingParameter] | list[MatchingBaseVariantParameter]:
         return self.matching_base_variant_parameters

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -30,20 +30,20 @@ class BasicStructure(ComplexDop):
     data objects. All structure-like objects adhere to the
     `CompositeCodec` type protocol.
     """
-    byte_size: Optional[int]
+    byte_size: int | None
     parameters: NamedItemList[Parameter]
 
     @property
-    def required_parameters(self) -> List[Parameter]:
+    def required_parameters(self) -> list[Parameter]:
         return composite_codec_get_required_parameters(self)
 
     @property
-    def free_parameters(self) -> List[Parameter]:
+    def free_parameters(self) -> list[Parameter]:
         return composite_codec_get_free_parameters(self)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "BasicStructure":
+                doc_frags: list[OdxDocFragment]) -> "BasicStructure":
         """Read a BASIC-STRUCTURE."""
         kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
 
@@ -56,7 +56,7 @@ class BasicStructure(ComplexDop):
 
         return BasicStructure(byte_size=byte_size, parameters=parameters, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for param in self.parameters:
@@ -79,7 +79,7 @@ class BasicStructure(ComplexDop):
 
         context.parameters = None
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         # Explicit size was specified, so we do not need to look at
         # the list of parameters
         if self.byte_size is not None:
@@ -96,7 +96,7 @@ class BasicStructure(ComplexDop):
         print(parameter_info(self.free_parameters), end="")
 
     @override
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         orig_pos = encode_state.cursor_byte_position
 

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 import re
 import textwrap
-from typing import List, Optional, Tuple, Union
 
 import markdownify
 from rich import print as rich_print
@@ -113,9 +112,9 @@ def print_service_parameters(service: DiagService,
     rich_print("\n")
 
 
-def extract_service_tabulation_data(services: List[DiagService],
+def extract_service_tabulation_data(services: list[DiagService],
                                     *,
-                                    additional_columns: Optional[List[Tuple[str, List[str]]]] = None
+                                    additional_columns: list[tuple[str, list[str]]] | None = None
                                    ) -> RichTable:
     """Extracts data of diagnostic services into Dictionary which can
     be printed by tabulate module
@@ -125,9 +124,9 @@ def extract_service_tabulation_data(services: List[DiagService],
     table = RichTable(
         title="", show_header=True, header_style="bold cyan", border_style="blue", show_lines=True)
 
-    name_column: List[str] = []
-    semantic_column: List[str] = []
-    request_column: List[str] = []
+    name_column: list[str] = []
+    semantic_column: list[str] = []
+    request_column: list[str] = []
 
     for service in services:
         name_column.append(service.short_name)
@@ -147,15 +146,19 @@ def extract_service_tabulation_data(services: List[DiagService],
         for ac_title, _ in additional_columns:
             table.add_column(ac_title, justify="left", style="white")
 
-        rows = zip(name_column, semantic_column, request_column,
-                   *[ac[1] for ac in additional_columns])
+        rows = zip(
+            name_column,
+            semantic_column,
+            request_column,
+            *[ac[1] for ac in additional_columns],
+            strict=False)
         for row in rows:
             table.add_row(*map(str, row))
 
     return table
 
 
-def extract_parameter_tabulation_data(parameters: List[Parameter]) -> RichTable:
+def extract_parameter_tabulation_data(parameters: list[Parameter]) -> RichTable:
     # extracts data of parameters of diagnostic services into
     # a RichTable object that can be printed
 
@@ -174,15 +177,15 @@ def extract_parameter_tabulation_data(parameters: List[Parameter]) -> RichTable:
     table.add_column("Value Type", justify="left", style="white")
     table.add_column("Linked DOP", justify="left", style="white")
 
-    name_column: List[str] = []
-    byte_column: List[str] = []
-    bit_length_column: List[str] = []
-    semantic_column: List[str] = []
-    param_type_column: List[str] = []
-    value_column: List[str] = []
-    value_type_column: List[str] = []
-    data_type_column: List[str] = []
-    dop_column: List[str] = []
+    name_column: list[str] = []
+    byte_column: list[str] = []
+    bit_length_column: list[str] = []
+    semantic_column: list[str] = []
+    param_type_column: list[str] = []
+    value_column: list[str] = []
+    value_type_column: list[str] = []
+    data_type_column: list[str] = []
+    dop_column: list[str] = []
 
     for param in parameters:
         name_column.append(param.short_name)
@@ -211,7 +214,7 @@ def extract_parameter_tabulation_data(parameters: List[Parameter]) -> RichTable:
             value_column.append(str(param.coded_values))
             value_type_column.append('coded values')
             dop_column.append("")
-        elif isinstance(param, (PhysicalConstantParameter, SystemParameter, ValueParameter)):
+        elif isinstance(param, PhysicalConstantParameter | SystemParameter | ValueParameter):
             # this is a hack to make this routine work for parameters
             # which reference DOPs of a type that a is not yet
             # internalized. (all parameter objects of the tested types
@@ -250,15 +253,24 @@ def extract_parameter_tabulation_data(parameters: List[Parameter]) -> RichTable:
             dop_column.append("")
 
     # Add all rows at once by zipping dictionary values
-    rows = zip(name_column, byte_column, bit_length_column, semantic_column, param_type_column,
-               data_type_column, value_column, value_type_column, dop_column)
+    rows = zip(
+        name_column,
+        byte_column,
+        bit_length_column,
+        semantic_column,
+        param_type_column,
+        data_type_column,
+        value_column,
+        value_type_column,
+        dop_column,
+        strict=False)
     for row in rows:
         table.add_row(*map(str, row))
 
     return table
 
 
-def print_dl_metrics(variants: List[DiagLayer]) -> None:
+def print_dl_metrics(variants: list[DiagLayer]) -> None:
     """
     Print diagnostic layer metrics using Rich tables.
     Args:
@@ -278,7 +290,7 @@ def print_dl_metrics(variants: List[DiagLayer]) -> None:
     # Process each variant
     for variant in variants:
         assert isinstance(variant, DiagLayer)
-        all_services: List[Union[DiagService, SingleEcuJob]] = sorted(
+        all_services: list[DiagService | SingleEcuJob] = sorted(
             variant.services, key=lambda x: x.short_name)
         ddds = variant.diag_data_dictionary_spec
 

--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -2,7 +2,7 @@
 import argparse
 import logging
 import sys
-from typing import List, Optional, Union, cast
+from typing import cast
 
 import InquirerPy.prompt as IP_prompt
 
@@ -66,7 +66,7 @@ def _validate_string_value(input: str, parameter: Parameter) -> bool:
         return input != ""
 
 
-def prompt_single_parameter_value(parameter: Parameter) -> Optional[AtomicOdxType]:
+def prompt_single_parameter_value(parameter: Parameter) -> AtomicOdxType | None:
     if not isinstance(parameter, ValueParameter):
         odxraise("Only the value of ValueParameters can be queried")
     if parameter.physical_type is None:
@@ -113,7 +113,7 @@ def prompt_single_parameter_value(parameter: Parameter) -> Optional[AtomicOdxTyp
         return cast(str, answer.get(parameter.short_name))
 
 
-def encode_message_interactively(codec: Union[Request, Response],
+def encode_message_interactively(codec: Request | Response,
                                  ask_user_confirmation: bool = False) -> None:
     if sys.__stdin__ is None or sys.__stdout__ is None or not sys.__stdin__.isatty(
     ) or not sys.__stdout__.isatty():
@@ -168,7 +168,7 @@ def encode_message_interactively(codec: Union[Request, Response],
             if (inner_params := getattr(dop := getattr(param, "dop", None), "parameters",
                                         None)) is not None:
                 assert isinstance(dop, DopBase)
-                inner_params = cast(List[Parameter], inner_params)
+                inner_params = cast(list[Parameter], inner_params)
                 # param refers to a complex DOP, i.e., the required
                 # value is a key-value dict
                 print(
@@ -201,8 +201,8 @@ def encode_message_interactively(codec: Union[Request, Response],
 
 
 def encode_message_from_string_values(
-    sub_service: Union[Request, Response],
-    parameter_values: Optional[ParameterValueDict] = None,
+    sub_service: Request | Response,
+    parameter_values: ParameterValueDict | None = None,
 ) -> None:
     if parameter_values is None:
         parameter_values = {}
@@ -243,7 +243,7 @@ def encode_message_from_string_values(
             inner_params = getattr(dop, "parameters", None)
             assert isinstance(dop, ComplexDop)
             assert isinstance(inner_params, list)
-            inner_params = cast(List[Parameter], inner_params)
+            inner_params = cast(list[Parameter], inner_params)
 
             typed_dict = parameter_value.copy()
             for inner_param_sn, inner_param_value in parameter_value.items():
@@ -316,7 +316,7 @@ def browse(odxdb: Database) -> None:
             )
 
         while True:
-            services: List[DiagService] = [
+            services: list[DiagService] = [
                 s for s in variant.services if isinstance(s, DiagService)
             ]
             # Select a service of the ECU
@@ -370,7 +370,7 @@ def browse(odxdb: Database) -> None:
 
             codec = answer.get("message_type")
             if codec is not None:
-                assert isinstance(codec, (Request, Response))
+                assert isinstance(codec, Request | Response)
                 table = extract_parameter_tabulation_data(codec.parameters)
                 print(table)
 

--- a/odxtools/cli/decode.py
+++ b/odxtools/cli/decode.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import re
-from typing import Dict, List, Optional
 
 from ..database import Database
 from ..diagservice import DiagService
@@ -26,13 +25,13 @@ def get_display_value(v: ParameterValue) -> str:
 
 def print_summary(
     odxdb: Database,
-    ecu_variants: Optional[List[str]] = None,
+    ecu_variants: list[str] | None = None,
     data: bytes = b'',
     decode: bool = False,
 ) -> None:
     ecu_names = ecu_variants if ecu_variants else [ecu.short_name for ecu in odxdb.ecus]
-    service_db: Dict[str, DiagService] = {}
-    service_ecus: Dict[str, List[str]] = {}
+    service_db: dict[str, DiagService] = {}
+    service_ecus: dict[str, list[str]] = {}
     for ecu_name in ecu_names:
         ecu = odxdb.ecus[ecu_name]
         if not ecu:

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 import argparse
-from typing import Dict, List, Optional
 
 from ..database import Database
 from ..diagservice import DiagService
@@ -24,13 +23,13 @@ def get_display_value(v: ParameterValue) -> str:
 
 
 def print_summary(odxdb: Database,
-                  service_names: List[str],
-                  ecu_variants: Optional[List[str]] = None,
+                  service_names: list[str],
+                  ecu_variants: list[str] | None = None,
                   allow_unknown_bit_lengths: bool = False,
                   print_params: bool = False) -> None:
     ecu_names = ecu_variants if ecu_variants else [ecu.short_name for ecu in odxdb.ecus]
-    service_db: Dict[str, DiagService] = {}
-    service_ecus: Dict[str, List[str]] = {}
+    service_db: dict[str, DiagService] = {}
+    service_ecus: dict[str, list[str]] = {}
     for ecu_name in ecu_names:
         ecu = odxdb.ecus[ecu_name]
         if not ecu:

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 import argparse
-from typing import Callable, List, Optional
+from collections.abc import Callable
 
 import rich
 
@@ -32,11 +32,11 @@ def print_summary(odxdb: Database,
                   print_state_transitions: bool = False,
                   print_audiences: bool = False,
                   allow_unknown_bit_lengths: bool = False,
-                  variants: Optional[List[str]] = None,
+                  variants: list[str] | None = None,
                   service_filter: Callable[[DiagComm], bool] = lambda x: True) -> None:
 
     diag_layer_names = [dl.short_name for dl in odxdb.diag_layers]
-    diag_layers: List[DiagLayer] = []
+    diag_layers: list[DiagLayer] = []
 
     if variants is None:
         variants = diag_layer_names
@@ -59,9 +59,9 @@ def print_summary(odxdb: Database,
         rich.print(f"Diagnostic layer: '{dl.short_name}'")
         rich.print(f" Variant Type: {dl.variant_type.value}")
 
-        all_services: List[DiagComm] = sorted(dl.services, key=lambda x: x.short_name)
+        all_services: list[DiagComm] = sorted(dl.services, key=lambda x: x.short_name)
 
-        if isinstance(dl, (BaseVariant, EcuVariant)):
+        if isinstance(dl, BaseVariant | EcuVariant):
             for proto in dl.protocols:
                 if (can_rx_id := dl.get_can_receive_id(proto.short_name)) is not None:
                     rich.print(
@@ -99,7 +99,7 @@ def print_summary(odxdb: Database,
                     else:
                         rich.print(f" Unidentifiable service: {service}")
         ddd_spec = dl.diag_data_dictionary_spec
-        data_object_properties: List[
+        data_object_properties: list[
             DataObjectProperty] = [] if ddd_spec is None else ddd_spec.data_object_props
         if print_dops and len(data_object_properties) > 0:
             rich.print("\n")
@@ -108,7 +108,7 @@ def print_summary(odxdb: Database,
                     data_object_properties, key=lambda x: (type(x).__name__, x.short_name)):
                 rich.print("  " + str(dop.short_name).replace("\n", "\n  "))
 
-        comparam_refs: List[ComparamInstance] = []
+        comparam_refs: list[ComparamInstance] = []
         if isinstance(dl, HierarchyElement):
             comparam_refs = dl.comparam_refs
 

--- a/odxtools/cli/main.py
+++ b/odxtools/cli/main.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import importlib
-from typing import Any, List
+from typing import Any
 
 import odxtools
 import odxtools.exceptions
@@ -11,7 +11,7 @@ from .dummy_sub_parser import DummyTool
 
 # import the tool modules which can be loaded. if a tool
 # can't be loaded, add a dummy one
-tool_modules: List[Any] = []
+tool_modules: list[Any] = []
 for tool_name in ["list", "browse", "snoop", "find", "decode", "compare"]:
     try:
         tool_modules.append(importlib.import_module(f".{tool_name}", package="odxtools.cli"))

--- a/odxtools/cli/snoop.py
+++ b/odxtools/cli/snoop.py
@@ -4,7 +4,7 @@
 import argparse
 import asyncio
 import sys
-from typing import Any, List, Optional, Type
+from typing import Any
 
 import can
 
@@ -103,7 +103,7 @@ def handle_telegram(telegram_id: int, payload: bytes) -> None:
               f"({payload!r}, {len(payload)} bytes)")
 
 
-def init_verbose_state_machine(BaseClass: Type[IsoTpStateMachine], *args: Any,
+def init_verbose_state_machine(BaseClass: type[IsoTpStateMachine], *args: Any,
                                **kwargs: Any) -> IsoTpStateMachine:
 
     class InformativeIsoTpDecoder(BaseClass):  # type: ignore[valid-type, misc]
@@ -246,7 +246,7 @@ def run(args: argparse.Namespace) -> None:
 
     protocol_name = args.protocol
     if odx_diag_layer is not None and protocol_name is not None:
-        protocols: Optional[List[Protocol]] = getattr(odx_diag_layer, "protocols", None)
+        protocols: list[Protocol] | None = getattr(odx_diag_layer, "protocols", None)
 
         if protocols is None:
             print(f"ECU variant {odx_diag_layer.short_name} is of type "

--- a/odxtools/codec.py
+++ b/odxtools/codec.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 import typing
-from typing import Optional, runtime_checkable
+from typing import runtime_checkable
 
 from .decodestate import DecodeState
 from .encodestate import EncodeState
@@ -17,12 +17,12 @@ class Codec(typing.Protocol):
     def short_name(self) -> str:
         return ""
 
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         ...
 
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         ...
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         ...

--- a/odxtools/commrelation.py
+++ b/odxtools/commrelation.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .commrelationvaluetype import CommRelationValueType
@@ -16,26 +16,26 @@ from .snrefcontext import SnRefContext
 
 @dataclass
 class CommRelation:
-    description: Optional[Description]
+    description: Description | None
     relation_type: str
-    diag_comm_ref: Optional[OdxLinkRef]
-    diag_comm_snref: Optional[str]
-    in_param_if_snref: Optional[str]
+    diag_comm_ref: OdxLinkRef | None
+    diag_comm_snref: str | None
+    in_param_if_snref: str | None
     #in_param_if_snpathref: Optional[str] # TODO
-    out_param_if_snref: Optional[str]
+    out_param_if_snref: str | None
     #out_param_if_snpathref: Optional[str] # TODO
-    value_type_raw: Optional[CommRelationValueType]
+    value_type_raw: CommRelationValueType | None
 
     @property
     def diag_comm(self) -> DiagComm:
         return self._diag_comm
 
     @property
-    def in_param_if(self) -> Optional[Parameter]:
+    def in_param_if(self) -> Parameter | None:
         return self._in_param_if
 
     @property
-    def out_param_if(self) -> Optional[Parameter]:
+    def out_param_if(self) -> Parameter | None:
         return self._out_param_if
 
     @property
@@ -46,7 +46,7 @@ class CommRelation:
         return self.value_type_raw
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "CommRelation":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "CommRelation":
         description = Description.from_et(et_element.find("DESC"), doc_frags)
         relation_type = odxrequire(et_element.findtext("RELATION-TYPE"))
 
@@ -85,7 +85,7 @@ class CommRelation:
             out_param_if_snref=out_param_if_snref,
             value_type_raw=value_type_raw)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .companyspecificinfo import CompanySpecificInfo
@@ -15,12 +15,12 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class CompanyData(IdentifiableElement):
-    roles: List[str]
+    roles: list[str]
     team_members: NamedItemList[TeamMember]
-    company_specific_info: Optional[CompanySpecificInfo]
+    company_specific_info: CompanySpecificInfo | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "CompanyData":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "CompanyData":
 
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -43,7 +43,7 @@ class CompanyData(IdentifiableElement):
             **kwargs,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         for tm in self.team_members:

--- a/odxtools/companydocinfo.py
+++ b/odxtools/companydocinfo.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .companydata import CompanyData
@@ -14,21 +14,21 @@ from .teammember import TeamMember
 @dataclass
 class CompanyDocInfo:
     company_data_ref: OdxLinkRef
-    team_member_ref: Optional[OdxLinkRef]
-    doc_label: Optional[str]
-    sdgs: List[SpecialDataGroup]
+    team_member_ref: OdxLinkRef | None
+    doc_label: str | None
+    sdgs: list[SpecialDataGroup]
 
     @property
     def company_data(self) -> CompanyData:
         return self._company_data
 
     @property
-    def team_member(self) -> Optional[TeamMember]:
+    def team_member(self) -> TeamMember | None:
         return self._team_member
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "CompanyDocInfo":
+                doc_frags: list[OdxDocFragment]) -> "CompanyDocInfo":
         # the company data reference is mandatory
         company_data_ref = odxrequire(
             OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags))
@@ -45,7 +45,7 @@ class CompanyDocInfo:
             sdgs=sdgs,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         for sdg in self.sdgs:
@@ -56,7 +56,7 @@ class CompanyDocInfo:
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
         self._company_data = odxlinks.resolve(self.company_data_ref, CompanyData)
 
-        self._team_member: Optional[TeamMember] = None
+        self._team_member: TeamMember | None = None
         if self.team_member_ref is not None:
             self._team_member = odxlinks.resolve(self.team_member_ref, TeamMember)
 

--- a/odxtools/companyrevisioninfo.py
+++ b/odxtools/companyrevisioninfo.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .companydata import CompanyData
@@ -12,8 +12,8 @@ from .snrefcontext import SnRefContext
 @dataclass
 class CompanyRevisionInfo:
     company_data_ref: OdxLinkRef
-    revision_label: Optional[str]
-    state: Optional[str]
+    revision_label: str | None
+    state: str | None
 
     @property
     def company_data(self) -> CompanyData:
@@ -21,7 +21,7 @@ class CompanyRevisionInfo:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "CompanyRevisionInfo":
+                doc_frags: list[OdxDocFragment]) -> "CompanyRevisionInfo":
 
         company_data_ref = odxrequire(
             OdxLinkRef.from_et(et_element.find("COMPANY-DATA-REF"), doc_frags))
@@ -31,7 +31,7 @@ class CompanyRevisionInfo:
         return CompanyRevisionInfo(
             company_data_ref=company_data_ref, revision_label=revision_label, state=state)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/companyspecificinfo.py
+++ b/odxtools/companyspecificinfo.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -11,12 +11,12 @@ from .specialdatagroup import SpecialDataGroup
 
 @dataclass
 class CompanySpecificInfo:
-    related_docs: List[RelatedDoc]
-    sdgs: List[SpecialDataGroup]
+    related_docs: list[RelatedDoc]
+    sdgs: list[SpecialDataGroup]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "CompanySpecificInfo":
+                doc_frags: list[OdxDocFragment]) -> "CompanySpecificInfo":
         related_docs = [
             RelatedDoc.from_et(rd, doc_frags)
             for rd in et_element.iterfind("RELATED-DOCS/RELATED-DOC")
@@ -28,7 +28,7 @@ class CompanySpecificInfo:
 
         return CompanySpecificInfo(related_docs=related_docs, sdgs=sdgs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         for rd in self.related_docs:

--- a/odxtools/comparam.py
+++ b/odxtools/comparam.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
@@ -27,7 +27,7 @@ class Comparam(BaseComparam):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Comparam":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Comparam":
         kwargs = dataclass_fields_asdict(BaseComparam.from_et(et_element, doc_frags))
 
         physical_default_value_raw = odxrequire(et_element.findtext("PHYSICAL-DEFAULT-VALUE"))
@@ -36,7 +36,7 @@ class Comparam(BaseComparam):
         return Comparam(
             dop_ref=dop_ref, physical_default_value_raw=physical_default_value_raw, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return super()._build_odxlinks()
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
@@ -20,10 +20,10 @@ class ComparamInstance:
 
     Be aware that the ODX specification calls this class COMPARAM-REF!
     """
-    value: Union[str, ComplexValue]
-    description: Optional[Description]
-    protocol_snref: Optional[str]
-    prot_stack_snref: Optional[str]
+    value: str | ComplexValue
+    description: Description | None
+    protocol_snref: str | None
+    prot_stack_snref: str | None
     spec_ref: OdxLinkRef
 
     @property
@@ -36,13 +36,13 @@ class ComparamInstance:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ComparamInstance":
+                doc_frags: list[OdxDocFragment]) -> "ComparamInstance":
         spec_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
 
         # ODX standard v2.0.0 defined only VALUE. ODX v2.0.1 decided
         # to break things and change it to a choice between SIMPLE-VALUE
         # and COMPLEX-VALUE
-        value: Union[str, List[Union[str, ComplexValue]]]
+        value: str | list[str | ComplexValue]
         if et_element.find("VALUE") is not None:
             value = odxrequire(et_element.findtext("VALUE"))
         elif et_element.find("SIMPLE-VALUE") is not None:
@@ -68,7 +68,7 @@ class ComparamInstance:
             prot_stack_snref=prot_stack_snref,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
@@ -98,7 +98,7 @@ class ComparamInstance:
 
         return result
 
-    def get_subvalue(self, subparam_name: str) -> Optional[str]:
+    def get_subvalue(self, subparam_name: str) -> str | None:
         """Retrieve the value of a complex communication parameter's sub-parameter by name
 
         This takes the default value of the comparam (if any) into
@@ -133,7 +133,7 @@ class ComparamInstance:
             return None
 
         result = value_list[idx]
-        if result is None and isinstance(subparam, (Comparam, ComplexComparam)):
+        if result is None and isinstance(subparam, Comparam | ComplexComparam):
             result = subparam.physical_default_value
         if not isinstance(result, str):
             odxraise()

--- a/odxtools/comparamspec.py
+++ b/odxtools/comparamspec.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .nameditemlist import NamedItemList
@@ -20,7 +20,7 @@ class ComparamSpec(OdxCategory):
     prot_stacks: NamedItemList[ProtStack]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ComparamSpec":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ComparamSpec":
 
         base_obj = OdxCategory.category_from_et(
             et_element, doc_frags, doc_type=DocType.COMPARAM_SPEC)
@@ -34,7 +34,7 @@ class ComparamSpec(OdxCategory):
 
         return ComparamSpec(prot_stacks=prot_stacks, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
 
         for ps in self.prot_stacks:

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .comparam import Comparam
@@ -22,12 +22,12 @@ class ComparamSubset(OdxCategory):
     comparams: NamedItemList[Comparam]
     complex_comparams: NamedItemList[ComplexComparam]
     data_object_props: NamedItemList[DataObjectProperty]
-    unit_spec: Optional[UnitSpec]
-    category: Optional[str]  # mandatory in ODX 2.2, but non-existent in ODX 2.0
+    unit_spec: UnitSpec | None
+    category: str | None  # mandatory in ODX 2.2, but non-existent in ODX 2.0
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ComparamSubset":
+                doc_frags: list[OdxDocFragment]) -> "ComparamSubset":
 
         category_attrib = et_element.attrib.get("CATEGORY")
 
@@ -64,7 +64,7 @@ class ComparamSubset(OdxCategory):
             unit_spec=unit_spec,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
 
         for comparam in self.comparams:

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Union
 from xml.etree import ElementTree
 
 from .basecomparam import BaseComparam
@@ -10,7 +10,7 @@ from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
-ComplexValue = List[Union[str, "ComplexValue"]]
+ComplexValue = list[Union[str, "ComplexValue"]]
 
 
 def create_complex_value_from_et(et_element: ElementTree.Element) -> ComplexValue:
@@ -26,8 +26,8 @@ def create_complex_value_from_et(et_element: ElementTree.Element) -> ComplexValu
 @dataclass
 class ComplexComparam(BaseComparam):
     subparams: NamedItemList[BaseComparam]
-    physical_default_value: Optional[ComplexValue]
-    allow_multiple_values_raw: Optional[bool]
+    physical_default_value: ComplexValue | None
+    allow_multiple_values_raw: bool | None
 
     @property
     def allow_multiple_values(self) -> bool:
@@ -35,7 +35,7 @@ class ComplexComparam(BaseComparam):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ComplexComparam":
+                doc_frags: list[OdxDocFragment]) -> "ComplexComparam":
         kwargs = dataclass_fields_asdict(BaseComparam.from_et(et_element, doc_frags))
 
         # to avoid a cyclic import, create_any_comparam_from_et cannot
@@ -68,7 +68,7 @@ class ComplexComparam(BaseComparam):
         # extract the complex physical default value. (what's the
         # purpose of this? the sub-parameters can define their own
         # default values if a default is desired...)
-        complex_physical_default_value: Optional[ComplexValue] = None
+        complex_physical_default_value: ComplexValue | None = None
         if (cpdv_elem := et_element.find("COMPLEX-PHYSICAL-DEFAULT-VALUE")) is not None:
             complex_physical_default_value = create_complex_value_from_et(cpdv_elem)
 
@@ -80,7 +80,7 @@ class ComplexComparam(BaseComparam):
             allow_multiple_values_raw=allow_multiple_values_raw,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
         for subparam in self.subparams:
             odxlinks.update(subparam._build_odxlinks())

--- a/odxtools/compositecodec.py
+++ b/odxtools/compositecodec.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 import typing
-from typing import List, Optional, runtime_checkable
+from typing import runtime_checkable
 
 from .codec import Codec
 from .decodestate import DecodeState
@@ -22,20 +22,20 @@ class CompositeCodec(Codec, typing.Protocol):
     """
 
     @property
-    def parameters(self) -> List[Parameter]:
+    def parameters(self) -> list[Parameter]:
         return []
 
     @property
-    def required_parameters(self) -> List[Parameter]:
+    def required_parameters(self) -> list[Parameter]:
         return []
 
     @property
-    def free_parameters(self) -> List[Parameter]:
+    def free_parameters(self) -> list[Parameter]:
         return []
 
 
 # some helper functions useful for composite codec objects
-def composite_codec_get_static_bit_length(codec: CompositeCodec) -> Optional[int]:
+def composite_codec_get_static_bit_length(codec: CompositeCodec) -> int | None:
     """Compute the length of a composite codec object in bits
 
     This is basically the sum of the lengths of all parameters. If the
@@ -59,7 +59,7 @@ def composite_codec_get_static_bit_length(codec: CompositeCodec) -> Optional[int
     return byte_length * 8
 
 
-def composite_codec_get_required_parameters(codec: CompositeCodec) -> List[Parameter]:
+def composite_codec_get_required_parameters(codec: CompositeCodec) -> list[Parameter]:
     """Return the list of parameters which are required to be
     specified for encoding the composite codec object
 
@@ -68,7 +68,7 @@ def composite_codec_get_required_parameters(codec: CompositeCodec) -> List[Param
     return [p for p in codec.parameters if p.is_required]
 
 
-def composite_codec_get_free_parameters(codec: CompositeCodec) -> List[Parameter]:
+def composite_codec_get_free_parameters(codec: CompositeCodec) -> list[Parameter]:
     """Return the list of parameters which can be freely specified by
     the user when encoding the composite codec object
 
@@ -84,7 +84,7 @@ def composite_codec_get_coded_const_prefix(codec: CompositeCodec,
 
     for param in codec.parameters:
         if (isinstance(param, MatchingRequestParameter) and param.request_byte_position < len(request_prefix)) or \
-            isinstance(param, (CodedConstParameter, PhysicalConstantParameter)):
+            isinstance(param, CodedConstParameter|PhysicalConstantParameter) :
             param.encode_into_pdu(physical_value=None, encode_state=encode_state)
         else:
             break
@@ -92,7 +92,7 @@ def composite_codec_get_coded_const_prefix(codec: CompositeCodec,
     return encode_state.coded_message
 
 
-def composite_codec_encode_into_pdu(codec: CompositeCodec, physical_value: Optional[ParameterValue],
+def composite_codec_encode_into_pdu(codec: CompositeCodec, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
     from .parameters.lengthkeyparameter import LengthKeyParameter
     from .parameters.tablekeyparameter import TableKeyParameter
@@ -132,7 +132,7 @@ def composite_codec_encode_into_pdu(codec: CompositeCodec, physical_value: Optio
             # the ODX is located last in the PDU...
             encode_state.is_end_of_pdu = orig_is_end_of_pdu
 
-        if isinstance(param, (LengthKeyParameter, TableKeyParameter)):
+        if isinstance(param, LengthKeyParameter | TableKeyParameter):
             # At this point, we encode a placeholder value for length-
             # and table keys, since these can be specified
             # implicitly (i.e., by means of parameters that use
@@ -159,7 +159,7 @@ def composite_codec_encode_into_pdu(codec: CompositeCodec, physical_value: Optio
     # because we allow these to be defined implicitly (i.e. they
     # are defined by their respective users)
     for param in codec.parameters:
-        if not isinstance(param, (LengthKeyParameter, TableKeyParameter)):
+        if not isinstance(param, LengthKeyParameter | TableKeyParameter):
             # the current parameter is neither a length- nor a table key
             continue
 

--- a/odxtools/compumethods/compucodecompumethod.py
+++ b/odxtools/compumethods/compucodecompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
@@ -20,21 +20,21 @@ class CompuCodeCompuMethod(CompuMethod):
     """
 
     @property
-    def internal_to_phys_code(self) -> Optional[ProgCode]:
+    def internal_to_phys_code(self) -> ProgCode | None:
         if self.compu_internal_to_phys is None:
             return None
 
         return self.compu_internal_to_phys.prog_code
 
     @property
-    def phys_to_internal_code(self) -> Optional[ProgCode]:
+    def phys_to_internal_code(self) -> ProgCode | None:
         if self.compu_phys_to_internal is None:
             return None
 
         return self.compu_phys_to_internal.prog_code
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "CompuCodeCompuMethod":
         cm = CompuMethod.compu_method_from_et(

--- a/odxtools/compumethods/compuconst.py
+++ b/odxtools/compumethods/compuconst.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Optional
 from xml.etree import ElementTree
 
 from ..odxtypes import AtomicOdxType, DataType
@@ -8,13 +7,13 @@ from ..odxtypes import AtomicOdxType, DataType
 
 @dataclass
 class CompuConst:
-    v: Optional[str]
-    vt: Optional[str]
+    v: str | None
+    vt: str | None
 
     data_type: DataType
 
     @property
-    def value(self) -> Optional[AtomicOdxType]:
+    def value(self) -> AtomicOdxType | None:
         return self._value
 
     @staticmethod
@@ -26,6 +25,6 @@ class CompuConst:
         return CompuConst(v=v, vt=vt, data_type=data_type)
 
     def __post_init__(self) -> None:
-        self._value: Optional[AtomicOdxType] = self.vt
+        self._value: AtomicOdxType | None = self.vt
         if self.v is not None:
             self._value = self.data_type.from_string(self.v)

--- a/odxtools/compumethods/compudefaultvalue.py
+++ b/odxtools/compumethods/compudefaultvalue.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Optional
 from xml.etree import ElementTree
 
 from ..odxtypes import DataType
@@ -11,7 +10,7 @@ from .compuinversevalue import CompuInverseValue
 
 @dataclass
 class CompuDefaultValue(CompuConst):
-    compu_inverse_value: Optional[CompuInverseValue]
+    compu_inverse_value: CompuInverseValue | None
 
     @staticmethod
     def compuvalue_from_et(et_element: ElementTree.Element, *,

--- a/odxtools/compumethods/compuinternaltophys.py
+++ b/odxtools/compumethods/compuinternaltophys.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -13,13 +13,13 @@ from .compuscale import CompuScale
 
 @dataclass
 class CompuInternalToPhys:
-    compu_scales: List[CompuScale]
-    prog_code: Optional[ProgCode]
-    compu_default_value: Optional[CompuDefaultValue]
+    compu_scales: list[CompuScale]
+    prog_code: ProgCode | None
+    compu_default_value: CompuDefaultValue | None
 
     @staticmethod
     def compu_internal_to_phys_from_et(et_element: ElementTree.Element,
-                                       doc_frags: List[OdxDocFragment], *, internal_type: DataType,
+                                       doc_frags: list[OdxDocFragment], *, internal_type: DataType,
                                        physical_type: DataType) -> "CompuInternalToPhys":
         compu_scales = [
             CompuScale.compuscale_from_et(
@@ -39,7 +39,7 @@ class CompuInternalToPhys:
         return CompuInternalToPhys(
             compu_scales=compu_scales, prog_code=prog_code, compu_default_value=compu_default_value)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         if self.prog_code is not None:

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise
@@ -31,14 +31,14 @@ class CompuMethod:
     """
 
     category: CompuCategory
-    compu_internal_to_phys: Optional[CompuInternalToPhys]
-    compu_phys_to_internal: Optional[CompuPhysToInternal]
+    compu_internal_to_phys: CompuInternalToPhys | None
+    compu_phys_to_internal: CompuPhysToInternal | None
 
     physical_type: DataType
     internal_type: DataType
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType, physical_type: DataType) -> "CompuMethod":
         cat_text = et_element.findtext("CATEGORY")
         if cat_text is None:
@@ -67,7 +67,7 @@ class CompuMethod:
             physical_type=physical_type,
             internal_type=internal_type)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         if self.compu_internal_to_phys is not None:

--- a/odxtools/compumethods/compuphystointernal.py
+++ b/odxtools/compumethods/compuphystointernal.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from ..odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -13,13 +13,13 @@ from .compuscale import CompuScale
 
 @dataclass
 class CompuPhysToInternal:
-    compu_scales: List[CompuScale]
-    prog_code: Optional[ProgCode]
-    compu_default_value: Optional[CompuDefaultValue]
+    compu_scales: list[CompuScale]
+    prog_code: ProgCode | None
+    compu_default_value: CompuDefaultValue | None
 
     @staticmethod
     def compu_phys_to_internal_from_et(et_element: ElementTree.Element,
-                                       doc_frags: List[OdxDocFragment], *, internal_type: DataType,
+                                       doc_frags: list[OdxDocFragment], *, internal_type: DataType,
                                        physical_type: DataType) -> "CompuPhysToInternal":
         compu_scales = [
             CompuScale.compuscale_from_et(
@@ -39,7 +39,7 @@ class CompuPhysToInternal:
         return CompuPhysToInternal(
             compu_scales=compu_scales, prog_code=prog_code, compu_default_value=compu_default_value)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         if self.prog_code is not None:

--- a/odxtools/compumethods/compurationalcoeffs.py
+++ b/odxtools/compumethods/compurationalcoeffs.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Union, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import odxassert, odxrequire
@@ -12,11 +12,11 @@ from ..odxtypes import DataType
 class CompuRationalCoeffs:
     value_type: DataType
 
-    numerators: List[Union[int, float]]
-    denominators: List[Union[int, float]]
+    numerators: list[int | float]
+    denominators: list[int | float]
 
     @staticmethod
-    def coeffs_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def coeffs_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                        value_type: DataType) -> "CompuRationalCoeffs":
         odxassert(
             value_type

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from ..description import Description
@@ -17,13 +16,13 @@ class CompuScale:
     """A COMPU-SCALE represents one value range of a COMPU-METHOD.
     """
 
-    short_label: Optional[str]
-    description: Optional[Description]
-    lower_limit: Optional[Limit]
-    upper_limit: Optional[Limit]
-    compu_inverse_value: Optional[CompuInverseValue]
-    compu_const: Optional[CompuConst]
-    compu_rational_coeffs: Optional[CompuRationalCoeffs]
+    short_label: str | None
+    description: Description | None
+    lower_limit: Limit | None
+    upper_limit: Limit | None
+    compu_inverse_value: CompuInverseValue | None
+    compu_const: CompuConst | None
+    compu_rational_coeffs: CompuRationalCoeffs | None
 
     # the following two attributes are not specified for COMPU-SCALE
     # tags in the XML, but they are required to do anything useful
@@ -38,7 +37,7 @@ class CompuScale:
     range_type: DataType
 
     @staticmethod
-    def compuscale_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compuscale_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                            domain_type: DataType, range_type: DataType) -> "CompuScale":
         short_label = et_element.findtext("SHORT-LABEL")
         description = Description.from_et(et_element.find("DESC"), doc_frags)
@@ -56,7 +55,7 @@ class CompuScale:
         if (cce := et_element.find("COMPU-CONST")) is not None:
             compu_const = CompuConst.compuvalue_from_et(cce, data_type=range_type)
 
-        compu_rational_coeffs: Optional[CompuRationalCoeffs] = None
+        compu_rational_coeffs: CompuRationalCoeffs | None = None
         if (crc_elem := et_element.find("COMPU-RATIONAL-COEFFS")) is not None:
             compu_rational_coeffs = CompuRationalCoeffs.coeffs_from_et(
                 crc_elem, doc_frags, value_type=range_type)

--- a/odxtools/compumethods/createanycompumethod.py
+++ b/odxtools/compumethods/createanycompumethod.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-from typing import List
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise, odxrequire
@@ -17,7 +16,7 @@ from .texttablecompumethod import TexttableCompuMethod
 
 
 def create_any_compu_method_from_et(et_element: ElementTree.Element,
-                                    doc_frags: List[OdxDocFragment], *, internal_type: DataType,
+                                    doc_frags: list[OdxDocFragment], *, internal_type: DataType,
                                     physical_type: DataType) -> CompuMethod:
     compu_category = odxrequire(et_element.findtext("CATEGORY"))
 

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List
 from xml.etree import ElementTree
 
 from ..exceptions import odxassert
@@ -18,7 +17,7 @@ class IdenticalCompuMethod(CompuMethod):
     """
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "IdenticalCompuMethod":
         cm = CompuMethod.compu_method_from_et(

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, overload
+from typing import Optional, overload
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise
@@ -11,29 +11,29 @@ from .intervaltype import IntervalType
 
 @dataclass
 class Limit:
-    value_raw: Optional[str]
-    value_type: Optional[DataType]
-    interval_type: Optional[IntervalType]
+    value_raw: str | None
+    value_type: DataType | None
+    interval_type: IntervalType | None
 
     @property
-    def value(self) -> Optional[AtomicOdxType]:
+    def value(self) -> AtomicOdxType | None:
         return self._value
 
     @staticmethod
     @overload
-    def limit_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment],
-                      value_type: Optional[DataType]) -> "Limit":
+    def limit_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment],
+                      value_type: DataType | None) -> "Limit":
         ...
 
     @staticmethod
     @overload
-    def limit_from_et(et_element: None, doc_frags: List[OdxDocFragment],
-                      value_type: Optional[DataType]) -> None:
+    def limit_from_et(et_element: None, doc_frags: list[OdxDocFragment],
+                      value_type: DataType | None) -> None:
         ...
 
     @staticmethod
-    def limit_from_et(et_element: Optional[ElementTree.Element], doc_frags: List[OdxDocFragment],
-                      value_type: Optional[DataType]) -> Optional["Limit"]:
+    def limit_from_et(et_element: ElementTree.Element | None, doc_frags: list[OdxDocFragment],
+                      value_type: DataType | None) -> Optional["Limit"]:
 
         if et_element is None:
             return None
@@ -50,7 +50,7 @@ class Limit:
         return Limit(value_raw=value_raw, interval_type=interval_type, value_type=value_type)
 
     def __post_init__(self) -> None:
-        self._value: Optional[AtomicOdxType] = None
+        self._value: AtomicOdxType | None = None
 
         if self.value_type is not None:
             self.set_value_type(self.value_type)

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
@@ -30,7 +30,7 @@ class LinearCompuMethod(CompuMethod):
         return self._segment
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "LinearCompuMethod":
         cm = CompuMethod.compu_method_from_et(

--- a/odxtools/compumethods/linearsegment.py
+++ b/odxtools/compumethods/linearsegment.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Optional, Union
 
 from ..exceptions import odxraise, odxrequire
 from ..odxtypes import AtomicOdxType, DataType
@@ -24,20 +23,20 @@ class LinearSegment:
     offset: float
     factor: float
     denominator: float
-    internal_lower_limit: Optional[Limit]
-    internal_upper_limit: Optional[Limit]
+    internal_lower_limit: Limit | None
+    internal_upper_limit: Limit | None
 
-    inverse_value: Union[int, float]  # value used as inverse if factor is 0
+    inverse_value: int | float  # value used as inverse if factor is 0
 
     internal_type: DataType
     physical_type: DataType
 
     @property
-    def physical_lower_limit(self) -> Optional[Limit]:
+    def physical_lower_limit(self) -> Limit | None:
         return self._physical_lower_limit
 
     @property
-    def physical_upper_limit(self) -> Optional[Limit]:
+    def physical_upper_limit(self) -> Limit | None:
         return self._physical_upper_limit
 
     @staticmethod
@@ -52,10 +51,10 @@ class LinearSegment:
         if len(coeffs.denominators) > 0:
             denominator = coeffs.denominators[0]
 
-        inverse_value: Union[int, float] = 0
+        inverse_value: int | float = 0
         if scale.compu_inverse_value is not None:
             x = odxrequire(scale.compu_inverse_value).value
-            if not isinstance(x, (int, float)):
+            if not isinstance(x, int | float):
                 odxraise(f"Non-numeric COMPU-INVERSE-VALUE specified ({x!r})")
             inverse_value = x
 
@@ -75,8 +74,8 @@ class LinearSegment:
     def __post_init__(self) -> None:
         self.__compute_physical_limits()
 
-    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> Union[float, int]:
-        if not isinstance(internal_value, (int, float)):
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> float | int:
+        if not isinstance(internal_value, int | float):
             odxraise(f"Internal values of linear compumethods must "
                      f"either be int or float (is: {type(internal_value).__name__})")
 
@@ -90,8 +89,8 @@ class LinearSegment:
 
         return result
 
-    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> Union[float, int]:
-        if not isinstance(physical_value, (int, float)):
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> float | int:
+        if not isinstance(physical_value, int | float):
             odxraise(f"Physical values of linear compumethods must "
                      f"either be int or float (is: {type(physical_value).__name__})")
 
@@ -115,7 +114,7 @@ class LinearSegment:
         This method is called by `__post_init__()`.
         """
 
-        def convert_internal_to_physical_limit(internal_limit: Optional[Limit]) -> Optional[Limit]:
+        def convert_internal_to_physical_limit(internal_limit: Limit | None) -> Limit | None:
             """Helper method to convert a single internal limit
             """
             if internal_limit is None or internal_limit.value_raw is None:
@@ -152,7 +151,7 @@ class LinearSegment:
         # Do type checks
         expected_type = self.physical_type.python_type
         if issubclass(expected_type, float):
-            if not isinstance(physical_value, (int, float)):
+            if not isinstance(physical_value, int | float):
                 return False
         else:
             if not isinstance(physical_value, expected_type):
@@ -173,7 +172,7 @@ class LinearSegment:
         # Do type checks
         expected_type = self.internal_type.python_type
         if issubclass(expected_type, float):
-            if not isinstance(internal_value, (int, float)):
+            if not isinstance(internal_value, int | float):
                 return False
         else:
             if not isinstance(internal_value, expected_type):

--- a/odxtools/compumethods/ratfunccompumethod.py
+++ b/odxtools/compumethods/ratfunccompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
@@ -30,11 +30,11 @@ class RatFuncCompuMethod(CompuMethod):
         return self._int_to_phys_segment
 
     @property
-    def phys_to_int_segment(self) -> Optional[RatFuncSegment]:
+    def phys_to_int_segment(self) -> RatFuncSegment | None:
         return self._phys_to_int_segment
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "RatFuncCompuMethod":
         cm = CompuMethod.compu_method_from_et(

--- a/odxtools/compumethods/ratfuncsegment.py
+++ b/odxtools/compumethods/ratfuncsegment.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, Union
 
 from ..exceptions import odxraise, odxrequire
 from ..odxtypes import AtomicOdxType, DataType
@@ -14,11 +13,11 @@ class RatFuncSegment:
     """
     value_type: DataType
 
-    numerator_coeffs: List[Union[int, float]]
-    denominator_coeffs: List[Union[int, float]]
+    numerator_coeffs: list[int | float]
+    denominator_coeffs: list[int | float]
 
-    lower_limit: Optional[Limit]
-    upper_limit: Optional[Limit]
+    lower_limit: Limit | None
+    upper_limit: Limit | None
 
     @staticmethod
     def from_compu_scale(scale: CompuScale, value_type: DataType) -> "RatFuncSegment":
@@ -39,8 +38,8 @@ class RatFuncSegment:
             upper_limit=upper_limit,
             value_type=scale.range_type)
 
-    def convert(self, value: AtomicOdxType) -> Union[float, int]:
-        if not isinstance(value, (int, float)):
+    def convert(self, value: AtomicOdxType) -> float | int:
+        if not isinstance(value, int | float):
             odxraise(f"Internal values of linear compumethods must "
                      f"either be int or float (is: {type(value).__name__})")
 
@@ -70,7 +69,7 @@ class RatFuncSegment:
         # Do type checks
         expected_type = self.value_type.python_type
         if issubclass(expected_type, float):
-            if not isinstance(value, (int, float)):
+            if not isinstance(value, int | float):
                 return False
         else:
             if not isinstance(value, expected_type):

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Union, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
@@ -21,11 +21,11 @@ class ScaleLinearCompuMethod(CompuMethod):
     """
 
     @property
-    def segments(self) -> List[LinearSegment]:
+    def segments(self) -> list[LinearSegment]:
         return self._segments
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "ScaleLinearCompuMethod":
         cm = CompuMethod.compu_method_from_et(
@@ -35,7 +35,7 @@ class ScaleLinearCompuMethod(CompuMethod):
         return ScaleLinearCompuMethod(**kwargs)
 
     def __post_init__(self) -> None:
-        self._segments: List[LinearSegment] = []
+        self._segments: list[LinearSegment] = []
 
         odxassert(self.category == CompuCategory.SCALE_LINEAR,
                   "ScaleLinearCompuMethod must exibit SCALE-LINEAR category")
@@ -100,7 +100,7 @@ class ScaleLinearCompuMethod(CompuMethod):
                 self._is_invertible = False
                 break
 
-            if not isinstance(x, (int, float)):
+            if not isinstance(x, int | float):
                 odxraise("Linear segments must use int or float for all quantities")
 
             # the respective function value at the interval's
@@ -111,7 +111,7 @@ class ScaleLinearCompuMethod(CompuMethod):
                 self._is_invertible = False
                 break
 
-    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> Union[float, int]:
+    def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> float | int:
         if not self._is_invertible:
             odxraise(
                 f"Trying to encode value {physical_value!r} using a non-invertible "
@@ -128,7 +128,7 @@ class ScaleLinearCompuMethod(CompuMethod):
 
         return seg.convert_physical_to_internal(physical_value)
 
-    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> Union[float, int]:
+    def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> float | int:
         applicable_segments = [
             seg for seg in self._segments if seg.internal_applies(internal_value)
         ]

--- a/odxtools/compumethods/scaleratfunccompumethod.py
+++ b/odxtools/compumethods/scaleratfunccompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise
@@ -20,15 +20,15 @@ class ScaleRatFuncCompuMethod(CompuMethod):
     """
 
     @property
-    def int_to_phys_segments(self) -> List[RatFuncSegment]:
+    def int_to_phys_segments(self) -> list[RatFuncSegment]:
         return self._int_to_phys_segments
 
     @property
-    def phys_to_int_segments(self) -> Optional[List[RatFuncSegment]]:
+    def phys_to_int_segments(self) -> list[RatFuncSegment] | None:
         return self._phys_to_int_segments
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "ScaleRatFuncCompuMethod":
         cm = CompuMethod.compu_method_from_et(

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Union
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
@@ -37,11 +36,11 @@ class TabIntpCompuMethod(CompuMethod):
     """
 
     @property
-    def internal_points(self) -> List[Union[float, int]]:
+    def internal_points(self) -> list[float | int]:
         return self._internal_points
 
     @property
-    def physical_points(self) -> List[Union[float, int]]:
+    def physical_points(self) -> list[float | int]:
         return self._physical_points
 
     @property
@@ -61,7 +60,7 @@ class TabIntpCompuMethod(CompuMethod):
         return self._physical_upper_limit
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "TabIntpCompuMethod":
         cm = CompuMethod.compu_method_from_et(
@@ -74,16 +73,16 @@ class TabIntpCompuMethod(CompuMethod):
         odxassert(self.category == CompuCategory.TAB_INTP,
                   "TabIntpCompuMethod must exibit TAB-INTP category")
 
-        self._internal_points: List[Union[int, float]] = []
-        self._physical_points: List[Union[int, float]] = []
+        self._internal_points: list[int | float] = []
+        self._physical_points: list[int | float] = []
         for scale in odxrequire(self.compu_internal_to_phys).compu_scales:
             internal_point = odxrequire(scale.lower_limit).value
             physical_point = odxrequire(scale.compu_const).value
 
-            if not isinstance(internal_point, (float, int)):
+            if not isinstance(internal_point, float | int):
                 odxraise("The type of values of tab-intp compumethods must "
                          "either int or float")
-            if not isinstance(physical_point, (float, int)):
+            if not isinstance(physical_point, float | int):
                 odxraise("The type of values of tab-intp compumethods must "
                          "either int or float")
 
@@ -130,10 +129,8 @@ class TabIntpCompuMethod(CompuMethod):
             ], "Physical data type of TAB-INTP compumethod must be one of"
             " [A_INT32, A_UINT32, A_FLOAT32, A_FLOAT64]")
 
-    def __piecewise_linear_interpolate(self, x: Union[int, float],
-                                       range_samples: List[Union[int, float]],
-                                       domain_samples: List[Union[int,
-                                                                  float]]) -> Union[float, None]:
+    def __piecewise_linear_interpolate(self, x: int | float, range_samples: list[int | float],
+                                       domain_samples: list[int | float]) -> float | None:
         for i in range(0, len(range_samples) - 1):
             if (x0 := range_samples[i]) <= x and x <= (x1 := range_samples[i + 1]):
                 y0 = domain_samples[i]
@@ -143,13 +140,13 @@ class TabIntpCompuMethod(CompuMethod):
         return None
 
     def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
-        if not isinstance(physical_value, (int, float)):
+        if not isinstance(physical_value, int | float):
             odxraise("The type of values of tab-intp compumethods must "
                      "either int or float", EncodeError)
             return None
 
         odxassert(
-            isinstance(physical_value, (int, float)),
+            isinstance(physical_value, int | float),
             "Only integers and floats can be piecewise linearly interpolated", EncodeError)
         result = self.__piecewise_linear_interpolate(physical_value, self._physical_points,
                                                      self._internal_points)
@@ -164,14 +161,14 @@ class TabIntpCompuMethod(CompuMethod):
         return res
 
     def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
-        if not isinstance(internal_value, (int, float)):
+        if not isinstance(internal_value, int | float):
             odxraise(
                 "The internal type of values of tab-intp compumethods must "
                 "either int or float", EncodeError)
             return None
 
         odxassert(
-            isinstance(internal_value, (int, float)),
+            isinstance(internal_value, int | float),
             "Only integers and floats can be piecewise linearly interpolated", DecodeError)
 
         result = self.__piecewise_linear_interpolate(internal_value, self._internal_points,
@@ -188,14 +185,14 @@ class TabIntpCompuMethod(CompuMethod):
         return res
 
     def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
-        if not isinstance(physical_value, (int, float)):
+        if not isinstance(physical_value, int | float):
             return False
 
         return min(self.physical_points) <= physical_value and physical_value <= max(
             self.physical_points)
 
     def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
-        if not isinstance(internal_value, (int, float)):
+        if not isinstance(internal_value, int | float):
             return False
 
         return min(self.internal_points) <= internal_value and internal_value <= max(

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..exceptions import DecodeError, EncodeError, odxassert, odxraise, odxrequire
@@ -22,7 +22,7 @@ class TexttableCompuMethod(CompuMethod):
     """
 
     @staticmethod
-    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def compu_method_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              internal_type: DataType,
                              physical_type: DataType) -> "TexttableCompuMethod":
         cm = CompuMethod.compu_method_from_et(
@@ -95,7 +95,7 @@ class TexttableCompuMethod(CompuMethod):
         scales = []
         if (citp := self.compu_internal_to_phys) is not None:
             scales = citp.compu_scales
-        matching_scales: List[CompuScale] = [x for x in scales if x.applies(internal_value)]
+        matching_scales: list[CompuScale] = [x for x in scales if x.applies(internal_value)]
 
         if len(matching_scales) == 0:
             if self._compu_physical_default_value is None:

--- a/odxtools/createanycomparam.py
+++ b/odxtools/createanycomparam.py
@@ -1,4 +1,3 @@
-from typing import List, Union
 from xml.etree import ElementTree
 
 from .comparam import Comparam
@@ -6,9 +5,8 @@ from .complexcomparam import ComplexComparam
 from .odxlink import OdxDocFragment
 
 
-def create_any_comparam_from_et(
-        et_element: ElementTree.Element,
-        doc_frags: List[OdxDocFragment]) -> Union[Comparam, ComplexComparam]:
+def create_any_comparam_from_et(et_element: ElementTree.Element,
+                                doc_frags: list[OdxDocFragment]) -> Comparam | ComplexComparam:
     if et_element.tag == "COMPARAM":
         return Comparam.from_et(et_element, doc_frags)
     elif et_element.tag == "COMPLEX-COMPARAM":

--- a/odxtools/createanydiagcodedtype.py
+++ b/odxtools/createanydiagcodedtype.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-from typing import List
 from xml.etree import ElementTree
 
 from .diagcodedtype import DiagCodedType
@@ -13,7 +12,7 @@ from .standardlengthtype import StandardLengthType
 
 
 def create_any_diag_coded_type_from_et(et_element: ElementTree.Element,
-                                       doc_frags: List[OdxDocFragment]) -> DiagCodedType:
+                                       doc_frags: list[OdxDocFragment]) -> DiagCodedType:
     dct_type = et_element.get(f"{xsi}type")
     if dct_type == "LEADING-LENGTH-INFO-TYPE":
         return LeadingLengthInfoType.from_et(et_element, doc_frags)

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
+from collections import OrderedDict
 from itertools import chain
 from os import PathLike
 from pathlib import Path
-from typing import IO, Any, Dict, List, Optional, OrderedDict, Union
+from typing import IO, Any, Union
 from xml.etree import ElementTree
 from zipfile import ZipFile
 
@@ -30,7 +31,7 @@ class Database:
     """
 
     def __init__(self) -> None:
-        self.model_version: Optional[Version] = None
+        self.model_version: Version | None = None
         self.auxiliary_files: OrderedDict[str, IO[bytes]] = OrderedDict()
 
         # create an empty database object
@@ -68,16 +69,16 @@ class Database:
 
     def add_auxiliary_file(self,
                            aux_file_name: Union[str, "PathLike[Any]"],
-                           aux_file_obj: Optional[IO[bytes]] = None) -> None:
+                           aux_file_obj: IO[bytes] | None = None) -> None:
         if aux_file_obj is None:
             aux_file_obj = open(aux_file_name, "rb")
 
         self.auxiliary_files[str(aux_file_name)] = aux_file_obj
 
     def _process_xml_tree(self, root: ElementTree.Element) -> None:
-        dlcs: List[DiagLayerContainer] = []
-        comparam_subsets: List[ComparamSubset] = []
-        comparam_specs: List[ComparamSpec] = []
+        dlcs: list[DiagLayerContainer] = []
+        comparam_subsets: list[ComparamSubset] = []
+        comparam_specs: list[ComparamSpec] = []
 
         # ODX spec version
         model_version = Version(root.attrib.get("MODEL-VERSION", "2.0"))
@@ -160,8 +161,8 @@ class Database:
         for dlc in self.diag_layer_containers:
             dlc._resolve_snrefs(context)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result: Dict[OdxLinkId, Any] = {}
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
+        result: dict[OdxLinkId, Any] = {}
 
         for subset in self.comparam_subsets:
             result.update(subset._build_odxlinks())

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .compumethods.compumethod import CompuMethod
@@ -37,20 +37,20 @@ class DataObjectProperty(DopBase):
     #: The type of the value in the physical world
     physical_type: PhysicalType
 
-    internal_constr: Optional[InternalConstr]
+    internal_constr: InternalConstr | None
 
     #: The unit associated with physical values (e.g. 'm/s^2')
-    unit_ref: Optional[OdxLinkRef]
+    unit_ref: OdxLinkRef | None
 
-    physical_constr: Optional[InternalConstr]
+    physical_constr: InternalConstr | None
 
     @property
-    def unit(self) -> Optional[Unit]:
+    def unit(self) -> Unit | None:
         return self._unit
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DataObjectProperty":
+                doc_frags: list[OdxDocFragment]) -> "DataObjectProperty":
         """Reads a DATA-OBJECT-PROP."""
         kwargs = dataclass_fields_asdict(DopBase.from_et(et_element, doc_frags))
 
@@ -83,7 +83,7 @@ class DataObjectProperty(DopBase):
             physical_constr=physical_constr,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
         result.update(self.compu_method._build_odxlinks())
         result.update(self.diag_coded_type._build_odxlinks())
@@ -96,7 +96,7 @@ class DataObjectProperty(DopBase):
         self.compu_method._resolve_odxlinks(odxlinks)
         self.diag_coded_type._resolve_odxlinks(odxlinks)
 
-        self._unit: Optional[Unit] = None
+        self._unit: Unit | None = None
         if self.unit_ref:
             self._unit = odxlinks.resolve(self.unit_ref, Unit)
 
@@ -106,7 +106,7 @@ class DataObjectProperty(DopBase):
         self.compu_method._resolve_snrefs(context)
         self.diag_coded_type._resolve_snrefs(context)
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return self.diag_coded_type.get_static_bit_length()
 
     def encode_into_pdu(self, physical_value: ParameterValue, encode_state: EncodeState) -> None:
@@ -118,7 +118,7 @@ class DataObjectProperty(DopBase):
                 f"The value {repr(physical_value)} of type {type(physical_value).__name__}"
                 f" is not a valid.")
 
-        if not isinstance(physical_value, (int, float, str, BytesTypes)):
+        if not isinstance(physical_value, int | float | str | BytesTypes):
             odxraise(f"Invalid type '{type(physical_value).__name__}' for physical value. "
                      f"(Expect atomic type!)")
         internal_value = self.compu_method.convert_physical_to_internal(physical_value)

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 from .encoding import Encoding, get_string_encoding
 from .exceptions import DecodeError, odxassert, odxraise, strict_mode
@@ -41,22 +41,22 @@ class DecodeState:
     cursor_bit_position: int = 0
 
     #: values of the length key parameters decoded so far
-    length_keys: Dict[str, int] = field(default_factory=dict)
+    length_keys: dict[str, int] = field(default_factory=dict)
 
     #: values of the table key parameters decoded so far
-    table_keys: Dict[str, "TableRow"] = field(default_factory=dict)
+    table_keys: dict[str, "TableRow"] = field(default_factory=dict)
 
     #: List of parameters that have been decoded so far. The journal
     #: is used by some types of parameters which depend on the values of
     #: other parameters; i.e., environment data description parameters
-    journal: List[Tuple["Parameter", Optional[ParameterValue]]] = field(default_factory=list)
+    journal: list[tuple["Parameter", ParameterValue | None]] = field(default_factory=list)
 
     def extract_atomic_value(
         self,
         *,
         bit_length: int,
         base_data_type: DataType,
-        base_type_encoding: Optional[Encoding],
+        base_type_encoding: Encoding | None,
         is_highlow_byte_order: bool,
     ) -> AtomicOdxType:
         """Extract an internal value from a blob of raw bytes.

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
@@ -10,13 +10,13 @@ from .odxlink import OdxDocFragment
 @dataclass
 class Description:
     text: str
-    external_docs: List[ExternalDoc]
+    external_docs: list[ExternalDoc]
 
-    text_identifier: Optional[str]
+    text_identifier: str | None
 
     @staticmethod
-    def from_et(et_element: Optional[ElementTree.Element],
-                doc_frags: List[OdxDocFragment]) -> Optional["Description"]:
+    def from_et(et_element: ElementTree.Element | None,
+                doc_frags: list[OdxDocFragment]) -> Optional["Description"]:
         if et_element is None:
             return None
 

--- a/odxtools/determinenumberofitems.py
+++ b/odxtools/determinenumberofitems.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .dataobjectproperty import DataObjectProperty
@@ -15,7 +15,7 @@ class DetermineNumberOfItems:
     The object that determines the number of items of dynamic fields
     """
     byte_position: int
-    bit_position: Optional[int]
+    bit_position: int | None
     dop_ref: OdxLinkRef
 
     @property
@@ -24,7 +24,7 @@ class DetermineNumberOfItems:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DetermineNumberOfItems":
+                doc_frags: list[OdxDocFragment]) -> "DetermineNumberOfItems":
         byte_position = int(odxrequire(et_element.findtext("BYTE-POSITION")))
         bit_position_str = et_element.findtext("BIT-POSITION")
         bit_position = int(bit_position_str) if bit_position_str is not None else None
@@ -36,7 +36,7 @@ class DetermineNumberOfItems:
             dop_ref=dop_ref,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Literal, cast
 from xml.etree import ElementTree
 
 from .decodestate import DecodeState
@@ -22,10 +22,10 @@ DctType = Literal[
 
 @dataclass
 class DiagCodedType:
-    base_type_encoding: Optional[Encoding]
+    base_type_encoding: Encoding | None
     base_data_type: DataType
 
-    is_highlow_byte_order_raw: Optional[bool]
+    is_highlow_byte_order_raw: bool | None
 
     @property
     def dct_type(self) -> DctType:
@@ -39,7 +39,7 @@ class DiagCodedType:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DiagCodedType":
+                doc_frags: list[OdxDocFragment]) -> "DiagCodedType":
         base_type_encoding = None
         if (base_type_encoding_str := et_element.get("BASE-TYPE-ENCODING")) is not None:
             try:
@@ -61,7 +61,7 @@ class DiagCodedType:
             base_data_type=base_data_type,
             is_highlow_byte_order_raw=is_highlow_byte_order_raw)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:  # noqa: B027
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:  # noqa: B027
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:  # noqa: B027
@@ -72,10 +72,10 @@ class DiagCodedType:
         """Recursively resolve any short-name references"""
         pass
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return None
 
-    def _minimal_byte_length_of(self, internal_value: Union[bytes, str]) -> int:
+    def _minimal_byte_length_of(self, internal_value: bytes | str) -> int:
         """Helper method to get the minimal byte length.
         (needed for LeadingLength- and MinMaxLengthType)
         """

--- a/odxtools/diagcomm.py
+++ b/odxtools/diagcomm.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -34,21 +34,21 @@ class DiagComm(IdentifiableElement):
 
     """
 
-    admin_data: Optional[AdminData]
-    sdgs: List[SpecialDataGroup]
-    functional_class_refs: List[OdxLinkRef]
-    audience: Optional[Audience]
-    protocol_snrefs: List[str]
-    related_diag_comm_refs: List[RelatedDiagCommRef]
-    pre_condition_state_refs: List[PreConditionStateRef]
-    state_transition_refs: List[StateTransitionRef]
+    admin_data: AdminData | None
+    sdgs: list[SpecialDataGroup]
+    functional_class_refs: list[OdxLinkRef]
+    audience: Audience | None
+    protocol_snrefs: list[str]
+    related_diag_comm_refs: list[RelatedDiagCommRef]
+    pre_condition_state_refs: list[PreConditionStateRef]
+    state_transition_refs: list[StateTransitionRef]
 
     # attributes
-    semantic: Optional[str]
-    diagnostic_class: Optional[DiagClassType]
-    is_mandatory_raw: Optional[bool]
-    is_executable_raw: Optional[bool]
-    is_final_raw: Optional[bool]
+    semantic: str | None
+    diagnostic_class: DiagClassType | None
+    is_mandatory_raw: bool | None
+    is_executable_raw: bool | None
+    is_final_raw: bool | None
 
     @property
     def functional_classes(self) -> NamedItemList[FunctionalClass]:
@@ -83,7 +83,7 @@ class DiagComm(IdentifiableElement):
         return self.is_final_raw is True
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagComm":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagComm":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
@@ -122,7 +122,7 @@ class DiagComm(IdentifiableElement):
 
         semantic = et_element.attrib.get("SEMANTIC")
 
-        diagnostic_class: Optional[DiagClassType] = None
+        diagnostic_class: DiagClassType | None = None
         if (diagnostic_class_str := et_element.attrib.get("DIAGNOSTIC-CLASS")) is not None:
             try:
                 diagnostic_class = DiagClassType(diagnostic_class_str)
@@ -149,7 +149,7 @@ class DiagComm(IdentifiableElement):
             is_final_raw=is_final_raw,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         if self.admin_data is not None:

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -26,7 +26,7 @@ from .unitspec import UnitSpec
 
 @dataclass
 class DiagDataDictionarySpec:
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
     dtc_dops: NamedItemList[DtcDop]
     env_data_descs: NamedItemList[EnvironmentDataDescription]
     data_object_props: NamedItemList[DataObjectProperty]
@@ -37,13 +37,13 @@ class DiagDataDictionarySpec:
     end_of_pdu_fields: NamedItemList[EndOfPduField]
     muxs: NamedItemList[Multiplexer]
     env_datas: NamedItemList[EnvironmentData]
-    unit_spec: Optional[UnitSpec]
+    unit_spec: UnitSpec | None
     tables: NamedItemList[Table]
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DiagDataDictionarySpec":
+                doc_frags: list[OdxDocFragment]) -> "DiagDataDictionarySpec":
         admin_data = None
         if (admin_data_elem := et_element.find("ADMIN-DATA")) is not None:
             admin_data = AdminData.from_et(admin_data_elem, doc_frags)
@@ -149,7 +149,7 @@ class DiagDataDictionarySpec:
                 self.env_datas,
             ))
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         # note that DataDictionarySpec objects do not exhibit an ODXLINK id.
         odxlinks = {}
 

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .diaglayers.basevariant import BaseVariant
@@ -41,7 +41,7 @@ class DiagLayerContainer(OdxCategory):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DiagLayerContainer":
+                doc_frags: list[OdxDocFragment]) -> "DiagLayerContainer":
 
         cat = OdxCategory.category_from_et(et_element, doc_frags, doc_type=DocType.CONTAINER)
         doc_frags = cat.odx_id.doc_fragments
@@ -85,7 +85,7 @@ class DiagLayerContainer(OdxCategory):
             self.ecu_variants,
         ),)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for protocol in self.protocols:
@@ -132,5 +132,5 @@ class DiagLayerContainer(OdxCategory):
     def _resolve_snrefs(self, context: SnRefContext) -> None:
         super()._resolve_snrefs(context)
 
-    def __getitem__(self, key: Union[int, str]) -> DiagLayer:
+    def __getitem__(self, key: int | str) -> DiagLayer:
         return self.diag_layers[key]

--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Union, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -32,19 +33,19 @@ class BaseVariant(HierarchyElement):
     # <properties forwarded to the "raw" base variant>
     #####
     @property
-    def diag_variables_raw(self) -> List[Union[DiagVariable, OdxLinkRef]]:
+    def diag_variables_raw(self) -> list[DiagVariable | OdxLinkRef]:
         return self.base_variant_raw.diag_variables_raw
 
     @property
-    def dyn_defined_spec(self) -> Optional[DynDefinedSpec]:
+    def dyn_defined_spec(self) -> DynDefinedSpec | None:
         return self.base_variant_raw.dyn_defined_spec
 
     @property
-    def base_variant_pattern(self) -> Optional[BaseVariantPattern]:
+    def base_variant_pattern(self) -> BaseVariantPattern | None:
         return self.base_variant_raw.base_variant_pattern
 
     @property
-    def parent_refs(self) -> List[ParentRef]:
+    def parent_refs(self) -> list[ParentRef]:
         return self.base_variant_raw.parent_refs
 
     #####
@@ -67,7 +68,7 @@ class BaseVariant(HierarchyElement):
     #######
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "BaseVariant":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "BaseVariant":
         base_variant_raw = BaseVariantRaw.from_et(et_element, doc_frags)
 
         return BaseVariant(diag_layer_raw=base_variant_raw)
@@ -80,7 +81,7 @@ class BaseVariant(HierarchyElement):
             "The raw diagnostic layer passed to BaseVariant "
             "must be a BaseVariantRaw")
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the base variant
 
         Note that the copied diagnostic layer is not fully
@@ -113,7 +114,7 @@ class BaseVariant(HierarchyElement):
 
             return dl.diag_layer_raw.diag_variables  # type: ignore[no-any-return]
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -127,7 +128,7 @@ class BaseVariant(HierarchyElement):
 
             return dl.diag_layer_raw.variable_groups  # type: ignore[no-any-return]
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)

--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from ..basevariantpattern import BaseVariantPattern
@@ -21,11 +21,11 @@ class BaseVariantRaw(HierarchyElementRaw):
     """This is a diagnostic layer for common functionality of an ECU
     """
 
-    diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]
-    dyn_defined_spec: Optional[DynDefinedSpec]
-    base_variant_pattern: Optional[BaseVariantPattern]
-    parent_refs: List[ParentRef]
+    dyn_defined_spec: DynDefinedSpec | None
+    base_variant_pattern: BaseVariantPattern | None
+    parent_refs: list[ParentRef]
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:
@@ -33,7 +33,7 @@ class BaseVariantRaw(HierarchyElementRaw):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "BaseVariantRaw":
+                doc_frags: list[OdxDocFragment]) -> "BaseVariantRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
@@ -42,10 +42,10 @@ class BaseVariantRaw(HierarchyElementRaw):
         kwargs = dataclass_fields_asdict(her)
         doc_frags = her.odx_id.doc_fragments
 
-        diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
+        diag_variables_raw: list[DiagVariable | OdxLinkRef] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:
             for dv_proxy_elem in dv_elems:
-                dv_proxy: Union[OdxLinkRef, DiagVariable]
+                dv_proxy: OdxLinkRef | DiagVariable
                 if dv_proxy_elem.tag == "DIAG-VARIABLE-REF":
                     dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, doc_frags)
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
@@ -81,7 +81,7 @@ class BaseVariantRaw(HierarchyElementRaw):
             parent_refs=parent_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for dv_proxy in self.diag_variables_raw:

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Callable, Iterable
 from copy import copy, deepcopy
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import chain
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union, cast
+from typing import Any, Union, cast
 from xml.etree import ElementTree
 
 from ..admindata import AdminData
@@ -29,7 +30,7 @@ from ..unitgroup import UnitGroup
 from .diaglayerraw import DiagLayerRaw
 from .diaglayertype import DiagLayerType
 
-PrefixTree = Dict[int, Union[List[DiagService], "PrefixTree"]]
+PrefixTree = dict[int, Union[list[DiagService], "PrefixTree"]]
 
 
 @dataclass
@@ -44,7 +45,7 @@ class DiagLayer:
     diag_layer_raw: DiagLayerRaw
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagLayer":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagLayer":
         diag_layer_raw = DiagLayerRaw.from_et(et_element, doc_frags)
 
         # Create DiagLayer
@@ -72,7 +73,7 @@ class DiagLayer:
         else:
             self._diag_data_dictionary_spec = self.diag_layer_raw.diag_data_dictionary_spec
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         """Construct a mapping from IDs to all objects that are contained in this diagnostic layer."""
         result = self.diag_layer_raw._build_odxlinks()
 
@@ -91,7 +92,7 @@ class DiagLayer:
         # reference. This mechanism can thus be seen as a kind of
         # "poor man's inheritance".
         if self.import_refs:
-            imported_links: Dict[OdxLinkId, Any] = {}
+            imported_links: dict[OdxLinkId, Any] = {}
             for import_ref in self.import_refs:
                 imported_dl = odxlinks.resolve(import_ref, DiagLayer)
 
@@ -168,7 +169,7 @@ class DiagLayer:
         """
         return get_local_objects(self)
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the diagnostic layer
 
         Note that the copied diagnostic layer is not fully
@@ -210,15 +211,15 @@ class DiagLayer:
         return self.diag_layer_raw.short_name
 
     @property
-    def long_name(self) -> Optional[str]:
+    def long_name(self) -> str | None:
         return self.diag_layer_raw.long_name
 
     @property
-    def description(self) -> Optional[Description]:
+    def description(self) -> Description | None:
         return self.diag_layer_raw.description
 
     @property
-    def admin_data(self) -> Optional[AdminData]:
+    def admin_data(self) -> AdminData | None:
         return self.diag_layer_raw.admin_data
 
     @property
@@ -258,7 +259,7 @@ class DiagLayer:
         return self.diag_layer_raw.global_negative_responses
 
     @property
-    def import_refs(self) -> List[OdxLinkRef]:
+    def import_refs(self) -> list[OdxLinkRef]:
         return self.diag_layer_raw.import_refs
 
     @property
@@ -270,7 +271,7 @@ class DiagLayer:
         return self.diag_layer_raw.sub_components
 
     @property
-    def sdgs(self) -> List[SpecialDataGroup]:
+    def sdgs(self) -> list[SpecialDataGroup]:
         return self.diag_layer_raw.sdgs
 
     @property
@@ -359,13 +360,13 @@ class DiagLayer:
         if sub_tree.get(-1) is None:
             sub_tree[-1] = [service]
         else:
-            cast(List[DiagService], sub_tree[-1]).append(service)
+            cast(list[DiagService], sub_tree[-1]).append(service)
 
-    def _find_services_for_uds(self, message: bytes) -> List[DiagService]:
+    def _find_services_for_uds(self, message: bytes) -> list[DiagService]:
         prefix_tree = self._prefix_tree
 
         # Find matching service(s) in prefix tree
-        possible_services: List[DiagService] = []
+        possible_services: list[DiagService] = []
         for b in message:
             if b in prefix_tree:
                 odxassert(isinstance(prefix_tree[b], dict))
@@ -373,11 +374,11 @@ class DiagLayer:
             else:
                 break
             if -1 in prefix_tree:
-                possible_services += cast(List[DiagService], prefix_tree[-1])
+                possible_services += cast(list[DiagService], prefix_tree[-1])
         return possible_services
 
-    def _decode(self, message: bytes, candidate_services: Iterable[DiagService]) -> List[Message]:
-        decoded_messages: List[Message] = []
+    def _decode(self, message: bytes, candidate_services: Iterable[DiagService]) -> list[Message]:
+        decoded_messages: list[Message] = []
 
         for service in candidate_services:
             try:
@@ -415,12 +416,12 @@ class DiagLayer:
 
         return decoded_messages
 
-    def decode(self, message: bytes) -> List[Message]:
+    def decode(self, message: bytes) -> list[Message]:
         candidate_services = self._find_services_for_uds(message)
 
         return self._decode(message, candidate_services)
 
-    def decode_response(self, response: bytes, request: bytes) -> List[Message]:
+    def decode_response(self, response: bytes, request: bytes) -> list[Message]:
         candidate_services = self._find_services_for_uds(request)
         if candidate_services is None:
             raise DecodeError(f"Couldn't find corresponding service for request {request.hex()}.")

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from ..additionalaudience import AdditionalAudience
@@ -36,21 +36,21 @@ class DiagLayerRaw(IdentifiableElement):
     """
 
     variant_type: DiagLayerType
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
     company_datas: NamedItemList[CompanyData]
     functional_classes: NamedItemList[FunctionalClass]
-    diag_data_dictionary_spec: Optional[DiagDataDictionarySpec]
-    diag_comms_raw: List[Union[OdxLinkRef, DiagComm]]
+    diag_data_dictionary_spec: DiagDataDictionarySpec | None
+    diag_comms_raw: list[OdxLinkRef | DiagComm]
     requests: NamedItemList[Request]
     positive_responses: NamedItemList[Response]
     negative_responses: NamedItemList[Response]
     global_negative_responses: NamedItemList[Response]
-    import_refs: List[OdxLinkRef]
+    import_refs: list[OdxLinkRef]
     state_charts: NamedItemList[StateChart]
     additional_audiences: NamedItemList[AdditionalAudience]
     sub_components: NamedItemList[SubComponent]
     libraries: NamedItemList[Library]
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
     @property
     def diag_comms(self) -> NamedItemList[DiagComm]:
@@ -70,7 +70,7 @@ class DiagLayerRaw(IdentifiableElement):
         return self._single_ecu_jobs
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagLayerRaw":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagLayerRaw":
         try:
             variant_type = DiagLayerType(et_element.tag)
         except ValueError:
@@ -102,10 +102,10 @@ class DiagLayerRaw(IdentifiableElement):
         if (ddds_elem := et_element.find("DIAG-DATA-DICTIONARY-SPEC")) is not None:
             diag_data_dictionary_spec = DiagDataDictionarySpec.from_et(ddds_elem, doc_frags)
 
-        diag_comms_raw: List[Union[OdxLinkRef, DiagComm]] = []
+        diag_comms_raw: list[OdxLinkRef | DiagComm] = []
         if (dc_elems := et_element.find("DIAG-COMMS")) is not None:
             for dc_proxy_elem in dc_elems:
-                dc: Union[OdxLinkRef, DiagComm]
+                dc: OdxLinkRef | DiagComm
                 if dc_proxy_elem.tag == "DIAG-COMM-REF":
                     dc = OdxLinkRef.from_et(dc_proxy_elem, doc_frags)
                 elif dc_proxy_elem.tag == "DIAG-SERVICE":
@@ -183,7 +183,7 @@ class DiagLayerRaw(IdentifiableElement):
             sdgs=sdgs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         """Construct a mapping from IDs to all objects that are contained in this diagnostic layer."""
         odxlinks = {self.odx_id: self}
 

--- a/odxtools/diaglayers/diaglayertype.py
+++ b/odxtools/diaglayers/diaglayertype.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import Dict
 
 
 class DiagLayerType(Enum):
@@ -19,7 +18,7 @@ class DiagLayerType(Enum):
 
         """
 
-        PRIORITY_OF_DIAG_LAYER_TYPE: Dict[DiagLayerType, int] = {
+        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, int] = {
             DiagLayerType.PROTOCOL:
                 1,
             DiagLayerType.FUNCTIONAL_GROUP:

--- a/odxtools/diaglayers/ecushareddata.py
+++ b/odxtools/diaglayers/ecushareddata.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 from xml.etree import ElementTree
 
 from ..diagvariable import DiagVariable
@@ -27,7 +27,7 @@ class EcuSharedData(DiagLayer):
         return cast(EcuSharedDataRaw, self.diag_layer_raw)
 
     @property
-    def diag_variables_raw(self) -> List[Union[OdxLinkRef, DiagVariable]]:
+    def diag_variables_raw(self) -> list[OdxLinkRef | DiagVariable]:
         return self.ecu_shared_data_raw.diag_variables_raw
 
     @property
@@ -40,7 +40,7 @@ class EcuSharedData(DiagLayer):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EcuSharedData":
+                doc_frags: list[OdxDocFragment]) -> "EcuSharedData":
         ecu_shared_data_raw = EcuSharedDataRaw.from_et(et_element, doc_frags)
 
         return EcuSharedData(diag_layer_raw=ecu_shared_data_raw)
@@ -78,7 +78,7 @@ class EcuSharedData(DiagLayer):
         self._resolve_snrefs(context)
         context.diag_layer = None
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the protocol layer
 
         Note that the copied diagnostic layer is not fully

--- a/odxtools/diaglayers/ecushareddataraw.py
+++ b/odxtools/diaglayers/ecushareddataraw.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from ..diagvariable import DiagVariable
@@ -18,7 +18,7 @@ class EcuSharedDataRaw(DiagLayerRaw):
     """This is a diagnostic layer for data shared accross others
     """
 
-    diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]
 
     @property
@@ -27,7 +27,7 @@ class EcuSharedDataRaw(DiagLayerRaw):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EcuSharedDataRaw":
+                doc_frags: list[OdxDocFragment]) -> "EcuSharedDataRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
@@ -36,10 +36,10 @@ class EcuSharedDataRaw(DiagLayerRaw):
         kwargs = dataclass_fields_asdict(dlr)
         doc_frags = dlr.odx_id.doc_fragments
 
-        diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
+        diag_variables_raw: list[DiagVariable | OdxLinkRef] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:
             for dv_proxy_elem in dv_elems:
-                dv_proxy: Union[OdxLinkRef, DiagVariable]
+                dv_proxy: OdxLinkRef | DiagVariable
                 if dv_proxy_elem.tag == "DIAG-VARIABLE-REF":
                     dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, doc_frags)
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
@@ -58,7 +58,7 @@ class EcuSharedDataRaw(DiagLayerRaw):
         return EcuSharedDataRaw(
             diag_variables_raw=diag_variables_raw, variable_groups=variable_groups, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
         for dv_proxy in self.diag_variables_raw:
             if not isinstance(dv_proxy, OdxLinkRef):

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Union, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -28,19 +29,19 @@ class EcuVariant(HierarchyElement):
         return cast(EcuVariantRaw, self.diag_layer_raw)
 
     @property
-    def diag_variables_raw(self) -> List[Union[DiagVariable, OdxLinkRef]]:
+    def diag_variables_raw(self) -> list[DiagVariable | OdxLinkRef]:
         return self.ecu_variant_raw.diag_variables_raw
 
     @property
-    def dyn_defined_spec(self) -> Optional[DynDefinedSpec]:
+    def dyn_defined_spec(self) -> DynDefinedSpec | None:
         return self.ecu_variant_raw.dyn_defined_spec
 
     @property
-    def parent_refs(self) -> List[ParentRef]:
+    def parent_refs(self) -> list[ParentRef]:
         return self.ecu_variant_raw.parent_refs
 
     @property
-    def base_variant(self) -> Optional[BaseVariant]:
+    def base_variant(self) -> BaseVariant | None:
         """Return the base variant for the ECU variant
 
         The ODX specification allows at a single base variant for each
@@ -55,7 +56,7 @@ class EcuVariant(HierarchyElement):
         return None
 
     @property
-    def ecu_variant_patterns(self) -> List[EcuVariantPattern]:
+    def ecu_variant_patterns(self) -> list[EcuVariantPattern]:
         return self.ecu_variant_raw.ecu_variant_patterns
 
     #######
@@ -74,7 +75,7 @@ class EcuVariant(HierarchyElement):
     #######
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "EcuVariant":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "EcuVariant":
         ecu_variant_raw = EcuVariantRaw.from_et(et_element, doc_frags)
 
         return EcuVariant(diag_layer_raw=ecu_variant_raw)
@@ -87,7 +88,7 @@ class EcuVariant(HierarchyElement):
             "The raw diagnostic layer passed to EcuVariant "
             "must be a EcuVariantRaw")
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the ECU variant
 
         Note that the copied diagnostic layer is not fully
@@ -120,7 +121,7 @@ class EcuVariant(HierarchyElement):
 
             return dl.diag_layer_raw.diag_variables
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -134,7 +135,7 @@ class EcuVariant(HierarchyElement):
 
             return dl.diag_layer_raw.variable_groups
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)

--- a/odxtools/diaglayers/ecuvariantraw.py
+++ b/odxtools/diaglayers/ecuvariantraw.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from ..diagvariable import DiagVariable
@@ -18,11 +18,11 @@ from .hierarchyelementraw import HierarchyElementRaw
 
 @dataclass
 class EcuVariantRaw(HierarchyElementRaw):
-    diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]
-    ecu_variant_patterns: List[EcuVariantPattern]
-    dyn_defined_spec: Optional[DynDefinedSpec]
-    parent_refs: List[ParentRef]
+    ecu_variant_patterns: list[EcuVariantPattern]
+    dyn_defined_spec: DynDefinedSpec | None
+    parent_refs: list[ParentRef]
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:
@@ -30,7 +30,7 @@ class EcuVariantRaw(HierarchyElementRaw):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EcuVariantRaw":
+                doc_frags: list[OdxDocFragment]) -> "EcuVariantRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
@@ -39,10 +39,10 @@ class EcuVariantRaw(HierarchyElementRaw):
         kwargs = dataclass_fields_asdict(her)
         doc_frags = her.odx_id.doc_fragments
 
-        diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
+        diag_variables_raw: list[DiagVariable | OdxLinkRef] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:
             for dv_proxy_elem in dv_elems:
-                dv_proxy: Union[OdxLinkRef, DiagVariable]
+                dv_proxy: OdxLinkRef | DiagVariable
                 if dv_proxy_elem.tag == "DIAG-VARIABLE-REF":
                     dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, doc_frags)
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
@@ -81,7 +81,7 @@ class EcuVariantRaw(HierarchyElementRaw):
             parent_refs=parent_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for dv_proxy in self.diag_variables_raw:

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Union, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -27,7 +28,7 @@ class FunctionalGroup(HierarchyElement):
         return cast(FunctionalGroupRaw, self.diag_layer_raw)
 
     @property
-    def diag_variables_raw(self) -> List[Union[DiagVariable, OdxLinkRef]]:
+    def diag_variables_raw(self) -> list[DiagVariable | OdxLinkRef]:
         return self.functional_group_raw.diag_variables_raw
 
     @property
@@ -39,12 +40,12 @@ class FunctionalGroup(HierarchyElement):
         return self._variable_groups
 
     @property
-    def parent_refs(self) -> List[ParentRef]:
+    def parent_refs(self) -> list[ParentRef]:
         return self.functional_group_raw.parent_refs
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "FunctionalGroup":
+                doc_frags: list[OdxDocFragment]) -> "FunctionalGroup":
         functional_group_raw = FunctionalGroupRaw.from_et(et_element, doc_frags)
 
         return FunctionalGroup(diag_layer_raw=functional_group_raw)
@@ -73,7 +74,7 @@ class FunctionalGroup(HierarchyElement):
 
             return dl.diag_layer_raw.diag_variables  # type: ignore[no-any-return]
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -87,12 +88,12 @@ class FunctionalGroup(HierarchyElement):
 
             return dl.diag_layer_raw.variable_groups  # type: ignore[no-any-return]
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the functional group layer
 
         Note that the copied diagnostic layer is not fully

--- a/odxtools/diaglayers/functionalgroupraw.py
+++ b/odxtools/diaglayers/functionalgroupraw.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from ..diagvariable import DiagVariable
@@ -19,9 +19,9 @@ class FunctionalGroupRaw(HierarchyElementRaw):
     """This is a diagnostic layer for common functionality of an ECU
     """
 
-    diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]
-    parent_refs: List[ParentRef]
+    parent_refs: list[ParentRef]
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:
@@ -29,7 +29,7 @@ class FunctionalGroupRaw(HierarchyElementRaw):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "FunctionalGroupRaw":
+                doc_frags: list[OdxDocFragment]) -> "FunctionalGroupRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
@@ -38,10 +38,10 @@ class FunctionalGroupRaw(HierarchyElementRaw):
         kwargs = dataclass_fields_asdict(her)
         doc_frags = her.odx_id.doc_fragments
 
-        diag_variables_raw: List[Union[DiagVariable, OdxLinkRef]] = []
+        diag_variables_raw: list[DiagVariable | OdxLinkRef] = []
         if (dv_elems := et_element.find("DIAG-VARIABLES")) is not None:
             for dv_proxy_elem in dv_elems:
-                dv_proxy: Union[OdxLinkRef, DiagVariable]
+                dv_proxy: OdxLinkRef | DiagVariable
                 if dv_proxy_elem.tag == "DIAG-VARIABLE-REF":
                     dv_proxy = OdxLinkRef.from_et(dv_proxy_elem, doc_frags)
                 elif dv_proxy_elem.tag == "DIAG-VARIABLE":
@@ -67,7 +67,7 @@ class FunctionalGroupRaw(HierarchyElementRaw):
             parent_refs=parent_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for dv_proxy in self.diag_variables_raw:

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: MIT
 import re
 import warnings
+from collections.abc import Callable, Iterable
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar,
-                    Union, cast)
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 from xml.etree import ElementTree
 
 from ..additionalaudience import AdditionalAudience
@@ -47,7 +47,7 @@ class HierarchyElement(DiagLayer):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "HierarchyElement":
+                doc_frags: list[OdxDocFragment]) -> "HierarchyElement":
         hierarchy_element_raw = HierarchyElementRaw.from_et(et_element, doc_frags)
 
         return HierarchyElement(diag_layer_raw=hierarchy_element_raw)
@@ -62,7 +62,7 @@ class HierarchyElement(DiagLayer):
             "The raw diagnostic layer passed to HierarchyElement "
             "must be a HierarchyElementRaw")
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         return result
@@ -73,7 +73,7 @@ class HierarchyElement(DiagLayer):
     def _resolve_snrefs(self, context: SnRefContext) -> None:
         super()._resolve_snrefs(context)
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the hierarchy element
 
         Note that the copied diagnostic layer is not fully
@@ -121,13 +121,13 @@ class HierarchyElement(DiagLayer):
         unit_groups = self._compute_available_unit_groups()
 
         # convenience variable for the locally-defined unit spec
-        local_unit_spec: Optional[UnitSpec]
+        local_unit_spec: UnitSpec | None
         if self.diag_layer_raw.diag_data_dictionary_spec is not None:
             local_unit_spec = self.diag_layer_raw.diag_data_dictionary_spec.unit_spec
         else:
             local_unit_spec = None
 
-        unit_spec: Optional[UnitSpec]
+        unit_spec: UnitSpec | None
         if local_unit_spec is None and not unit_groups:
             # no locally defined unit spec and no inherited unit groups
             unit_spec = None
@@ -188,8 +188,8 @@ class HierarchyElement(DiagLayer):
         tables = self._compute_available_ddd_spec_items(
             lambda ddd_spec: ddd_spec.tables, lambda parent_ref: parent_ref.not_inherited_tables)
 
-        ddds_admin_data: Optional[AdminData] = None
-        ddds_sdgs: List[SpecialDataGroup] = []
+        ddds_admin_data: AdminData | None = None
+        ddds_sdgs: list[SpecialDataGroup] = []
         if self.diag_layer_raw.diag_data_dictionary_spec:
             ddds_admin_data = self.diag_layer_raw.diag_data_dictionary_spec.admin_data
             ddds_sdgs = self.diag_layer_raw.diag_data_dictionary_spec.sdgs
@@ -291,7 +291,7 @@ class HierarchyElement(DiagLayer):
 
         local_objects = get_local_objects(self)
         local_object_short_names = {x.short_name for x in local_objects}
-        result_dict: Dict[str, Tuple[TNamed, DiagLayer]] = {}
+        result_dict: dict[str, tuple[TNamed, DiagLayer]] = {}
 
         # populate the result dictionary with the inherited objects
         for parent_ref in self._get_parent_refs_sorted_by_priority(reverse=True):
@@ -361,7 +361,7 @@ class HierarchyElement(DiagLayer):
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[DiagComm]:
             return dl._get_local_diag_comms(odxlinks)
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_diag_comms
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -372,7 +372,7 @@ class HierarchyElement(DiagLayer):
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[Response]:
             return dl.diag_layer_raw.global_negative_responses
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_global_neg_responses
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -380,7 +380,7 @@ class HierarchyElement(DiagLayer):
     def _compute_available_ddd_spec_items(
         self,
         include: Callable[[DiagDataDictionarySpec], Iterable[TNamed]],
-        exclude: Callable[["ParentRef"], List[str]],
+        exclude: Callable[["ParentRef"], list[str]],
     ) -> NamedItemList[TNamed]:
 
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[TNamed]:
@@ -396,7 +396,7 @@ class HierarchyElement(DiagLayer):
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[FunctionalClass]:
             return dl.diag_layer_raw.functional_classes
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -406,7 +406,7 @@ class HierarchyElement(DiagLayer):
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[AdditionalAudience]:
             return dl.diag_layer_raw.additional_audiences
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -416,7 +416,7 @@ class HierarchyElement(DiagLayer):
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[StateChart]:
             return dl.diag_layer_raw.state_charts
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -426,7 +426,7 @@ class HierarchyElement(DiagLayer):
         def get_local_objects_fn(dl: DiagLayer) -> Iterable[UnitGroup]:
             return dl._get_local_unit_groups()
 
-        def not_inherited_fn(parent_ref: ParentRef) -> List[str]:
+        def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
@@ -502,7 +502,7 @@ class HierarchyElement(DiagLayer):
     #####
     # <communication parameter handling>
     #####
-    def _compute_available_commmunication_parameters(self) -> List[ComparamInstance]:
+    def _compute_available_commmunication_parameters(self) -> list[ComparamInstance]:
         """Compute the list of communication parameters that apply to
         the diagnostic layer
 
@@ -526,7 +526,7 @@ class HierarchyElement(DiagLayer):
         without a specified protocol are taken as fallbacks...
 
         """
-        com_params_dict: Dict[Tuple[str, Optional[str]], ComparamInstance] = {}
+        com_params_dict: dict[tuple[str, str | None], ComparamInstance] = {}
 
         # Look in parent refs for inherited communication
         # parameters. First fetch the communication parameters from
@@ -564,7 +564,7 @@ class HierarchyElement(DiagLayer):
         """
         from .protocol import Protocol
 
-        result_dict: Dict[str, Protocol] = {}
+        result_dict: dict[str, Protocol] = {}
 
         for parent_ref in getattr(self, "parent_refs", []):
             for prot in getattr(parent_ref.layer, "protocols", []):
@@ -579,15 +579,15 @@ class HierarchyElement(DiagLayer):
         self,
         cp_short_name: str,
         *,
-        protocol: Optional[Union[str, "Protocol"]] = None,
-    ) -> Optional[ComparamInstance]:
+        protocol: Union[str, "Protocol"] | None = None,
+    ) -> ComparamInstance | None:
         """Find a specific communication parameter according to some criteria.
 
         Setting a given parameter to `None` means "don't care"."""
 
         from .protocol import Protocol
 
-        protocol_name: Optional[str]
+        protocol_name: str | None
         if isinstance(protocol, Protocol):
             protocol_name = protocol.short_name
         else:
@@ -611,8 +611,7 @@ class HierarchyElement(DiagLayer):
         return cps[0]
 
     def get_max_can_payload_size(self,
-                                 protocol: Optional[Union[str,
-                                                          "Protocol"]] = None) -> Optional[int]:
+                                 protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """Return the maximum size of a CAN frame payload that can be
         transmitted in bytes.
 
@@ -642,13 +641,13 @@ class HierarchyElement(DiagLayer):
         # unexpected format of parameter value
         return 8
 
-    def uses_can(self, protocol: Optional[Union[str, "Protocol"]] = None) -> bool:
+    def uses_can(self, protocol: Union[str, "Protocol"] | None = None) -> bool:
         """
         Check if CAN ought to be used as the link layer protocol.
         """
         return self.get_can_receive_id(protocol=protocol) is not None
 
-    def uses_can_fd(self, protocol: Optional[Union[str, "Protocol"]] = None) -> bool:
+    def uses_can_fd(self, protocol: Union[str, "Protocol"] | None = None) -> bool:
         """Check if CAN-FD ought to be used.
 
         If the ECU is not using CAN-FD for the specified protocol, `False`
@@ -667,7 +666,7 @@ class HierarchyElement(DiagLayer):
 
         return "CANFD" in com_param.value
 
-    def get_can_baudrate(self, protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:
+    def get_can_baudrate(self, protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """Baudrate of the CAN bus which is used by the ECU [bits/s]
 
         If the ECU is not using CAN for the specified protocol, None
@@ -684,8 +683,7 @@ class HierarchyElement(DiagLayer):
 
         return int(val)
 
-    def get_can_fd_baudrate(self,
-                            protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:
+    def get_can_fd_baudrate(self, protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """Data baudrate of the CAN bus which is used by the ECU [bits/s]
 
         If the ECU is not using CAN-FD for the specified protocol,
@@ -704,8 +702,7 @@ class HierarchyElement(DiagLayer):
 
         return int(val)
 
-    def get_can_receive_id(self,
-                           protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:
+    def get_can_receive_id(self, protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """CAN ID to which the ECU listens for diagnostic messages"""
         com_param = self.get_comparam("CP_UniqueRespIdTable", protocol=protocol)
         if com_param is None:
@@ -724,7 +721,7 @@ class HierarchyElement(DiagLayer):
 
         return int(result)
 
-    def get_can_send_id(self, protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:
+    def get_can_send_id(self, protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """CAN ID to which the ECU sends replies to diagnostic messages"""
 
         # this hopefully resolves to the 'CP_UniqueRespIdTable'
@@ -749,8 +746,7 @@ class HierarchyElement(DiagLayer):
 
         return int(result)
 
-    def get_can_func_req_id(self,
-                            protocol: Optional[Union[str, "Protocol"]] = None) -> Optional[int]:
+    def get_can_func_req_id(self, protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """CAN Functional Request Id."""
         com_param = self.get_comparam("CP_CanFuncReqId", protocol=protocol)
         if com_param is None:
@@ -764,8 +760,7 @@ class HierarchyElement(DiagLayer):
         return int(result)
 
     def get_doip_logical_ecu_address(self,
-                                     protocol: Optional[Union[str,
-                                                              "Protocol"]] = None) -> Optional[int]:
+                                     protocol: Union[str, "Protocol"] | None = None) -> int | None:
         """Return the address of the ECU when using functional addressing.
 
         The parameter protocol is used to distinguish between
@@ -796,8 +791,8 @@ class HierarchyElement(DiagLayer):
         return int(ecu_addr)
 
     def get_doip_logical_gateway_address(self,
-                                         protocol: Optional[Union[str, "Protocol"]] = None
-                                        ) -> Optional[int]:
+                                         protocol: Union[str, "Protocol"] | None = None
+                                        ) -> int | None:
         """The logical gateway address for the diagnosis over IP transport protocol"""
 
         # retrieve CP_DoIPLogicalGatewayAddress from the
@@ -814,8 +809,8 @@ class HierarchyElement(DiagLayer):
         return int(result)
 
     def get_doip_logical_tester_address(self,
-                                        protocol: Optional[Union[str, "Protocol"]] = None
-                                       ) -> Optional[int]:
+                                        protocol: Union[str, "Protocol"] | None = None
+                                       ) -> int | None:
         """DoIp logical gateway address"""
 
         # retrieve CP_DoIPLogicalTesterAddress from the
@@ -832,8 +827,8 @@ class HierarchyElement(DiagLayer):
         return int(result)
 
     def get_doip_logical_functional_address(self,
-                                            protocol: Optional[Union[str, "Protocol"]] = None
-                                           ) -> Optional[int]:
+                                            protocol: Union[str, "Protocol"] | None = None
+                                           ) -> int | None:
         """The logical functional DoIP address of the ECU."""
 
         # retrieve CP_DoIPLogicalFunctionalAddress from the
@@ -853,8 +848,8 @@ class HierarchyElement(DiagLayer):
         return int(result)
 
     def get_doip_routing_activation_timeout(self,
-                                            protocol: Optional[Union[str, "Protocol"]] = None
-                                           ) -> Optional[float]:
+                                            protocol: Union[str, "Protocol"] | None = None
+                                           ) -> float | None:
         """The timout for the DoIP routing activation request in seconds"""
 
         # retrieve CP_DoIPRoutingActivationTimeout from the
@@ -871,8 +866,8 @@ class HierarchyElement(DiagLayer):
         return float(result) / 1e6
 
     def get_doip_routing_activation_type(self,
-                                         protocol: Optional[Union[str, "Protocol"]] = None
-                                        ) -> Optional[int]:
+                                         protocol: Union[str, "Protocol"] | None = None
+                                        ) -> int | None:
         """The DoIP routing activation type
 
         The number returned has the following meaning:
@@ -897,8 +892,7 @@ class HierarchyElement(DiagLayer):
         return int(result)
 
     def get_tester_present_time(self,
-                                protocol: Optional[Union[str,
-                                                         "Protocol"]] = None) -> Optional[float]:
+                                protocol: Union[str, "Protocol"] | None = None) -> float | None:
         """Timeout on inactivity in seconds.
 
         This is defined by the communication parameter "CP_TesterPresentTime".

--- a/odxtools/diaglayers/hierarchyelementraw.py
+++ b/odxtools/diaglayers/hierarchyelementraw.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from ..comparaminstance import ComparamInstance
@@ -17,11 +17,11 @@ class HierarchyElementRaw(DiagLayerRaw):
     This class represents the data present in the XML, not the "logical" view.
     """
 
-    comparam_refs: List[ComparamInstance]
+    comparam_refs: list[ComparamInstance]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "HierarchyElementRaw":
+                doc_frags: list[OdxDocFragment]) -> "HierarchyElementRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
@@ -37,7 +37,7 @@ class HierarchyElementRaw(DiagLayerRaw):
 
         return HierarchyElementRaw(comparam_refs=comparam_refs, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for comparam_ref in self.comparam_refs:

--- a/odxtools/diaglayers/protocol.py
+++ b/odxtools/diaglayers/protocol.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from ..comparamspec import ComparamSpec
@@ -29,11 +29,11 @@ class Protocol(HierarchyElement):
         return self.protocol_raw.comparam_spec
 
     @property
-    def prot_stack(self) -> Optional[ProtStack]:
+    def prot_stack(self) -> ProtStack | None:
         return self.protocol_raw.prot_stack
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Protocol":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Protocol":
         protocol_raw = ProtocolRaw.from_et(et_element, doc_frags)
 
         return Protocol(diag_layer_raw=protocol_raw)
@@ -46,7 +46,7 @@ class Protocol(HierarchyElement):
             "The raw diagnostic layer passed to Protocol "
             "must be a ProtocolRaw")
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the protocol layer
 
         Note that the copied diagnostic layer is not fully

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from ..comparamspec import ComparamSpec
@@ -24,19 +24,19 @@ class ProtocolRaw(HierarchyElementRaw):
     """
 
     comparam_spec_ref: OdxLinkRef
-    prot_stack_snref: Optional[str]
-    parent_refs: List[ParentRef]
+    prot_stack_snref: str | None
+    parent_refs: list[ParentRef]
 
     @property
     def comparam_spec(self) -> ComparamSpec:
         return self._comparam_spec
 
     @property
-    def prot_stack(self) -> Optional[ProtStack]:
+    def prot_stack(self) -> ProtStack | None:
         return self._prot_stack
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ProtocolRaw":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ProtocolRaw":
         # objects contained by diagnostic layers exibit an additional
         # document fragment for the diag layer, so we use the document
         # fragments of the odx id of the diag layer for IDs of
@@ -63,7 +63,7 @@ class ProtocolRaw(HierarchyElementRaw):
             parent_refs=parent_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for parent_ref in self.parent_refs:

--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -16,12 +16,12 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class DiagnosticTroubleCode(IdentifiableElement):
     trouble_code: int
-    display_trouble_code: Optional[str]
+    display_trouble_code: str | None
     text: Text
-    level: Optional[int]
-    sdgs: List[SpecialDataGroup]
+    level: int | None
+    sdgs: list[SpecialDataGroup]
 
-    is_temporary_raw: Optional[bool]
+    is_temporary_raw: bool | None
 
     @property
     def is_temporary(self) -> bool:
@@ -29,7 +29,7 @@ class DiagnosticTroubleCode(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DiagnosticTroubleCode":
+                doc_frags: list[OdxDocFragment]) -> "DiagnosticTroubleCode":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         trouble_code = int(odxrequire(et_element.findtext("TROUBLE-CODE")))
@@ -53,8 +53,8 @@ class DiagnosticTroubleCode(IdentifiableElement):
             is_temporary_raw=is_temporary_raw,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result: Dict[OdxLinkId, Any] = {}
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
+        result: dict[OdxLinkId, Any] = {}
 
         result[self.odx_id] = self
 

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import typing
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, runtime_checkable
+from typing import Any, runtime_checkable
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -33,32 +33,32 @@ class DiagVariable(IdentifiableElement):
     """Representation of a diagnostic variable
     """
 
-    admin_data: Optional[AdminData]
-    variable_group_ref: Optional[OdxLinkRef]
-    sw_variables: List[SwVariable]
+    admin_data: AdminData | None
+    variable_group_ref: OdxLinkRef | None
+    sw_variables: list[SwVariable]
 
     # a diag variable must specify either COMM-RELATIONS or a
     # reference to a table row
-    comm_relations: List[CommRelation]
+    comm_relations: list[CommRelation]
 
     # these are nested inside the SNREF-TO-TABLEROW tag
-    table_snref: Optional[str]
-    table_row_snref: Optional[str]
+    table_snref: str | None
+    table_row_snref: str | None
 
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
-    is_read_before_write_raw: Optional[bool]
+    is_read_before_write_raw: bool | None
 
     @property
-    def table(self) -> Optional[Table]:
+    def table(self) -> Table | None:
         return self._table
 
     @property
-    def table_row(self) -> Optional[TableRow]:
+    def table_row(self) -> TableRow | None:
         return self._table_row
 
     @property
-    def variable_group(self) -> Optional[VariableGroup]:
+    def variable_group(self) -> VariableGroup | None:
         return self._variable_group
 
     @property
@@ -66,7 +66,7 @@ class DiagVariable(IdentifiableElement):
         return self.is_read_before_write_raw is True
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DiagVariable":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DiagVariable":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
@@ -106,7 +106,7 @@ class DiagVariable(IdentifiableElement):
             is_read_before_write_raw=is_read_before_write_raw,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         if self.admin_data is not None:

--- a/odxtools/docrevision.py
+++ b/odxtools/docrevision.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .companyrevisioninfo import CompanyRevisionInfo
@@ -17,20 +17,20 @@ class DocRevision:
     Representation of a single revision of the relevant object.
     """
 
-    team_member_ref: Optional[OdxLinkRef]
-    revision_label: Optional[str]
-    state: Optional[str]
+    team_member_ref: OdxLinkRef | None
+    revision_label: str | None
+    state: str | None
     date: str
-    tool: Optional[str]
-    company_revision_infos: List[CompanyRevisionInfo]
-    modifications: List[Modification]
+    tool: str | None
+    company_revision_infos: list[CompanyRevisionInfo]
+    modifications: list[Modification]
 
     @property
-    def team_member(self) -> Optional[TeamMember]:
+    def team_member(self) -> TeamMember | None:
         return self._team_member
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DocRevision":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DocRevision":
 
         team_member_ref = OdxLinkRef.from_et(et_element.find("TEAM-MEMBER-REF"), doc_frags)
         revision_label = et_element.findtext("REVISION-LABEL")
@@ -59,11 +59,11 @@ class DocRevision:
             modifications=modifications,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        self._team_member: Optional[TeamMember] = None
+        self._team_member: TeamMember | None = None
         if self.team_member_ref is not None:
             self._team_member = odxlinks.resolve(self.team_member_ref, TeamMember)
 

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -24,11 +24,11 @@ class DopBase(IdentifiableElement):
 
     """
 
-    admin_data: Optional[AdminData]
-    sdgs: List[SpecialDataGroup]
+    admin_data: AdminData | None
+    sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DopBase":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DopBase":
 
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -42,7 +42,7 @@ class DopBase(IdentifiableElement):
 
         return DopBase(admin_data=admin_data, sdgs=sdgs, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         for sdg in self.sdgs:
@@ -58,7 +58,7 @@ class DopBase(IdentifiableElement):
         for sdg in self.sdgs:
             sdg._resolve_snrefs(context)
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return None
 
     def is_valid_physical_value(self, physical_value: ParameterValue) -> bool:

--- a/odxtools/dtcconnector.py
+++ b/odxtools/dtcconnector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .diagnostictroublecode import DiagnosticTroubleCode
@@ -26,7 +26,7 @@ class DtcConnector(NamedElement):
         return self._dtc
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "DtcConnector":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "DtcConnector":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         dtc_dop_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DTC-DOP-REF"), doc_frags))
@@ -35,7 +35,7 @@ class DtcConnector(NamedElement):
 
         return DtcConnector(dtc_dop_ref=dtc_dop_ref, dtc_snref=dtc_snref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Dict, List, Sequence
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -33,7 +34,7 @@ class DynamicEndmarkerField(Field):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DynamicEndmarkerField":
+                doc_frags: list[OdxDocFragment]) -> "DynamicEndmarkerField":
         kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
 
         # ODX 2.0 uses DATA-OBJECT-PROP-REF
@@ -43,7 +44,7 @@ class DynamicEndmarkerField(Field):
 
         return DynamicEndmarkerField(dyn_end_dop_ref=dyn_end_dop_ref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
         return odxlinks
 
@@ -102,7 +103,7 @@ class DynamicEndmarkerField(Field):
         orig_origin = decode_state.origin_byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
 
-        result: List[ParameterValue] = []
+        result: list[ParameterValue] = []
         while True:
             # check if we're at the end of the PDU
             if decode_state.cursor_byte_position == len(decode_state.coded_message):

--- a/odxtools/dynamiclengthfield.py
+++ b/odxtools/dynamiclengthfield.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Dict, List, Sequence
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -24,7 +25,7 @@ class DynamicLengthField(Field):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DynamicLengthField":
+                doc_frags: list[OdxDocFragment]) -> "DynamicLengthField":
         kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
 
         offset = int(odxrequire(et_element.findtext('OFFSET')))
@@ -36,7 +37,7 @@ class DynamicLengthField(Field):
         return DynamicLengthField(
             offset=offset, determine_number_of_items=determine_number_of_items, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
         odxlinks.update(self.determine_number_of_items._build_odxlinks())
         return odxlinks
@@ -106,7 +107,7 @@ class DynamicLengthField(Field):
         decode_state.cursor_bit_position = det_num_items.bit_position or 0
 
         n = det_num_items.dop.decode_from_pdu(decode_state)
-        result: List[ParameterValue] = []
+        result: list[ParameterValue] = []
 
         if not isinstance(n, int):
             odxraise(f"Number of items specified by a dynamic length field {self.short_name} "

--- a/odxtools/dyndefinedspec.py
+++ b/odxtools/dyndefinedspec.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .dyniddefmodeinfo import DynIdDefModeInfo
@@ -10,19 +10,19 @@ from .snrefcontext import SnRefContext
 
 @dataclass
 class DynDefinedSpec:
-    dyn_id_def_mode_infos: List[DynIdDefModeInfo]
+    dyn_id_def_mode_infos: list[DynIdDefModeInfo]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DynDefinedSpec":
+                doc_frags: list[OdxDocFragment]) -> "DynDefinedSpec":
         dyn_id_def_mode_infos = [
             DynIdDefModeInfo.from_et(x, doc_frags)
             for x in et_element.iterfind("DYN-ID-DEF-MODE-INFOS/DYN-ID-DEF-MODE-INFO")
         ]
         return DynDefinedSpec(dyn_id_def_mode_infos=dyn_id_def_mode_infos)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result: Dict[OdxLinkId, Any] = {}
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
+        result: dict[OdxLinkId, Any] = {}
 
         for didmi in self.dyn_id_def_mode_infos:
             result.update(didmi._build_odxlinks())

--- a/odxtools/dynenddopref.py
+++ b/odxtools/dynenddopref.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, overload
+from typing import Optional, overload
 from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
@@ -14,18 +14,18 @@ class DynEndDopRef(OdxLinkRef):
 
     @staticmethod
     @overload
-    def from_et(et_element: None, source_doc_frags: List[OdxDocFragment]) -> None:
+    def from_et(et_element: None, source_doc_frags: list[OdxDocFragment]) -> None:
         ...
 
     @staticmethod
     @overload
     def from_et(et_element: ElementTree.Element,
-                source_doc_frags: List[OdxDocFragment]) -> "DynEndDopRef":
+                source_doc_frags: list[OdxDocFragment]) -> "DynEndDopRef":
         ...
 
     @staticmethod
-    def from_et(et_element: Optional[ElementTree.Element],
-                source_doc_frags: List[OdxDocFragment]) -> Optional["DynEndDopRef"]:
+    def from_et(et_element: ElementTree.Element | None,
+                source_doc_frags: list[OdxDocFragment]) -> Optional["DynEndDopRef"]:
 
         if et_element is None:
             odxraise("Mandatory DYN-END-DOP-REF tag is missing")

--- a/odxtools/dyniddefmodeinfo.py
+++ b/odxtools/dyniddefmodeinfo.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from .diagclasstype import DiagClassType
@@ -16,17 +16,17 @@ from .table import Table
 class DynIdDefModeInfo:
     def_mode: str
 
-    clear_dyn_def_message_ref: Optional[OdxLinkRef]
-    clear_dyn_def_message_snref: Optional[str]
+    clear_dyn_def_message_ref: OdxLinkRef | None
+    clear_dyn_def_message_snref: str | None
 
-    read_dyn_def_message_ref: Optional[OdxLinkRef]
-    read_dyn_def_message_snref: Optional[str]
+    read_dyn_def_message_ref: OdxLinkRef | None
+    read_dyn_def_message_snref: str | None
 
-    dyn_def_message_ref: Optional[OdxLinkRef]
-    dyn_def_message_snref: Optional[str]
+    dyn_def_message_ref: OdxLinkRef | None
+    dyn_def_message_snref: str | None
 
-    supported_dyn_ids: List[bytes]
-    selection_table_refs: List[Union[OdxLinkRef, str]]
+    supported_dyn_ids: list[bytes]
+    selection_table_refs: list[OdxLinkRef | str]
 
     @property
     def clear_dyn_def_message(self) -> DiagComm:
@@ -46,7 +46,7 @@ class DynIdDefModeInfo:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DynIdDefModeInfo":
+                doc_frags: list[OdxDocFragment]) -> "DynIdDefModeInfo":
         def_mode = odxrequire(et_element.findtext("DEF-MODE"))
 
         clear_dyn_def_message_ref = OdxLinkRef.from_et(
@@ -71,7 +71,7 @@ class DynIdDefModeInfo:
             for x in et_element.iterfind("SUPPORTED-DYN-IDS/SUPPORTED-DYN-ID")
         ]
 
-        selection_table_refs: List[Union[OdxLinkRef, str]] = []
+        selection_table_refs: list[OdxLinkRef | str] = []
         if (st_elems := et_element.find("SELECTION-TABLE-REFS")) is not None:
             for st_elem in st_elems:
                 if st_elem.tag == "SELECTION-TABLE-REF":
@@ -104,8 +104,8 @@ class DynIdDefModeInfo:
         odxassert(self.dyn_def_message_ref is not None or self.dyn_def_message_snref is not None,
                   "A DYN-DEF-MESSAGE must be specified")
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        result: Dict[OdxLinkId, Any] = {}
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
+        result: dict[OdxLinkId, Any] = {}
 
         return result
 

--- a/odxtools/ecuvariantpattern.py
+++ b/odxtools/ecuvariantpattern.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Union
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -17,16 +16,16 @@ class EcuVariantPattern(VariantPattern):
     """ECU variant patterns are variant patterns used to identify the
     concrete variant of an ECU.
     """
-    matching_parameters: List[MatchingParameter]
+    matching_parameters: list[MatchingParameter]
 
     @override
-    def get_matching_parameters(
-            self) -> Union[List[MatchingParameter], List[MatchingBaseVariantParameter]]:
+    def get_matching_parameters(self
+                               ) -> list[MatchingParameter] | list[MatchingBaseVariantParameter]:
         return self.matching_parameters
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EcuVariantPattern":
+                doc_frags: list[OdxDocFragment]) -> "EcuVariantPattern":
 
         matching_parameters = [
             MatchingParameter.from_et(mp_el, doc_frags)

--- a/odxtools/element.py
+++ b/odxtools/element.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .description import Description
@@ -11,11 +10,11 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class NamedElement:
     short_name: str
-    long_name: Optional[str]
-    description: Optional[Description]
+    long_name: str | None
+    description: Description | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "NamedElement":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "NamedElement":
 
         return NamedElement(
             short_name=odxrequire(et_element.findtext("SHORT-NAME")),
@@ -27,11 +26,11 @@ class NamedElement:
 @dataclass
 class IdentifiableElement(NamedElement):
     odx_id: OdxLinkId
-    oid: Optional[str]
+    oid: str | None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "IdentifiableElement":
+                doc_frags: list[OdxDocFragment]) -> "IdentifiableElement":
 
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 

--- a/odxtools/encoding.py
+++ b/odxtools/encoding.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import Optional
 
 from .exceptions import odxraise
 from .odxtypes import DataType
@@ -23,8 +22,8 @@ class Encoding(Enum):
     NONE = "NONE"
 
 
-def get_string_encoding(base_data_type: DataType, base_type_encoding: Optional[Encoding],
-                        is_highlow_byte_order: bool) -> Optional[str]:
+def get_string_encoding(base_data_type: DataType, base_type_encoding: Encoding | None,
+                        is_highlow_byte_order: bool) -> str | None:
     """If the encoding is for a string, return the value for
     `str.encode()`/`str.decode()` to convert the string object
     to/from a byte array

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import List, Optional, Sequence
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -17,12 +17,12 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class EndOfPduField(Field):
     """End of PDU fields are structures that are repeated until the end of the PDU"""
-    max_number_of_items: Optional[int]
-    min_number_of_items: Optional[int]
+    max_number_of_items: int | None
+    min_number_of_items: int | None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EndOfPduField":
+                doc_frags: list[OdxDocFragment]) -> "EndOfPduField":
         kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
 
         if (max_n_str := et_element.findtext("MAX-NUMBER-OF-ITEMS")) is not None:
@@ -40,7 +40,7 @@ class EndOfPduField(Field):
             **kwargs)
 
     @override
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         odxassert(not encode_state.cursor_bit_position,
                   "No bit position can be specified for end-of-pdu fields!")
@@ -72,7 +72,7 @@ class EndOfPduField(Field):
         orig_origin = decode_state.origin_byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
 
-        result: List[ParameterValue] = []
+        result: list[ParameterValue] = []
         while decode_state.cursor_byte_position < len(decode_state.coded_message):
             # ATTENTION: the ODX specification is very misleading
             # here: it says that the item is repeated until the end of

--- a/odxtools/envdataconnector.py
+++ b/odxtools/envdataconnector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import NamedElement
@@ -27,7 +27,7 @@ class EnvDataConnector(NamedElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EnvDataConnector":
+                doc_frags: list[OdxDocFragment]) -> "EnvDataConnector":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         env_data_desc_ref = odxrequire(
@@ -38,7 +38,7 @@ class EnvDataConnector(NamedElement):
         return EnvDataConnector(
             env_data_desc_ref=env_data_desc_ref, env_data_snref=env_data_snref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
@@ -20,12 +19,12 @@ class EnvironmentData(BasicStructure):
     sense, it is quite similar to NRC-CONST parameters.)
     """
 
-    all_value: Optional[bool]
-    dtc_values: List[int]
+    all_value: bool | None
+    dtc_values: list[int]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EnvironmentData":
+                doc_frags: list[OdxDocFragment]) -> "EnvironmentData":
         """Reads Environment Data from Diag Layer."""
         kwargs = dataclass_fields_asdict(BasicStructure.from_et(et_element, doc_frags))
 

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -35,18 +35,18 @@ class EnvironmentDataDescription(ComplexDop):
 
     """
 
-    param_snref: Optional[str]
-    param_snpathref: Optional[str]
+    param_snref: str | None
+    param_snpathref: str | None
 
     # in ODX 2.0.0, ENV-DATAS seems to be a mandatory
     # sub-element of ENV-DATA-DESC, in ODX 2.2 it is not
     # present
     env_datas: NamedItemList[EnvironmentData]
-    env_data_refs: List[OdxLinkRef]
+    env_data_refs: list[OdxLinkRef]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "EnvironmentDataDescription":
+                doc_frags: list[OdxDocFragment]) -> "EnvironmentDataDescription":
         """Reads Environment Data Description from Diag Layer."""
         kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
 
@@ -78,7 +78,7 @@ class EnvironmentDataDescription(ComplexDop):
             env_data_refs=env_data_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = {self.odx_id: self}
 
         if not self.env_data_refs:
@@ -105,7 +105,7 @@ class EnvironmentDataDescription(ComplexDop):
                 ed._resolve_snrefs(context)
 
     @override
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         """Convert a physical value into bytes and emplace them into a PDU.
         """
@@ -118,7 +118,7 @@ class EnvironmentDataDescription(ComplexDop):
                      "descriptions via SNPATHREF is not supported yet")
             return None
 
-        numerical_dtc_value: Optional[ParameterValue] = None
+        numerical_dtc_value: ParameterValue | None = None
         for prev_param, prev_param_value in reversed(encode_state.journal):
             if prev_param.short_name == self.param_snref:
                 numerical_dtc_value = self._get_numerical_dtc_from_parameter(
@@ -165,7 +165,7 @@ class EnvironmentDataDescription(ComplexDop):
                      "descriptions via SNPATHREF is not supported yet")
             return None
 
-        numerical_dtc_value: Optional[ParameterValue] = None
+        numerical_dtc_value: ParameterValue | None = None
         for prev_param, prev_param_value in reversed(decode_state.journal):
             if prev_param.short_name == self.param_snref:
                 numerical_dtc_value = self._get_numerical_dtc_from_parameter(
@@ -204,10 +204,10 @@ class EnvironmentDataDescription(ComplexDop):
         return result
 
     def _get_numerical_dtc_from_parameter(self, param: Parameter,
-                                          param_value: Optional[ParameterValue]) -> int:
+                                          param_value: ParameterValue | None) -> int:
         if isinstance(param, ParameterWithDOP):
             dop = param.dop
-            if not isinstance(dop, (DataObjectProperty, DtcDop)):
+            if not isinstance(dop, DataObjectProperty | DtcDop):
                 odxraise(f"The DOP of the parameter referenced by environment data descriptions "
                          f"must use either be DataObjectProperty or a DtcDop (encountered "
                          f"{type(param).__name__} for parameter '{param.short_name}' "

--- a/odxtools/exceptions.py
+++ b/odxtools/exceptions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from typing import TYPE_CHECKING, NoReturn, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, NoReturn, TypeVar
 
 from .globals import logger
 
@@ -37,7 +37,7 @@ class OdxWarning(Warning):
 strict_mode = True
 
 
-def odxraise(message: Optional[str] = None, error_type: Type[Exception] = OdxError) -> NoReturn:
+def odxraise(message: str | None = None, error_type: type[Exception] = OdxError) -> NoReturn:
     """
     Raise an exception but only if in strict mode.
 
@@ -53,8 +53,8 @@ def odxraise(message: Optional[str] = None, error_type: Type[Exception] = OdxErr
 
 
 def odxassert(condition: bool,
-              message: Optional[str] = None,
-              error_type: Type[Exception] = OdxError) -> None:
+              message: str | None = None,
+              error_type: type[Exception] = OdxError) -> None:
     """
     This method works similar as the build-in `assert` statement
 
@@ -72,7 +72,7 @@ def odxassert(condition: bool,
 T = TypeVar("T")
 
 
-def odxrequire(obj: Optional[T], message: Optional[str] = None) -> T:
+def odxrequire(obj: T | None, message: str | None = None) -> T:
     """This function ensures that an object required by the ODX
     specification is actually present.
 

--- a/odxtools/externalaccessmethod.py
+++ b/odxtools/externalaccessmethod.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -15,7 +14,7 @@ class ExternalAccessMethod(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ExternalAccessMethod":
+                doc_frags: list[OdxDocFragment]) -> "ExternalAccessMethod":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         method = odxrequire(et_element.findtext("METHOD"))

--- a/odxtools/externaldoc.py
+++ b/odxtools/externaldoc.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
@@ -8,12 +8,12 @@ from .odxlink import OdxDocFragment
 
 @dataclass
 class ExternalDoc:
-    description: Optional[str]
+    description: str | None
     href: str
 
     @staticmethod
-    def from_et(et_element: Optional[ElementTree.Element],
-                doc_frags: List[OdxDocFragment]) -> Optional["ExternalDoc"]:
+    def from_et(et_element: ElementTree.Element | None,
+                doc_frags: list[OdxDocFragment]) -> Optional["ExternalDoc"]:
         if et_element is None:
             return None
 

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
@@ -15,11 +14,11 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class Field(ComplexDop):
-    structure_ref: Optional[OdxLinkRef]
-    structure_snref: Optional[str]
-    env_data_desc_ref: Optional[OdxLinkRef]
-    env_data_desc_snref: Optional[str]
-    is_visible_raw: Optional[bool]
+    structure_ref: OdxLinkRef | None
+    structure_snref: str | None
+    env_data_desc_ref: OdxLinkRef | None
+    env_data_desc_snref: str | None
+    is_visible_raw: bool | None
 
     @property
     def structure(self) -> BasicStructure:
@@ -31,7 +30,7 @@ class Field(ComplexDop):
         return self.is_visible_raw in (None, True)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Field":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Field":
         kwargs = dataclass_fields_asdict(ComplexDop.from_et(et_element, doc_frags))
 
         structure_ref = OdxLinkRef.from_et(et_element.find("BASIC-STRUCTURE-REF"), doc_frags)
@@ -54,8 +53,8 @@ class Field(ComplexDop):
             **kwargs)
 
     def __post_init__(self) -> None:
-        self._structure: Optional[BasicStructure] = None
-        self._env_data_desc: Optional[EnvironmentDataDescription] = None
+        self._structure: BasicStructure | None = None
+        self._env_data_desc: EnvironmentDataDescription | None = None
         num_struct_refs = 0 if self.structure_ref is None else 1
         num_struct_refs += 0 if self.structure_snref is None else 1
 
@@ -87,5 +86,5 @@ class Field(ComplexDop):
             self._env_data_desc = resolve_snref(self.env_data_desc_snref, ddds.env_data_descs,
                                                 EnvironmentDataDescription)
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return None

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -16,11 +16,11 @@ class FunctionalClass(IdentifiableElement):
     Corresponds to FUNCT-CLASS.
     """
 
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "FunctionalClass":
+                doc_frags: list[OdxDocFragment]) -> "FunctionalClass":
 
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -28,7 +28,7 @@ class FunctionalClass(IdentifiableElement):
 
         return FunctionalClass(admin_data=admin_data, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/inputparam.py
+++ b/odxtools/inputparam.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from deprecation import deprecated
@@ -15,10 +15,10 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class InputParam(NamedElement):
-    physical_default_value: Optional[str]
+    physical_default_value: str | None
     dop_base_ref: OdxLinkRef
-    oid: Optional[str]
-    semantic: Optional[str]
+    oid: str | None
+    semantic: str | None
 
     @property
     def dop(self) -> DopBase:
@@ -30,7 +30,7 @@ class InputParam(NamedElement):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "InputParam":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "InputParam":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         physical_default_value = et_element.findtext("PHYSICAL-DEFAULT-VALUE")
@@ -46,7 +46,7 @@ class InputParam(NamedElement):
             semantic=semantic,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/internalconstr.py
+++ b/odxtools/internalconstr.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .compumethods.limit import Limit
@@ -16,14 +15,14 @@ class InternalConstr:
 
     # TODO: Enforce the internal and physical constraints.
 
-    lower_limit: Optional[Limit]
-    upper_limit: Optional[Limit]
-    scale_constrs: List[ScaleConstr]
+    lower_limit: Limit | None
+    upper_limit: Limit | None
+    scale_constrs: list[ScaleConstr]
 
     value_type: DataType
 
     @staticmethod
-    def constr_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def constr_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                        value_type: DataType) -> "InternalConstr":
 
         lower_limit = Limit.limit_from_et(

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -30,7 +29,7 @@ class LeadingLengthInfoType(DiagCodedType):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "LeadingLengthInfoType":
+                doc_frags: list[OdxDocFragment]) -> "LeadingLengthInfoType":
         kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
 
         bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
@@ -53,7 +52,7 @@ class LeadingLengthInfoType(DiagCodedType):
     @override
     def encode_into_pdu(self, internal_value: AtomicOdxType, encode_state: EncodeState) -> None:
 
-        if not isinstance(internal_value, (str, bytes)):
+        if not isinstance(internal_value, str | bytes):
             odxraise(
                 f"LEADING-LENGTH-INFO types can only be used for strings and byte fields, "
                 f"not {type(internal_value).__name__}", EncodeError)

--- a/odxtools/library.py
+++ b/odxtools/library.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -19,17 +19,17 @@ class Library(IdentifiableElement):
     """
 
     code_file: str
-    encryption: Optional[str]
+    encryption: str | None
     syntax: str
     revision: str
-    entrypoint: Optional[str]
+    entrypoint: str | None
 
     @property
     def code(self) -> bytes:
         return self._code
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Library":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Library":
 
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -47,7 +47,7 @@ class Library(IdentifiableElement):
             entrypoint=entrypoint,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/linkeddtcdop.py
+++ b/odxtools/linkeddtcdop.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .diagnostictroublecode import DiagnosticTroubleCode
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class LinkedDtcDop:
-    not_inherited_dtc_snrefs: List[str]
+    not_inherited_dtc_snrefs: list[str]
     dtc_dop_ref: OdxLinkRef
 
     @property
@@ -31,7 +31,7 @@ class LinkedDtcDop:
         return self._dtc_dop.short_name
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "LinkedDtcDop":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "LinkedDtcDop":
         not_inherited_dtc_snrefs = [
             odxrequire(el.get("SHORT-NAME"))
             for el in et_element.iterfind("NOT-INHERITED-DTC-SNREFS/"
@@ -43,7 +43,7 @@ class LinkedDtcDop:
         return LinkedDtcDop(
             not_inherited_dtc_snrefs=not_inherited_dtc_snrefs, dtc_dop_ref=dtc_dop_ref)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/loadfile.py
+++ b/odxtools/loadfile.py
@@ -1,19 +1,18 @@
 # SPDX-License-Identifier: MIT
 import os
 from pathlib import Path
-from typing import Union
 
 from .database import Database
 
 
-def load_pdx_file(pdx_file: Union[str, Path]) -> Database:
+def load_pdx_file(pdx_file: str | Path) -> Database:
     db = Database()
     db.add_pdx_file(str(pdx_file))
     db.refresh()
     return db
 
 
-def load_odx_d_file(odx_d_file_name: Union[str, Path]) -> Database:
+def load_odx_d_file(odx_d_file_name: str | Path) -> Database:
     db = Database()
     db.add_odx_file(str(odx_d_file_name))
     db.refresh()
@@ -21,7 +20,7 @@ def load_odx_d_file(odx_d_file_name: Union[str, Path]) -> Database:
     return db
 
 
-def load_file(file_name: Union[str, Path]) -> Database:
+def load_file(file_name: str | Path) -> Database:
     if str(file_name).lower().endswith(".pdx"):
         return load_pdx_file(str(file_name))
     elif str(file_name).lower().endswith(".odx-d"):
@@ -30,7 +29,7 @@ def load_file(file_name: Union[str, Path]) -> Database:
         raise RuntimeError(f"Could not guess the file format of file '{file_name}'!")
 
 
-def load_files(*file_names: Union[str, Path]) -> Database:
+def load_files(*file_names: str | Path) -> Database:
     db = Database()
     for file_name in file_names:
         p = Path(file_name)
@@ -45,7 +44,7 @@ def load_files(*file_names: Union[str, Path]) -> Database:
     return db
 
 
-def load_directory(dir_name: Union[str, Path]) -> Database:
+def load_directory(dir_name: str | Path) -> Database:
     db = Database()
     for file_name in os.listdir(str(dir_name)):
         p = Path(dir_name) / file_name

--- a/odxtools/matchingbasevariantparameter.py
+++ b/odxtools/matchingbasevariantparameter.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .matchingparameter import MatchingParameter
@@ -18,7 +17,7 @@ class MatchingBaseVariantParameter(MatchingParameter):
     additional subtag `USE-PHYSICAL-ADDRESSING`.
     """
 
-    use_physical_addressing_raw: Optional[bool]
+    use_physical_addressing_raw: bool | None
 
     @property
     def use_physical_addressing(self) -> bool:
@@ -26,7 +25,7 @@ class MatchingBaseVariantParameter(MatchingParameter):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MatchingBaseVariantParameter":
+                doc_frags: list[OdxDocFragment]) -> "MatchingBaseVariantParameter":
 
         kwargs = dataclass_fields_asdict(MatchingParameter.from_et(et_element, doc_frags))
 

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .diaglayers.diaglayer import DiagLayer
@@ -34,12 +34,12 @@ class MatchingParameter:
     # or negative response. What it probably actually wants to say is
     # that any response that can possibly be received shall exhibit
     # the referenced parameter.
-    out_param_if_snref: Optional[str]
-    out_param_if_snpathref: Optional[str]
+    out_param_if_snref: str | None
+    out_param_if_snpathref: str | None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MatchingParameter":
+                doc_frags: list[OdxDocFragment]) -> "MatchingParameter":
 
         expected_value = odxrequire(et_element.findtext("EXPECTED-VALUE"))
         diag_comm_snref = odxrequire(
@@ -61,7 +61,7 @@ class MatchingParameter:
             out_param_if_snpathref=out_param_if_snpathref,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
@@ -93,7 +93,7 @@ class MatchingParameter:
 
         return self.__matches(param_dict, snpath_chunks)
 
-    def __matches(self, param_dict: ParameterValue, snpath_chunks: List[str]) -> bool:
+    def __matches(self, param_dict: ParameterValue, snpath_chunks: list[str]) -> bool:
         if len(snpath_chunks) == 0:
             parameter_value = param_dict
             if isinstance(parameter_value, dict):
@@ -105,7 +105,7 @@ class MatchingParameter:
                 # floating point
                 return abs(float(self.expected_value) - parameter_value) < 1e-8
             elif isinstance(parameter_value, BytesTypes):
-                return parameter_value.hex().upper() == self.expected_value.upper()
+                return bytes(parameter_value).hex().upper() == self.expected_value.upper()
             elif isinstance(parameter_value, DiagnosticTroubleCode):
                 # TODO: what happens if non-numerical DTCs like
                 # "U123456" are specified? Is specifying DTCs even

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -18,7 +18,7 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class MinMaxLengthType(DiagCodedType):
-    max_length: Optional[int]
+    max_length: int | None
     min_length: int
     termination: Termination
 
@@ -29,7 +29,7 @@ class MinMaxLengthType(DiagCodedType):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MinMaxLengthType":
+                doc_frags: list[OdxDocFragment]) -> "MinMaxLengthType":
         kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
 
         max_length = None
@@ -77,7 +77,7 @@ class MinMaxLengthType(DiagCodedType):
     @override
     def encode_into_pdu(self, internal_value: AtomicOdxType, encode_state: EncodeState) -> None:
 
-        if not isinstance(internal_value, (str, BytesTypes)):
+        if not isinstance(internal_value, str | BytesTypes):
             odxraise("MinMaxLengthType is currently only implemented for strings and byte arrays",
                      EncodeError)
 

--- a/odxtools/modification.py
+++ b/odxtools/modification.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
@@ -11,16 +11,16 @@ from .snrefcontext import SnRefContext
 @dataclass
 class Modification:
     change: str
-    reason: Optional[str]
+    reason: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Modification":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Modification":
         change = odxrequire(et_element.findtext("CHANGE"))
         reason = et_element.findtext("REASON")
 
         return Modification(change=change, reason=reason)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .compumethods.limit import Limit
@@ -17,18 +17,18 @@ from .utils import dataclass_fields_asdict
 class MultiplexerCase(NamedElement):
     """This class represents a case which represents a range of keys of a multiplexer."""
 
-    structure_ref: Optional[OdxLinkRef]
-    structure_snref: Optional[str]
+    structure_ref: OdxLinkRef | None
+    structure_snref: str | None
     lower_limit: Limit
     upper_limit: Limit
 
     @property
-    def structure(self) -> Optional[Structure]:
+    def structure(self) -> Structure | None:
         return self._structure
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MultiplexerCase":
+                doc_frags: list[OdxDocFragment]) -> "MultiplexerCase":
         """Reads a case for a Multiplexer."""
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
         structure_ref = OdxLinkRef.from_et(et_element.find("STRUCTURE-REF"), doc_frags)
@@ -54,7 +54,7 @@ class MultiplexerCase(NamedElement):
             upper_limit=upper_limit,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/multiplexerdefaultcase.py
+++ b/odxtools/multiplexerdefaultcase.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import NamedElement
@@ -14,16 +14,16 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class MultiplexerDefaultCase(NamedElement):
     """This class represents a Default Case, which is selected when there are no cases defined in the Multiplexer."""
-    structure_ref: Optional[OdxLinkRef]
-    structure_snref: Optional[str]
+    structure_ref: OdxLinkRef | None
+    structure_snref: str | None
 
     @property
-    def structure(self) -> Optional[Structure]:
+    def structure(self) -> Structure | None:
         return self._structure
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MultiplexerDefaultCase":
+                doc_frags: list[OdxDocFragment]) -> "MultiplexerDefaultCase":
         """Reads a default case for a multiplexer."""
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
@@ -35,7 +35,7 @@ class MultiplexerDefaultCase(NamedElement):
         return MultiplexerDefaultCase(
             structure_ref=structure_ref, structure_snref=structure_snref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/multiplexerswitchkey.py
+++ b/odxtools/multiplexerswitchkey.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .dataobjectproperty import DataObjectProperty
@@ -15,7 +15,7 @@ class MultiplexerSwitchKey:
     The object that determines the case to be used by a multiplexer
     """
     byte_position: int
-    bit_position: Optional[int]
+    bit_position: int | None
     dop_ref: OdxLinkRef
 
     @property
@@ -24,7 +24,7 @@ class MultiplexerSwitchKey:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MultiplexerSwitchKey":
+                doc_frags: list[OdxDocFragment]) -> "MultiplexerSwitchKey":
         byte_position = int(odxrequire(et_element.findtext("BYTE-POSITION")))
         bit_position_str = et_element.findtext("BIT-POSITION")
         bit_position = int(bit_position_str) if bit_position_str is not None else None
@@ -36,7 +36,7 @@ class MultiplexerSwitchKey:
             dop_ref=dop_ref,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
 import abc
 import typing
+from collections.abc import Collection, Iterable
 from copy import deepcopy
 from keyword import iskeyword
-from typing import (Any, Collection, Dict, Iterable, List, Optional, SupportsIndex, Tuple, TypeVar,
-                    Union, cast, overload, runtime_checkable)
+from typing import Any, SupportsIndex, TypeVar, cast, overload, runtime_checkable
 
 from .exceptions import odxraise
 
@@ -21,7 +21,7 @@ T = TypeVar("T")
 TNamed = TypeVar("TNamed", bound=OdxNamed)
 
 
-class ItemAttributeList(List[T]):
+class ItemAttributeList(list[T]):
     """A list that provides direct access to its items as named attributes.
 
     This is a hybrid between a list and a user-defined object: One can
@@ -35,8 +35,8 @@ class ItemAttributeList(List[T]):
     returned by the item-to-name function are valid identifiers in python.
     """
 
-    def __init__(self, input_list: Optional[Iterable[T]] = None) -> None:
-        self._item_dict: Dict[str, T] = {}
+    def __init__(self, input_list: Iterable[T] | None = None) -> None:
+        self._item_dict: dict[str, T] = {}
 
         if input_list is not None:
             for item in input_list:
@@ -121,10 +121,10 @@ class ItemAttributeList(List[T]):
     def values(self) -> Collection[T]:
         return self._item_dict.values()
 
-    def items(self) -> Collection[Tuple[str, T]]:
+    def items(self) -> Collection[tuple[str, T]]:
         return self._item_dict.items()
 
-    def __dir__(self) -> Dict[str, Any]:
+    def __dir__(self) -> dict[str, Any]:
         result = dict(self.__dict__)
         result.update(self._item_dict)
         return result
@@ -138,11 +138,11 @@ class ItemAttributeList(List[T]):
         ...
 
     @overload
-    def __getitem__(self, key: slice) -> List[T]:
+    def __getitem__(self, key: slice) -> list[T]:
         ...
 
-    def __getitem__(self, key: Union[SupportsIndex, str, slice]) -> Union[T, List[T]]:
-        if isinstance(key, (SupportsIndex, slice)):
+    def __getitem__(self, key: SupportsIndex | str | slice) -> T | list[T]:
+        if isinstance(key, SupportsIndex | slice):
             return super().__getitem__(key)
         else:
             return self._item_dict[key]
@@ -153,13 +153,13 @@ class ItemAttributeList(List[T]):
 
         return self._item_dict[key]
 
-    def get(self, key: Union[int, str], default: Optional[T] = None) -> Optional[T]:
+    def get(self, key: int | str, default: T | None = None) -> T | None:
         if isinstance(key, int):
             if 0 <= key and key < len(self):
                 return super().__getitem__(key)
             return default
         else:
-            return cast(Optional[T], self._item_dict.get(key, default))
+            return cast(T | None, self._item_dict.get(key, default))
 
     def __eq__(self, other: object) -> bool:
         """
@@ -179,7 +179,7 @@ class ItemAttributeList(List[T]):
     def __copy__(self) -> Any:
         return self.__class__(list(self))
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
@@ -189,7 +189,7 @@ class ItemAttributeList(List[T]):
 
         return result
 
-    def __reduce__(self) -> Tuple[Any, ...]:
+    def __reduce__(self) -> tuple[Any, ...]:
         """Support for Python's pickle protocol.
         This method ensures that the object can be reconstructed with its current state,
         using its class and the list of items it contains.

--- a/odxtools/negoutputparam.py
+++ b/odxtools/negoutputparam.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .dopbase import DopBase
@@ -22,14 +22,14 @@ class NegOutputParam(NamedElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "NegOutputParam":
+                doc_frags: list[OdxDocFragment]) -> "NegOutputParam":
 
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
         dop_base_ref = odxrequire(OdxLinkRef.from_et(et_element.find("DOP-BASE-REF"), doc_frags))
 
         return NegOutputParam(dop_base_ref=dop_base_ref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/obd.py
+++ b/odxtools/obd.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from enum import IntEnum
-from typing import Optional
 
 
 class SID(IntEnum):
@@ -47,7 +46,7 @@ _sid_to_name = {
 }
 
 
-def sid_to_name(sid: int) -> Optional[str]:
+def sid_to_name(sid: int) -> str | None:
     if sid in _sid_to_name:
         return _sid_to_name[sid]
 

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -21,17 +21,17 @@ if TYPE_CHECKING:
 class OdxCategory(IdentifiableElement):
     """This is the base class for all top-level container classes in ODX"""
 
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
     company_datas: NamedItemList[CompanyData]
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "OdxCategory":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "OdxCategory":
         raise Exception("Calling `._from_et()` is not allowed for OdxCategory. "
                         "Use `OdxCategory.category_from_et()`!")
 
     @staticmethod
-    def category_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def category_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                          doc_type: DocType) -> "OdxCategory":
 
         short_name = odxrequire(et_element.findtext("SHORT-NAME"))
@@ -51,7 +51,7 @@ class OdxCategory(IdentifiableElement):
 
         return OdxCategory(admin_data=admin_data, company_datas=company_datas, sdgs=sdgs, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         if self.admin_data is not None:

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
 import warnings
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar, overload
+from typing import Any, Optional, TypeVar, overload
 from xml.etree import ElementTree
 
 from .exceptions import OdxWarning, odxassert, odxraise, odxrequire
@@ -44,7 +45,7 @@ class OdxLinkId:
 
     #: The name and type of the document fragment to which the
     #: `local_id` is relative to
-    doc_fragments: List[OdxDocFragment]
+    doc_fragments: list[OdxDocFragment]
 
     def __hash__(self) -> int:
         # we do not hash about the document fragment here, because
@@ -68,7 +69,7 @@ class OdxLinkId:
 
     @staticmethod
     def from_et(et: ElementTree.Element,
-                doc_fragments: List[OdxDocFragment]) -> Optional["OdxLinkId"]:
+                doc_fragments: list[OdxDocFragment]) -> Optional["OdxLinkId"]:
         """Construct an OdxLinkId for a given XML node (ElementTree object).
 
         Returns None if the given XML node does not exhibit an ID.
@@ -94,7 +95,7 @@ class OdxLinkRef:
     ref_id: str
 
     #: The document fragments to which the `ref_id` refers to (in reverse order)
-    ref_docs: List[OdxDocFragment]
+    ref_docs: list[OdxDocFragment]
 
     # TODO: this is difficult because OdxLinkRef is derived from and
     # we do not want having to specify it mandatorily
@@ -102,17 +103,17 @@ class OdxLinkRef:
 
     @overload
     @staticmethod
-    def from_et(et: None, source_doc_frags: List[OdxDocFragment]) -> None:
+    def from_et(et: None, source_doc_frags: list[OdxDocFragment]) -> None:
         ...
 
     @overload
     @staticmethod
-    def from_et(et: ElementTree.Element, source_doc_frags: List[OdxDocFragment]) -> "OdxLinkRef":
+    def from_et(et: ElementTree.Element, source_doc_frags: list[OdxDocFragment]) -> "OdxLinkRef":
         ...
 
     @staticmethod
-    def from_et(et: Optional[ElementTree.Element],
-                source_doc_frags: List[OdxDocFragment]) -> Optional["OdxLinkRef"]:
+    def from_et(et: ElementTree.Element | None,
+                source_doc_frags: list[OdxDocFragment]) -> Optional["OdxLinkRef"]:
         """Construct an OdxLinkRef for a given XML node (ElementTree object).
 
         Returns None if the given XML node does not represent a reference.
@@ -170,17 +171,17 @@ class OdxLinkDatabase:
     """
 
     def __init__(self) -> None:
-        self._db: Dict[OdxDocFragment, Dict[str, Any]] = {}
+        self._db: dict[OdxDocFragment, dict[str, Any]] = {}
 
     @overload
     def resolve(self, ref: OdxLinkRef, expected_type: None = None) -> Any:
         ...
 
     @overload
-    def resolve(self, ref: OdxLinkRef, expected_type: Type[T]) -> T:
+    def resolve(self, ref: OdxLinkRef, expected_type: type[T]) -> T:
         ...
 
-    def resolve(self, ref: OdxLinkRef, expected_type: Optional[Any] = None) -> Any:
+    def resolve(self, ref: OdxLinkRef, expected_type: Any | None = None) -> Any:
         """
         Resolve a reference to an object
 
@@ -219,12 +220,10 @@ class OdxLinkDatabase:
         ...
 
     @overload
-    def resolve_lenient(self, ref: OdxLinkRef, expected_type: Type[T]) -> Optional[T]:
+    def resolve_lenient(self, ref: OdxLinkRef, expected_type: type[T]) -> T | None:
         ...
 
-    def resolve_lenient(self,
-                        ref: OdxLinkRef,
-                        expected_type: Optional[Any] = None) -> Optional[Any]:
+    def resolve_lenient(self, ref: OdxLinkRef, expected_type: Any | None = None) -> Any | None:
         """
         Resolve a reference to an object
 
@@ -254,7 +253,7 @@ class OdxLinkDatabase:
 
         return None
 
-    def update(self, new_entries: Dict[OdxLinkId, Any], *, overwrite: bool = True) -> None:
+    def update(self, new_entries: dict[OdxLinkId, Any], *, overwrite: bool = True) -> None:
         """
         Add a bunch of new objects to the ODXLINK database.
 
@@ -287,7 +286,7 @@ def resolve_snref(target_short_name: str,
 @overload
 def resolve_snref(target_short_name: str,
                   items: Iterable[OdxNamed],
-                  expected_type: Type[TNamed],
+                  expected_type: type[TNamed],
                   *,
                   lenient: None = None) -> TNamed:
     ...
@@ -296,16 +295,16 @@ def resolve_snref(target_short_name: str,
 @overload
 def resolve_snref(target_short_name: str,
                   items: Iterable[OdxNamed],
-                  expected_type: Type[TNamed],
+                  expected_type: type[TNamed],
                   *,
-                  lenient: bool = True) -> Optional[TNamed]:
+                  lenient: bool = True) -> TNamed | None:
     ...
 
 
 def resolve_snref(target_short_name: str,
                   items: Iterable[OdxNamed],
                   expected_type: Any = None,
-                  lenient: Optional[bool] = None) -> Any:
+                  lenient: bool | None = None) -> Any:
     candidates = [x for x in items if x.short_name == target_short_name]
 
     if not candidates:

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Callable, Iterable
 from enum import Enum
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, SupportsBytes, Tuple,
-                    Type, Union, overload)
+from typing import TYPE_CHECKING, Any, SupportsBytes, Union, overload
 from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxraise, odxrequire
@@ -16,22 +16,22 @@ def bytefield_to_bytearray(bytefield: str) -> bytearray:
     return bytearray([int(x, 16) for x in bytes_string])
 
 
-BytesTypes = (bytearray, bytes, SupportsBytes)
-AtomicOdxType = Union[str, int, float, bytearray, bytes]
+BytesTypes = bytearray | bytes | SupportsBytes
+AtomicOdxType = str | int | float | BytesTypes
 
 # dictionary mapping short names to a Parameter that needs to be
 # specified. Complex parameters (structures) may contain
 # sub-parameters, so this is a recursive type...
-ParameterDict = Dict[str, Union["Parameter", "ParameterDict"]]
+ParameterDict = dict[str, Union["Parameter", "ParameterDict"]]
 
 # Dictionary mapping short names of parameters to the value it
 # exhibits. Complex parameters (structures) may contain
 # sub-parameters, so this is a recursive type, and fields encompass
 # multiple items, so this can be a list of objects.
-TableStructParameterValue = Tuple[str, "ParameterValue"]
+TableStructParameterValue = tuple[str, "ParameterValue"]
 ParameterValue = Union[AtomicOdxType, "ParameterValueDict", TableStructParameterValue,
                        Iterable["ParameterValue"], "DiagnosticTroubleCode"]
-ParameterValueDict = Dict[str, ParameterValue]
+ParameterValueDict = dict[str, ParameterValue]
 
 
 @overload
@@ -44,7 +44,7 @@ def odxstr_to_bool(str_val: str) -> bool:
     ...
 
 
-def odxstr_to_bool(str_val: Optional[str]) -> Optional[bool]:
+def odxstr_to_bool(str_val: str | None) -> bool | None:
     if str_val is None:
         return None
 
@@ -79,7 +79,7 @@ def parse_int(value: str) -> int:
 
 #: conversion functions for strings from the XML to the types stored
 #: by the internalized database
-_PARSE_ODX_TYPE: Dict[str, Callable[[str], AtomicOdxType]] = {
+_PARSE_ODX_TYPE: dict[str, Callable[[str], AtomicOdxType]] = {
     "A_INT32": parse_int,
     "A_UINT32": parse_int,
     "A_FLOAT32": float,
@@ -92,7 +92,7 @@ _PARSE_ODX_TYPE: Dict[str, Callable[[str], AtomicOdxType]] = {
 
 #: mapping from type name strings specified by the XML to the types
 #: used by the internalized database
-_ODX_TYPE_TO_PYTHON_TYPE: Dict[str, Type[AtomicOdxType]] = {
+_ODX_TYPE_TO_PYTHON_TYPE: dict[str, type[int | float | str | bytearray]] = {
     "A_INT32": int,
     "A_UINT32": int,
     "A_FLOAT32": float,
@@ -109,8 +109,8 @@ def compare_odx_values(a: AtomicOdxType, b: AtomicOdxType) -> int:
     # specification. (cf section 7.3.6.5)
 
     # numeric values are compared numerically (duh!)
-    if isinstance(a, (int, float)):
-        if not isinstance(b, (int, float)):
+    if isinstance(a, int | float):
+        if not isinstance(b, int | float):
             odxraise()
 
         tmp = a - b
@@ -140,10 +140,13 @@ def compare_odx_values(a: AtomicOdxType, b: AtomicOdxType) -> int:
         if not isinstance(b, BytesTypes):
             odxraise()
 
-        obj_len = max(len(a), len(b))
+        a_bytes = bytes(a)
+        b_bytes = bytes(b)
 
-        tmp_a = a.ljust(obj_len, b'\x00')
-        tmp_b = b.ljust(obj_len, b'\x00')
+        obj_len = max(len(a_bytes), len(b_bytes))
+
+        tmp_a = a_bytes.ljust(obj_len, b'\x00')
+        tmp_b = b_bytes.ljust(obj_len, b'\x00')
 
         if tmp_a > tmp_b:
             return 1
@@ -193,7 +196,7 @@ class DataType(Enum):
     A_UTF8STRING = "A_UTF8STRING"
 
     @property
-    def python_type(self) -> Type[AtomicOdxType]:
+    def python_type(self) -> type[int | float | str | bytearray]:
         return _ODX_TYPE_TO_PYTHON_TYPE[self.value]
 
     @property
@@ -211,7 +214,7 @@ class DataType(Enum):
     def create_from_et(self, et_element: ElementTree.Element) -> AtomicOdxType:
         ...
 
-    def create_from_et(self, et_element: Optional[ElementTree.Element]) -> Optional[AtomicOdxType]:
+    def create_from_et(self, et_element: ElementTree.Element | None) -> AtomicOdxType | None:
         """
             Parse a V/VT value union and return an AtomicOdxType from them that match current datatype
             this includes, but not limited to COMPU-CONST, COMPU-DEFAULT-VALUE, COMPU-INVERSE-VALUE
@@ -236,7 +239,7 @@ class DataType(Enum):
         expected_type = self.python_type
         if isinstance(value, expected_type):
             return True
-        elif expected_type is float and isinstance(value, (int, float)):
+        elif expected_type is float and isinstance(value, int | float):
             return True
         elif self == DataType.A_BYTEFIELD and isinstance(value, BytesTypes):
             return True

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from deprecation import deprecated
@@ -16,7 +16,7 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class OutputParam(IdentifiableElement):
     dop_base_ref: OdxLinkRef
-    semantic: Optional[str]
+    semantic: str | None
 
     @property
     def dop(self) -> DopBase:
@@ -27,7 +27,7 @@ class OutputParam(IdentifiableElement):
         return self._dop
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "OutputParam":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "OutputParam":
 
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -36,7 +36,7 @@ class OutputParam(IdentifiableElement):
 
         return OutputParam(dop_base_ref=dop_base_ref, semantic=semantic, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/parameterinfo.py
+++ b/odxtools/parameterinfo.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import textwrap
+from collections.abc import Iterable
 from io import StringIO
-from typing import Iterable
 
 from .compumethods.compucodecompumethod import CompuCodeCompuMethod
 from .compumethods.identicalcompumethod import IdenticalCompuMethod

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -45,7 +45,7 @@ class CodedConstParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "CodedConstParameter":
+                doc_frags: list[OdxDocFragment]) -> "CodedConstParameter":
 
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
@@ -61,7 +61,7 @@ class CodedConstParameter(Parameter):
             AtomicOdxType, self.diag_coded_type.base_data_type.from_string(self.coded_value_raw))
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         result.update(self.diag_coded_type._build_odxlinks())
@@ -69,7 +69,7 @@ class CodedConstParameter(Parameter):
         return result
 
     @override
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return self.diag_coded_type.get_static_bit_length()
 
     @property
@@ -77,7 +77,7 @@ class CodedConstParameter(Parameter):
         return self.diag_coded_type.base_data_type
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         if physical_value is not None and physical_value != self.coded_value:
             odxraise(

--- a/odxtools/parameters/createanyparameter.py
+++ b/odxtools/parameters/createanyparameter.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-from typing import List
 from xml.etree import ElementTree
 
 from ..exceptions import odxraise
@@ -21,7 +20,7 @@ from .valueparameter import ValueParameter
 
 
 def create_any_parameter_from_et(et_element: ElementTree.Element,
-                                 doc_frags: List[OdxDocFragment]) \
+                                 doc_frags: list[OdxDocFragment]) \
                                  -> Parameter:
     parameter_type = et_element.get(f"{xsi}type")
 

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -34,14 +33,14 @@ class DynamicParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "DynamicParameter":
+                doc_frags: list[OdxDocFragment]) -> "DynamicParameter":
 
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
         return DynamicParameter(**kwargs)
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         raise NotImplementedError("Encoding DynamicParameter is not implemented yet.")
 

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import final, override
@@ -49,7 +49,7 @@ class LengthKeyParameter(ParameterWithDOP):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "LengthKeyParameter":
+                doc_frags: list[OdxDocFragment]) -> "LengthKeyParameter":
 
         kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
 
@@ -58,7 +58,7 @@ class LengthKeyParameter(ParameterWithDOP):
         return LengthKeyParameter(odx_id=odx_id, **kwargs)
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         result[self.odx_id] = self
@@ -67,7 +67,7 @@ class LengthKeyParameter(ParameterWithDOP):
 
     @override
     @final
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         # if you get this exception, you ought to use
         # `.encode_placeholder_into_pdu()` followed by (after the
@@ -75,7 +75,7 @@ class LengthKeyParameter(ParameterWithDOP):
         # `.encode_value_into_pdu()`.
         raise RuntimeError("_encode_positioned_into_pdu() cannot be called for length keys.")
 
-    def encode_placeholder_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_placeholder_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
 
         if physical_value is not None:

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -37,7 +36,7 @@ class MatchingRequestParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "MatchingRequestParameter":
+                doc_frags: list[OdxDocFragment]) -> "MatchingRequestParameter":
 
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
@@ -48,11 +47,11 @@ class MatchingRequestParameter(Parameter):
             request_byte_position=request_byte_position, byte_length=byte_length, **kwargs)
 
     @override
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return 8 * self.byte_length
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         if encode_state.triggering_request is None:
             odxraise(

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -34,7 +34,7 @@ class NrcConstParameter(Parameter):
 
     """
 
-    coded_values_raw: List[str]
+    coded_values_raw: list[str]
     diag_coded_type: DiagCodedType
 
     @property
@@ -57,13 +57,13 @@ class NrcConstParameter(Parameter):
         return self.diag_coded_type.base_data_type
 
     @property
-    def coded_values(self) -> List[AtomicOdxType]:
+    def coded_values(self) -> list[AtomicOdxType]:
         return self._coded_values
 
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "NrcConstParameter":
+                doc_frags: list[OdxDocFragment]) -> "NrcConstParameter":
 
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
@@ -82,7 +82,7 @@ class NrcConstParameter(Parameter):
         ]
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         result.update(self.diag_coded_type._build_odxlinks())
@@ -90,11 +90,11 @@ class NrcConstParameter(Parameter):
         return result
 
     @override
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return self.diag_coded_type.get_static_bit_length()
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         # NRC-CONST parameters are not encoding any value on its
         # own. instead, it is supposed to overlap with a value

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 from xml.etree import ElementTree
 
 from typing_extensions import final, override
@@ -42,11 +42,11 @@ class Parameter(NamedElement):
     non-positionable parameter types.
 
     """
-    sdgs: List[SpecialDataGroup]
-    semantic: Optional[str]
-    oid: Optional[str]
-    byte_position: Optional[int]
-    bit_position: Optional[int]
+    sdgs: list[SpecialDataGroup]
+    semantic: str | None
+    oid: str | None
+    byte_position: int | None
+    bit_position: int | None
 
     @property
     def parameter_type(self) -> ParameterType:
@@ -78,7 +78,7 @@ class Parameter(NamedElement):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Parameter":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Parameter":
 
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
@@ -100,7 +100,7 @@ class Parameter(NamedElement):
             bit_position=bit_position,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         for sdg in self.sdgs:
@@ -116,11 +116,11 @@ class Parameter(NamedElement):
         for sdg in self.sdgs:
             sdg._resolve_snrefs(context)
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return None
 
     @final
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         """Convert a physical value into its encoded form and place it
         into the PDU
@@ -140,7 +140,7 @@ class Parameter(NamedElement):
 
         encode_state.cursor_bit_position = 0
 
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         """Method which actually encodes the parameter
 

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -21,8 +21,8 @@ from .parameter import Parameter
 
 @dataclass
 class ParameterWithDOP(Parameter):
-    dop_ref: Optional[OdxLinkRef]
-    dop_snref: Optional[str]
+    dop_ref: OdxLinkRef | None
+    dop_snref: str | None
 
     @property
     def dop(self) -> DopBase:
@@ -33,7 +33,7 @@ class ParameterWithDOP(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ParameterWithDOP":
+                doc_frags: list[OdxDocFragment]) -> "ParameterWithDOP":
 
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
@@ -50,7 +50,7 @@ class ParameterWithDOP(Parameter):
         self._dop: DopBase
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return super()._build_odxlinks()
 
     @override
@@ -70,21 +70,21 @@ class ParameterWithDOP(Parameter):
             self._dop = resolve_snref(self.dop_snref, ddds.all_data_object_properties, DopBase)
 
     @override
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         if self._dop is not None:
             return self._dop.get_static_bit_length()
         else:
             return None
 
     @property
-    def physical_type(self) -> Optional[PhysicalType]:
-        if isinstance(self.dop, (DataObjectProperty, DtcDop)):
+    def physical_type(self) -> PhysicalType | None:
+        if isinstance(self.dop, DataObjectProperty | DtcDop):
             return self.dop.physical_type
         else:
             return None
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         self.dop.encode_into_pdu(cast(AtomicOdxType, physical_value), encode_state)
 

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -43,7 +43,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "PhysicalConstantParameter":
+                doc_frags: list[OdxDocFragment]) -> "PhysicalConstantParameter":
 
         kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
 
@@ -53,7 +53,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
             physical_constant_value_raw=physical_constant_value_raw, **kwargs)
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return super()._build_odxlinks()
 
     @override
@@ -72,7 +72,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
         self._physical_constant_value = base_data_type.from_string(self.physical_constant_value_raw)
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         if physical_value is not None and physical_value != self.physical_constant_value:
             odxraise(

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -36,7 +35,7 @@ class ReservedParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ReservedParameter":
+                doc_frags: list[OdxDocFragment]) -> "ReservedParameter":
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
         bit_length = int(odxrequire(et_element.findtext("BIT-LENGTH")))
@@ -44,11 +43,11 @@ class ReservedParameter(Parameter):
         return ReservedParameter(bit_length=bit_length, **kwargs)
 
     @override
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return self.bit_length
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         encode_state.cursor_byte_position += (encode_state.cursor_bit_position + self.bit_length +
                                               7) // 8

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -2,7 +2,6 @@
 import getpass
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -50,7 +49,7 @@ class SystemParameter(ParameterWithDOP):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "SystemParameter":
+                doc_frags: list[OdxDocFragment]) -> "SystemParameter":
         kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
 
         sysparam = odxrequire(et_element.get("SYSPARAM"))
@@ -58,7 +57,7 @@ class SystemParameter(ParameterWithDOP):
         return SystemParameter(sysparam=sysparam, **kwargs)
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         if physical_value is None:
             # determine the value to be encoded automatically

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -45,7 +45,7 @@ class TableEntryParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "TableEntryParameter":
+                doc_frags: list[OdxDocFragment]) -> "TableEntryParameter":
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
         target_str = odxrequire(et_element.findtext("TARGET"))
@@ -68,7 +68,7 @@ class TableEntryParameter(Parameter):
             self._table_row = odxlinks.resolve(self.table_row_ref)
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         raise NotImplementedError("Encoding a TableEntryParameter is not implemented yet.")
 

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from xml.etree import ElementTree
 
 from typing_extensions import final, override
@@ -26,18 +26,18 @@ class TableKeyParameter(Parameter):
 
     # the spec mandates that exactly one of the two attributes must
     # be non-None
-    table_ref: Optional[OdxLinkRef]
-    table_snref: Optional[str]
+    table_ref: OdxLinkRef | None
+    table_snref: str | None
 
     # the spec mandates that exactly one of the two attributes must
     # be non-None
-    table_row_ref: Optional[OdxLinkRef]
-    table_row_snref: Optional[str]
+    table_row_ref: OdxLinkRef | None
+    table_row_snref: str | None
 
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "TableKeyParameter":
+                doc_frags: list[OdxDocFragment]) -> "TableKeyParameter":
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
         odx_id = odxrequire(OdxLinkId.from_et(et_element, doc_frags))
@@ -62,7 +62,7 @@ class TableKeyParameter(Parameter):
 
     def __post_init__(self) -> None:
         self._table: Table
-        self._table_row: Optional[TableRow] = None
+        self._table_row: TableRow | None = None
 
     @property
     @override
@@ -70,7 +70,7 @@ class TableKeyParameter(Parameter):
         return "TABLE-KEY"
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         result[self.odx_id] = self
@@ -143,7 +143,7 @@ class TableKeyParameter(Parameter):
 
     @override
     @final
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
         # if you get this exception, you ought to use
         # `.encode_placeholder_into_pdu()` followed by (after the
@@ -151,7 +151,7 @@ class TableKeyParameter(Parameter):
         # `.encode_value_into_pdu()`.
         raise RuntimeError("_encode_positioned_into_pdu() cannot be called for table keys.")
 
-    def encode_placeholder_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_placeholder_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
 
         if physical_value is not None:

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 
 @dataclass
 class TableStructParameter(Parameter):
-    table_key_ref: Optional[OdxLinkRef]
-    table_key_snref: Optional[str]
+    table_key_ref: OdxLinkRef | None
+    table_key_snref: str | None
 
     @property
     @override
@@ -50,7 +50,7 @@ class TableStructParameter(Parameter):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "TableStructParameter":
+                doc_frags: list[OdxDocFragment]) -> "TableStructParameter":
 
         kwargs = dataclass_fields_asdict(Parameter.from_et(et_element, doc_frags))
 
@@ -67,7 +67,7 @@ class TableStructParameter(Parameter):
             odxraise("Either table_key_ref or table_key_snref must be defined.")
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return super()._build_odxlinks()
 
     @override
@@ -86,10 +86,10 @@ class TableStructParameter(Parameter):
                                             TableKeyParameter)
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
 
-        if not isinstance(physical_value, (tuple, list)) or \
+        if not isinstance(physical_value, tuple|list) or \
            len(physical_value) != 2 or \
            not isinstance(physical_value[0], str):
             odxraise(

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -18,7 +18,7 @@ from .parameterwithdop import ParameterWithDOP
 
 @dataclass
 class ValueParameter(ParameterWithDOP):
-    physical_default_value_raw: Optional[str]
+    physical_default_value_raw: str | None
 
     @property
     @override
@@ -26,7 +26,7 @@ class ValueParameter(ParameterWithDOP):
         return "VALUE"
 
     @property
-    def physical_default_value(self) -> Optional[AtomicOdxType]:
+    def physical_default_value(self) -> AtomicOdxType | None:
         return self._physical_default_value
 
     @property
@@ -42,7 +42,7 @@ class ValueParameter(ParameterWithDOP):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ValueParameter":
+                doc_frags: list[OdxDocFragment]) -> "ValueParameter":
 
         kwargs = dataclass_fields_asdict(ParameterWithDOP.from_et(et_element, doc_frags))
 
@@ -51,10 +51,10 @@ class ValueParameter(ParameterWithDOP):
         return ValueParameter(physical_default_value_raw=physical_default_value_raw, **kwargs)
 
     def __post_init__(self) -> None:
-        self._physical_default_value: Optional[AtomicOdxType] = None
+        self._physical_default_value: AtomicOdxType | None = None
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return super()._build_odxlinks()
 
     @override
@@ -75,7 +75,7 @@ class ValueParameter(ParameterWithDOP):
                 self.physical_default_value_raw)
 
     @override
-    def _encode_positioned_into_pdu(self, physical_value: Optional[ParameterValue],
+    def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
 
         if physical_value is None:

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, cast
+from typing import TYPE_CHECKING, Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -33,7 +33,7 @@ class ParamLengthInfoType(DiagCodedType):
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "ParamLengthInfoType":
+                doc_frags: list[OdxDocFragment]) -> "ParamLengthInfoType":
         kwargs = dataclass_fields_asdict(DiagCodedType.from_et(et_element, doc_frags))
 
         length_key_ref = odxrequire(
@@ -41,7 +41,7 @@ class ParamLengthInfoType(DiagCodedType):
 
         return ParamLengthInfoType(length_key_ref=length_key_ref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return super()._build_odxlinks()
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
@@ -74,6 +74,8 @@ class ParamLengthInfoType(DiagCodedType):
             elif self.base_data_type in [DataType.A_UNICODE2STRING]:
                 bit_length = 16 * len(cast(str, internal_value))
             elif self.base_data_type in [DataType.A_INT32, DataType.A_UINT32]:
+                if not isinstance(internal_value, int):
+                    odxraise()
                 bit_length = int(internal_value).bit_length()
                 if self.base_data_type == DataType.A_INT32:
                     bit_length += 1

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
@@ -16,18 +16,18 @@ if TYPE_CHECKING:
 @dataclass
 class ParentRef:
     layer_ref: OdxLinkRef
-    not_inherited_diag_comms: List[str]  # short_name references
-    not_inherited_variables: List[str]  # short_name references
-    not_inherited_dops: List[str]  # short_name references
-    not_inherited_tables: List[str]  # short_name references
-    not_inherited_global_neg_responses: List[str]  # short_name references
+    not_inherited_diag_comms: list[str]  # short_name references
+    not_inherited_variables: list[str]  # short_name references
+    not_inherited_dops: list[str]  # short_name references
+    not_inherited_tables: list[str]  # short_name references
+    not_inherited_global_neg_responses: list[str]  # short_name references
 
     @property
     def layer(self) -> "DiagLayer":
         return self._layer
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ParentRef":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ParentRef":
 
         layer_ref = odxrequire(OdxLinkRef.from_et(et_element, doc_frags))
 
@@ -69,7 +69,7 @@ class ParentRef:
             not_inherited_global_neg_responses=not_inherited_global_neg_responses,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
@@ -81,7 +81,7 @@ class ParentRef:
     def _resolve_snrefs(self, context: SnRefContext) -> None:
         pass
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -41,20 +41,20 @@ class PhysicalDimension(IdentifiableElement):
     )
     ```
     """
-    length_exp: Optional[int]
-    mass_exp: Optional[int]
-    time_exp: Optional[int]
-    current_exp: Optional[int]
-    temperature_exp: Optional[int]
-    molar_amount_exp: Optional[int]
-    luminous_intensity_exp: Optional[int]
+    length_exp: int | None
+    mass_exp: int | None
+    time_exp: int | None
+    current_exp: int | None
+    temperature_exp: int | None
+    molar_amount_exp: int | None
+    luminous_intensity_exp: int | None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "PhysicalDimension":
+                doc_frags: list[OdxDocFragment]) -> "PhysicalDimension":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
-        def read_optional_int(element: ElementTree.Element, name: str) -> Optional[int]:
+        def read_optional_int(element: ElementTree.Element, name: str) -> int | None:
             if (val_str := element.findtext(name)) is not None:
                 return int(val_str)
             else:
@@ -78,7 +78,7 @@ class PhysicalDimension(IdentifiableElement):
             luminous_intensity_exp=luminous_intensity_exp,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .exceptions import odxraise
@@ -32,20 +31,20 @@ class PhysicalType:
     PhysicalType(DataType.A_FLOAT64, precision=2)
     """
 
-    precision: Optional[int]
+    precision: int | None
     """Number of digits after the decimal point to display to the user
     The precision is only applicable if the base data type is A_FLOAT32 or A_FLOAT64.
     """
 
     base_data_type: DataType
 
-    display_radix: Optional[Radix]
+    display_radix: Radix | None
     """The display radix defines how integers are displayed to the user.
     The display radix is only applicable if the base data type is A_UINT32.
     """
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "PhysicalType":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "PhysicalType":
         precision_str = et_element.findtext("PRECISION")
         precision = int(precision_str) if precision_str is not None else None
 

--- a/odxtools/posresponsesuppressible.py
+++ b/odxtools/posresponsesuppressible.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
@@ -14,21 +13,21 @@ from .utils import read_hex_binary
 class PosResponseSuppressible:
     bit_mask: int
 
-    coded_const_snref: Optional[str]
-    coded_const_snpathref: Optional[str]
+    coded_const_snref: str | None
+    coded_const_snpathref: str | None
 
-    value_snref: Optional[str]
-    value_snpathref: Optional[str]
+    value_snref: str | None
+    value_snpathref: str | None
 
-    phys_const_snref: Optional[str]
-    phys_const_snpathref: Optional[str]
+    phys_const_snref: str | None
+    phys_const_snpathref: str | None
 
-    table_key_snref: Optional[str]
-    table_key_snpathref: Optional[str]
+    table_key_snref: str | None
+    table_key_snpathref: str | None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "PosResponseSuppressible":
+                doc_frags: list[OdxDocFragment]) -> "PosResponseSuppressible":
 
         bit_mask = odxrequire(read_hex_binary(et_element.find("BIT-MASK")))
 

--- a/odxtools/preconditionstateref.py
+++ b/odxtools/preconditionstateref.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .exceptions import odxassert, odxrequire
@@ -21,10 +21,10 @@ class PreConditionStateRef(OdxLinkRef):
     """
     This class represents the PRE-CONDITION-STATE-REF XML tag.
     """
-    value: Optional[str]
+    value: str | None
 
-    in_param_if_snref: Optional[str]
-    in_param_if_snpathref: Optional[str]
+    in_param_if_snref: str | None
+    in_param_if_snpathref: str | None
 
     @property
     def state(self) -> "State":
@@ -33,7 +33,7 @@ class PreConditionStateRef(OdxLinkRef):
     @staticmethod
     def from_et(  # type: ignore[override]
             et_element: ElementTree.Element,
-            doc_frags: List[OdxDocFragment]) -> "PreConditionStateRef":
+            doc_frags: list[OdxDocFragment]) -> "PreConditionStateRef":
         kwargs = dataclass_fields_asdict(OdxLinkRef.from_et(et_element, doc_frags))
 
         value = et_element.findtext("VALUE")
@@ -57,7 +57,7 @@ class PreConditionStateRef(OdxLinkRef):
             odxassert(self.in_param_if_snref is not None or self.in_param_if_snref is not None,
                       "If VALUE is specified, a parameter must be referenced")
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
@@ -66,7 +66,7 @@ class PreConditionStateRef(OdxLinkRef):
     def _resolve_snrefs(self, context: SnRefContext) -> None:
         pass
 
-    def applies(self, state_machine: "StateMachine", params: List[Parameter],
+    def applies(self, state_machine: "StateMachine", params: list[Parameter],
                 param_value_dict: ParameterValueDict) -> bool:
         """Given a state machine, evaluate whether the precondition is fulfilled or not
 

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
@@ -14,11 +14,11 @@ from .snrefcontext import SnRefContext
 class ProgCode:
     """A reference to code that is executed by a single ECU job"""
     code_file: str
-    encryption: Optional[str]
+    encryption: str | None
     syntax: str
     revision: str
-    entrypoint: Optional[str]
-    library_refs: List[OdxLinkRef]
+    entrypoint: str | None
+    library_refs: list[OdxLinkRef]
 
     @property
     def code(self) -> bytes:
@@ -29,7 +29,7 @@ class ProgCode:
         return self._libraries
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ProgCode":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ProgCode":
         code_file = odxrequire(et_element.findtext("CODE-FILE"))
         encryption = et_element.findtext("ENCRYPTION")
         syntax = odxrequire(et_element.findtext("SYNTAX"))
@@ -50,7 +50,7 @@ class ProgCode:
             library_refs=library_refs,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/protstack.py
+++ b/odxtools/protstack.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .comparamsubset import ComparamSubset
@@ -17,14 +17,14 @@ class ProtStack(IdentifiableElement):
     # mandatory in ODX 2.2, but non existent in ODX 2.0
     pdu_protocol_type: str
     physical_link_type: str
-    comparam_subset_refs: List[OdxLinkRef]
+    comparam_subset_refs: list[OdxLinkRef]
 
     @property
     def comparam_subsets(self) -> NamedItemList[ComparamSubset]:
         return self._comparam_subsets
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "ProtStack":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "ProtStack":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         pdu_protocol_type = odxrequire(et_element.findtext("PDU-PROTOCOL-TYPE"))
@@ -41,7 +41,7 @@ class ProtStack(IdentifiableElement):
             comparam_subset_refs=comparam_subset_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
         return result
 

--- a/odxtools/relateddiagcommref.py
+++ b/odxtools/relateddiagcommref.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List
 from xml.etree import ElementTree
 
 from .exceptions import odxrequire
@@ -15,7 +14,7 @@ class RelatedDiagCommRef(OdxLinkRef):
     @staticmethod
     def from_et(  # type: ignore[override]
             et_element: ElementTree.Element,
-            doc_frags: List[OdxDocFragment]) -> "RelatedDiagCommRef":
+            doc_frags: list[OdxDocFragment]) -> "RelatedDiagCommRef":
         kwargs = dataclass_fields_asdict(odxrequire(OdxLinkRef.from_et(et_element, doc_frags)))
 
         relation_type = odxrequire(et_element.findtext("RELATION-TYPE"))

--- a/odxtools/relateddoc.py
+++ b/odxtools/relateddoc.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .description import Description
@@ -11,12 +11,12 @@ from .xdoc import XDoc
 
 @dataclass
 class RelatedDoc:
-    xdoc: Optional[XDoc]
-    description: Optional[Description]
+    xdoc: XDoc | None
+    description: Description | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "RelatedDoc":
-        xdoc: Optional[XDoc] = None
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "RelatedDoc":
+        xdoc: XDoc | None = None
         if (xdoc_elem := et_element.find("XDOC")) is not None:
             xdoc = XDoc.from_et(xdoc_elem, doc_frags)
         description = Description.from_et(et_element.find("DESC"), doc_frags)
@@ -26,7 +26,7 @@ class RelatedDoc:
             description=description,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         if self.xdoc:

--- a/odxtools/request.py
+++ b/odxtools/request.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -29,20 +29,20 @@ class Request(IdentifiableElement):
 
     This class implements the `CompositeCodec` interface.
     """
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
     parameters: NamedItemList[Parameter]
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
     @property
-    def required_parameters(self) -> List[Parameter]:
+    def required_parameters(self) -> list[Parameter]:
         return composite_codec_get_required_parameters(self)
 
     @property
-    def free_parameters(self) -> List[Parameter]:
+    def free_parameters(self) -> list[Parameter]:
         return composite_codec_get_free_parameters(self)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Request":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Request":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
@@ -56,7 +56,7 @@ class Request(IdentifiableElement):
 
         return Request(admin_data=admin_data, parameters=parameters, sdgs=sdgs, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         if self.admin_data is not None:
@@ -96,7 +96,7 @@ class Request(IdentifiableElement):
         context.request = None
         context.parameters = None
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return composite_codec_get_static_bit_length(self)
 
     def print_free_parameters_info(self) -> None:
@@ -123,7 +123,7 @@ class Request(IdentifiableElement):
 
         return cast(ParameterValueDict, param_values)
 
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         composite_codec_encode_into_pdu(self, physical_value, encode_state)
 

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -39,12 +39,12 @@ class Response(IdentifiableElement):
 
     response_type: ResponseType
 
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
     parameters: NamedItemList[Parameter]
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Response":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Response":
         """Reads a response."""
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -70,7 +70,7 @@ class Response(IdentifiableElement):
             sdgs=sdgs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         if self.admin_data is not None:
@@ -110,7 +110,7 @@ class Response(IdentifiableElement):
         context.response = None
         context.parameters = None
 
-    def encode(self, coded_request: Optional[bytes] = None, **kwargs: ParameterValue) -> bytearray:
+    def encode(self, coded_request: bytes | None = None, **kwargs: ParameterValue) -> bytearray:
         encode_state = EncodeState(triggering_request=coded_request, is_end_of_pdu=True)
 
         self.encode_into_pdu(physical_value=kwargs, encode_state=encode_state)
@@ -126,22 +126,22 @@ class Response(IdentifiableElement):
 
         return cast(ParameterValueDict, param_values)
 
-    def encode_into_pdu(self, physical_value: Optional[ParameterValue],
+    def encode_into_pdu(self, physical_value: ParameterValue | None,
                         encode_state: EncodeState) -> None:
         composite_codec_encode_into_pdu(self, physical_value, encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:
         return composite_codec_decode_from_pdu(self, decode_state)
 
-    def get_static_bit_length(self) -> Optional[int]:
+    def get_static_bit_length(self) -> int | None:
         return composite_codec_get_static_bit_length(self)
 
     @property
-    def required_parameters(self) -> List[Parameter]:
+    def required_parameters(self) -> list[Parameter]:
         return composite_codec_get_required_parameters(self)
 
     @property
-    def free_parameters(self) -> List[Parameter]:
+    def free_parameters(self) -> list[Parameter]:
         return composite_codec_get_free_parameters(self)
 
     def print_free_parameters_info(self) -> None:

--- a/odxtools/scaleconstr.py
+++ b/odxtools/scaleconstr.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .compumethods.limit import Limit
@@ -16,15 +15,15 @@ class ScaleConstr:
     """This class represents a SCALE-CONSTR.
     """
 
-    short_label: Optional[str]
-    description: Optional[Description]
+    short_label: str | None
+    description: Description | None
     lower_limit: Limit
     upper_limit: Limit
     validity: ValidType
     value_type: DataType
 
     @staticmethod
-    def scale_constr_from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment], *,
+    def scale_constr_from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment], *,
                              value_type: DataType) -> "ScaleConstr":
         short_label = et_element.findtext("SHORT-LABEL")
         description = Description.from_et(et_element.find("DESC"), doc_frags)

--- a/odxtools/servicebinner.py
+++ b/odxtools/servicebinner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Iterable, Iterator
 from io import StringIO
-from typing import Dict, Iterable, Iterator, Optional
 
 from . import obd, uds
 from .diagservice import DiagService
@@ -21,7 +21,7 @@ class ServiceBinner:
     """
 
     def __init__(self, services: Iterable[DiagService]):
-        service_groups: Dict[Optional[int], NamedItemList[DiagService]] = {}
+        service_groups: dict[int | None, NamedItemList[DiagService]] = {}
         for service in services:
             SID = self.__extract_sid(service)
 
@@ -32,7 +32,7 @@ class ServiceBinner:
 
         self._service_groups = service_groups
 
-    def __extract_sid(self, service: DiagService) -> Optional[int]:
+    def __extract_sid(self, service: DiagService) -> int | None:
         # diagnostic services without requests are possible; just like
         # aircraft without wings...
         if service.request is None:
@@ -96,10 +96,10 @@ class ServiceBinner:
 
         return result.getvalue()
 
-    def __iter__(self) -> Iterator[Optional[int]]:
+    def __iter__(self) -> Iterator[int | None]:
         return iter(self._service_groups)
 
-    def __getitem__(self, sid: Optional[int]) -> NamedItemList[DiagService]:
+    def __getitem__(self, sid: int | None) -> NamedItemList[DiagService]:
         if sid is None:
             return self._service_groups.get(sid, NamedItemList())
 

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .diagcomm import DiagComm
@@ -30,13 +30,13 @@ class SingleEcuJob(DiagComm):
     standard.
     """
 
-    prog_codes: List[ProgCode]
+    prog_codes: list[ProgCode]
     input_params: NamedItemList[InputParam]
     output_params: NamedItemList[OutputParam]
     neg_output_params: NamedItemList[NegOutputParam]
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "SingleEcuJob":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SingleEcuJob":
         kwargs = dataclass_fields_asdict(DiagComm.from_et(et_element, doc_frags))
 
         prog_codes = [
@@ -64,7 +64,7 @@ class SingleEcuJob(DiagComm):
             neg_output_params=neg_output_params,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = super()._build_odxlinks()
 
         for prog_code in self.prog_codes:

--- a/odxtools/snrefcontext.py
+++ b/odxtools/snrefcontext.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .database import Database
@@ -25,5 +25,5 @@ class SnRefContext:
     single_ecu_job: Optional["SingleEcuJob"] = None
     request: Optional["Request"] = None
     response: Optional["Response"] = None
-    parameters: Optional[List["Parameter"]] = None
+    parameters: list["Parameter"] | None = None
     state_chart: Optional["StateChart"] = None

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -10,12 +10,12 @@ from .snrefcontext import SnRefContext
 @dataclass
 class SpecialData:
     """This corresponds to the SD XML tag"""
-    semantic_info: Optional[str]  # the "SI" attribute
-    text_identifier: Optional[str]  # the "TI" attribute, specifies the language used
+    semantic_info: str | None  # the "SI" attribute
+    text_identifier: str | None  # the "TI" attribute, specifies the language used
     value: str
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "SpecialData":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SpecialData":
         semantic_info = et_element.get("SI")
         text_identifier = et_element.get("TI")
         value = et_element.text or ""
@@ -23,7 +23,7 @@ class SpecialData:
         return SpecialData(
             semantic_info=semantic_info, text_identifier=text_identifier, value=value)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Union
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
@@ -12,14 +12,14 @@ from .specialdatagroupcaption import SpecialDataGroupCaption
 @dataclass
 class SpecialDataGroup:
     """This corresponds to the SDG XML tag"""
-    sdg_caption: Optional[SpecialDataGroupCaption]
-    sdg_caption_ref: Optional[OdxLinkRef]
-    values: List[Union["SpecialDataGroup", SpecialData]]
-    semantic_info: Optional[str]  # the "SI" attribute
+    sdg_caption: SpecialDataGroupCaption | None
+    sdg_caption_ref: OdxLinkRef | None
+    values: list[Union["SpecialDataGroup", SpecialData]]
+    semantic_info: str | None  # the "SI" attribute
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "SpecialDataGroup":
+                doc_frags: list[OdxDocFragment]) -> "SpecialDataGroup":
 
         sdg_caption = None
         if caption_elem := et_element.find("SDG-CAPTION"):
@@ -31,9 +31,9 @@ class SpecialDataGroup:
 
         semantic_info = et_element.get("SI")
 
-        values: List[Union[SpecialData, SpecialDataGroup]] = []
+        values: list[SpecialData | SpecialDataGroup] = []
         for value_elem in et_element:
-            next_entry: Optional[Union[SpecialData, SpecialDataGroup]] = None
+            next_entry: SpecialData | SpecialDataGroup | None = None
             if value_elem.tag == "SDG":
                 next_entry = SpecialDataGroup.from_et(value_elem, doc_frags)
             elif value_elem.tag == "SD":
@@ -49,7 +49,7 @@ class SpecialDataGroup:
             values=values,
         )
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         if self.sdg_caption_ref is None and self.sdg_caption is not None:

--- a/odxtools/specialdatagroupcaption.py
+++ b/odxtools/specialdatagroupcaption.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -14,12 +14,12 @@ class SpecialDataGroupCaption(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "SpecialDataGroupCaption":
+                doc_frags: list[OdxDocFragment]) -> "SpecialDataGroupCaption":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         return SpecialDataGroupCaption(**kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         result[self.odx_id] = self

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -16,12 +16,12 @@ class State(IdentifiableElement):
     """
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "State":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "State":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         return State(**kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/statechart.py
+++ b/odxtools/statechart.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -19,7 +19,7 @@ class StateChart(IdentifiableElement):
     Corresponds to STATE-CHART.
     """
     semantic: str
-    state_transitions: List[StateTransition]
+    state_transitions: list[StateTransition]
     start_state_snref: str
     states: NamedItemList[State]
 
@@ -28,7 +28,7 @@ class StateChart(IdentifiableElement):
         return self._start_state
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "StateChart":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "StateChart":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         semantic: str = odxrequire(et_element.findtext("SEMANTIC"))
@@ -52,7 +52,7 @@ class StateChart(IdentifiableElement):
             states=NamedItemList(states),
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = {self.odx_id: self}
 
         for strans in self.state_transitions:

--- a/odxtools/statemachine.py
+++ b/odxtools/statemachine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Generator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generator, Union
+from typing import TYPE_CHECKING, Any
 
 from .exceptions import odxraise
 from .odxtypes import ParameterValueDict
@@ -97,7 +98,7 @@ class StateMachine:
         self._active_state = state_chart.start_state
 
     def execute(self, service: "DiagService", **service_params: Any
-               ) -> Generator[bytes, Union[bytes, bytearray, ParameterValueDict], None]:
+               ) -> Generator[bytes, bytes | bytearray | ParameterValueDict, None]:
         """Run a diagnostic service and update the state machine
         depending on the outcome.
 
@@ -159,7 +160,7 @@ class StateMachine:
 
         if raw_resp is None:
             raise RuntimeError("The calling code must send back a reply")
-        elif isinstance(raw_resp, (bytes, bytearray)):
+        elif isinstance(raw_resp, bytes | bytearray):
             for decoded_resp_msg in self.diag_layer.decode_response(raw_resp, raw_req):
                 for stransref in service.state_transition_refs:
                     # we only execute the first applicable state

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -19,7 +19,7 @@ class StateTransition(IdentifiableElement):
     """
     source_snref: str
     target_snref: str
-    external_access_method: Optional[ExternalAccessMethod]
+    external_access_method: ExternalAccessMethod | None
 
     @property
     def source_state(self) -> State:
@@ -31,7 +31,7 @@ class StateTransition(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "StateTransition":
+                doc_frags: list[OdxDocFragment]) -> "StateTransition":
 
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
@@ -50,7 +50,7 @@ class StateTransition(IdentifiableElement):
             external_access_method=external_access_method,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/staticfield.py
+++ b/odxtools/staticfield.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Dict, List, Sequence
+from typing import Any
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -23,7 +24,7 @@ class StaticField(Field):
 
     @staticmethod
     @override
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "StaticField":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "StaticField":
         kwargs = dataclass_fields_asdict(Field.from_et(et_element, doc_frags))
 
         fixed_number_of_items = int(odxrequire(et_element.findtext('FIXED-NUMBER-OF-ITEMS')))
@@ -33,7 +34,7 @@ class StaticField(Field):
             fixed_number_of_items=fixed_number_of_items, item_byte_size=item_byte_size, **kwargs)
 
     @override
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         odxlinks = super()._build_odxlinks()
         return odxlinks
 
@@ -89,7 +90,7 @@ class StaticField(Field):
         orig_origin = decode_state.origin_byte_position
         decode_state.origin_byte_position = decode_state.cursor_byte_position
 
-        result: List[ParameterValue] = []
+        result: list[ParameterValue] = []
         for _ in range(self.fixed_number_of_items):
             orig_cursor = decode_state.cursor_byte_position
 

--- a/odxtools/structure.py
+++ b/odxtools/structure.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
@@ -11,14 +10,14 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class Structure(BasicStructure):
-    is_visible_raw: Optional[bool]
+    is_visible_raw: bool | None
 
     @property
     def is_visible(self) -> bool:
         return self.is_visible_raw in (True, None)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Structure":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Structure":
         """Read a STRUCTURE element from XML."""
         kwargs = dataclass_fields_asdict(BasicStructure.from_et(et_element, doc_frags))
 

--- a/odxtools/subcomponent.py
+++ b/odxtools/subcomponent.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .dtcconnector import DtcConnector
@@ -25,16 +25,16 @@ class SubComponent(IdentifiableElement):
 
     """
 
-    sub_component_patterns: List[SubComponentPattern]
+    sub_component_patterns: list[SubComponentPattern]
     sub_component_param_connectors: NamedItemList[SubComponentParamConnector]
     table_row_connectors: NamedItemList[TableRowConnector]
     env_data_connectors: NamedItemList[EnvDataConnector]
     dtc_connectors: NamedItemList[DtcConnector]
 
-    semantic: Optional[str]
+    semantic: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "SubComponent":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SubComponent":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         semantic = et_element.get("SEMANTIC")
@@ -69,7 +69,7 @@ class SubComponent(IdentifiableElement):
             dtc_connectors=NamedItemList(dtc_connectors),
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
 
         for scp in self.sub_component_patterns:

--- a/odxtools/subcomponentparamconnector.py
+++ b/odxtools/subcomponentparamconnector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .diagservice import DiagService
@@ -18,8 +18,8 @@ class SubComponentParamConnector(IdentifiableElement):
     diag_comm_snref: str
 
     # TODO: we currently only support SNREFs, not SNPATHREFs
-    out_param_if_refs: List[str]
-    in_param_if_refs: List[str]
+    out_param_if_refs: list[str]
+    in_param_if_refs: list[str]
 
     @property
     def service(self) -> DiagService:
@@ -35,7 +35,7 @@ class SubComponentParamConnector(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "SubComponentParamConnector":
+                doc_frags: list[OdxDocFragment]) -> "SubComponentParamConnector":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         diag_comm_snref = odxrequire(
@@ -65,7 +65,7 @@ class SubComponentParamConnector(IdentifiableElement):
             in_param_if_refs=in_param_if_refs,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/subcomponentpattern.py
+++ b/odxtools/subcomponentpattern.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
 
 @dataclass
 class SubComponentPattern:
-    matching_parameters: List["MatchingParameter"]
+    matching_parameters: list["MatchingParameter"]
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "SubComponentPattern":
+                doc_frags: list[OdxDocFragment]) -> "SubComponentPattern":
         from .matchingparameter import MatchingParameter
 
         matching_parameters = [
@@ -26,7 +26,7 @@ class SubComponentPattern:
 
         return SubComponentPattern(matching_parameters=matching_parameters)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {}
         for mp in self.matching_parameters:
             result.update(mp._build_odxlinks())

--- a/odxtools/swvariable.py
+++ b/odxtools/swvariable.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .element import NamedElement
@@ -10,11 +9,11 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class SwVariable(NamedElement):
-    origin: Optional[str]
-    oid: Optional[str]
+    origin: str | None
+    oid: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "SwVariable":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "SwVariable":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         origin = et_element.findtext("ORIGIN")

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -19,17 +19,17 @@ from .utils import dataclass_fields_asdict
 @dataclass
 class Table(IdentifiableElement):
     """This class represents a TABLE."""
-    key_label: Optional[str]
-    struct_label: Optional[str]
-    admin_data: Optional[AdminData]
-    key_dop_ref: Optional[OdxLinkRef]
-    table_rows_raw: List[Union[TableRow, OdxLinkRef]]
-    table_diag_comm_connectors: List[TableDiagCommConnector]
-    sdgs: List[SpecialDataGroup]
-    semantic: Optional[str]
+    key_label: str | None
+    struct_label: str | None
+    admin_data: AdminData | None
+    key_dop_ref: OdxLinkRef | None
+    table_rows_raw: list[TableRow | OdxLinkRef]
+    table_diag_comm_connectors: list[TableDiagCommConnector]
+    sdgs: list[SpecialDataGroup]
+    semantic: str | None
 
     @property
-    def key_dop(self) -> Optional[DataObjectProperty]:
+    def key_dop(self) -> DataObjectProperty | None:
         """The key data object property associated with this table."""
         return self._key_dop
 
@@ -39,7 +39,7 @@ class Table(IdentifiableElement):
         return self._table_rows
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Table":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Table":
         """Reads a TABLE."""
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
         odx_id = kwargs["odx_id"]
@@ -48,7 +48,7 @@ class Table(IdentifiableElement):
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
         key_dop_ref = OdxLinkRef.from_et(et_element.find("KEY-DOP-REF"), doc_frags)
 
-        table_rows_raw: List[Union[OdxLinkRef, TableRow]] = []
+        table_rows_raw: list[OdxLinkRef | TableRow] = []
         for sub_elem in et_element:
             if sub_elem.tag == "TABLE-ROW":
                 table_rows_raw.append(
@@ -77,7 +77,7 @@ class Table(IdentifiableElement):
             semantic=semantic,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         for table_row_wrapper in self.table_rows_raw:
@@ -93,7 +93,7 @@ class Table(IdentifiableElement):
         return result
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        self._key_dop: Optional[DataObjectProperty] = None
+        self._key_dop: DataObjectProperty | None = None
         if self.key_dop_ref is not None:
             self._key_dop = odxlinks.resolve(self.key_dop_ref, DataObjectProperty)
 

--- a/odxtools/tablediagcommconnector.py
+++ b/odxtools/tablediagcommconnector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .diagcomm import DiagComm
@@ -13,8 +13,8 @@ from .snrefcontext import SnRefContext
 class TableDiagCommConnector:
     semantic: str
 
-    diag_comm_ref: Optional[OdxLinkRef]
-    diag_comm_snref: Optional[str]
+    diag_comm_ref: OdxLinkRef | None
+    diag_comm_snref: str | None
 
     @property
     def diag_comm(self) -> DiagComm:
@@ -22,7 +22,7 @@ class TableDiagCommConnector:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "TableDiagCommConnector":
+                doc_frags: list[OdxDocFragment]) -> "TableDiagCommConnector":
 
         semantic = odxrequire(et_element.findtext("SEMANTIC"))
 
@@ -34,7 +34,7 @@ class TableDiagCommConnector:
         return TableDiagCommConnector(
             semantic=semantic, diag_comm_ref=diag_comm_ref, diag_comm_snref=diag_comm_snref)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/tablerowconnector.py
+++ b/odxtools/tablerowconnector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import NamedElement
@@ -27,7 +27,7 @@ class TableRowConnector(NamedElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "TableRowConnector":
+                doc_frags: list[OdxDocFragment]) -> "TableRowConnector":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         table_ref = odxrequire(OdxLinkRef.from_et(et_element.find("TABLE-REF"), doc_frags))
@@ -36,7 +36,7 @@ class TableRowConnector(NamedElement):
 
         return TableRowConnector(table_ref=table_ref, table_row_snref=table_row_snref, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/teammember.py
+++ b/odxtools/teammember.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -12,17 +12,17 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class TeamMember(IdentifiableElement):
-    roles: List[str]
-    department: Optional[str]
-    address: Optional[str]
-    zipcode: Optional[str]  # the tag for this is "ZIP", but `zip` is a keyword in python
-    city: Optional[str]
-    phone: Optional[str]
-    fax: Optional[str]
-    email: Optional[str]
+    roles: list[str]
+    department: str | None
+    address: str | None
+    zipcode: str | None  # the tag for this is "ZIP", but `zip` is a keyword in python
+    city: str | None
+    phone: str | None
+    fax: str | None
+    email: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "TeamMember":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "TeamMember":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         roles = [odxrequire(role_elem.text) for role_elem in et_element.iterfind("ROLES/ROLE")]
@@ -45,7 +45,7 @@ class TeamMember(IdentifiableElement):
             email=email,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         result = {self.odx_id: self}
 
         return result

--- a/odxtools/text.py
+++ b/odxtools/text.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List, Optional
 from xml.etree import ElementTree
 
 from .odxlink import OdxDocFragment
@@ -8,10 +7,10 @@ from .odxlink import OdxDocFragment
 @dataclass
 class Text:
     text: str
-    text_identifier: Optional[str]
+    text_identifier: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Text":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Text":
         # Extract the contents of the tag as a string.
         raw_string = et_element.text or ""
         for e in et_element:

--- a/odxtools/uds.py
+++ b/odxtools/uds.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 from enum import IntEnum
 from itertools import chain
-from typing import Optional
 
 import odxtools.obd as obd
 
@@ -82,7 +81,7 @@ _sid_to_name = {
 SID = IntEnum("UdsSID", ((i.name, i.value) for i in chain(obd.SID, UDSSID)))  # type: ignore[misc]
 
 
-def sid_to_name(sid: int) -> Optional[str]:
+def sid_to_name(sid: int) -> str | None:
     if sid in _sid_to_name:
         return _sid_to_name[sid]
     elif 0x81 <= sid and sid <= 0x82:
@@ -142,7 +141,7 @@ def negative_response_id(service_id: int) -> int:
     return NegativeResponseId
 
 
-def is_response_pending(telegram_payload: bytes, request_sid: Optional[int] = None) -> bool:
+def is_response_pending(telegram_payload: bytes, request_sid: int | None = None) -> bool:
     # "response pending" responses exhibit at least three bytes
     if len(telegram_payload) < 3:
         return False

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement
@@ -53,21 +53,21 @@ class Unit(IdentifiableElement):
     ```
     """
     display_name: str
-    factor_si_to_unit: Optional[float]
-    offset_si_to_unit: Optional[float]
-    physical_dimension_ref: Optional[OdxLinkRef]
+    factor_si_to_unit: float | None
+    offset_si_to_unit: float | None
+    physical_dimension_ref: OdxLinkRef | None
 
     @property
-    def physical_dimension(self) -> Optional[PhysicalDimension]:
+    def physical_dimension(self) -> PhysicalDimension | None:
         return self._physical_dimension
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "Unit":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "Unit":
         kwargs = dataclass_fields_asdict(IdentifiableElement.from_et(et_element, doc_frags))
 
         display_name = odxrequire(et_element.findtext("DISPLAY-NAME"))
 
-        def read_optional_float(element: ElementTree.Element, name: str) -> Optional[float]:
+        def read_optional_float(element: ElementTree.Element, name: str) -> float | None:
             if (elem_str := element.findtext(name)) is not None:
                 return float(elem_str)
             else:
@@ -85,11 +85,11 @@ class Unit(IdentifiableElement):
             physical_dimension_ref=physical_dimension_ref,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {self.odx_id: self}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:
-        self._physical_dimension: Optional[PhysicalDimension] = None
+        self._physical_dimension: PhysicalDimension | None = None
         if self.physical_dimension_ref:
             self._physical_dimension = odxlinks.resolve(self.physical_dimension_ref,
                                                         PhysicalDimension)

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from .element import NamedElement
@@ -20,15 +20,15 @@ class UnitGroup(NamedElement):
     There are two categories of groups: COUNTRY and EQUIV-UNITS.
     """
     category: UnitGroupCategory
-    unit_refs: List[OdxLinkRef]
-    oid: Optional[str]
+    unit_refs: list[OdxLinkRef]
+    oid: str | None
 
     @property
     def units(self) -> NamedItemList[Unit]:
         return self._units
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "UnitGroup":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "UnitGroup":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         category_str = odxrequire(et_element.findtext("CATEGORY"))
@@ -46,7 +46,7 @@ class UnitGroup(NamedElement):
 
         return UnitGroup(category=category, unit_refs=unit_refs, oid=oid, **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .admindata import AdminData
@@ -25,11 +25,11 @@ class UnitSpec:
     The following odx elements are not internalized: ADMIN-DATA, SDGS
     """
 
-    admin_data: Optional[AdminData]
+    admin_data: AdminData | None
     unit_groups: NamedItemList[UnitGroup]
     units: NamedItemList[Unit]
     physical_dimensions: NamedItemList[PhysicalDimension]
-    sdgs: List[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup]
 
     def __post_init__(self) -> None:
         self.unit_groups = NamedItemList(self.unit_groups)
@@ -37,7 +37,7 @@ class UnitSpec:
         self.physical_dimensions = NamedItemList(self.physical_dimensions)
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "UnitSpec":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "UnitSpec":
 
         admin_data = AdminData.from_et(et_element.find("ADMIN-DATA"), doc_frags)
         unit_groups = NamedItemList([
@@ -60,8 +60,8 @@ class UnitSpec:
             physical_dimensions=physical_dimensions,
             sdgs=sdgs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
-        odxlinks: Dict[OdxLinkId, Any] = {}
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
+        odxlinks: dict[OdxLinkId, Any] = {}
         for unit in self.units:
             odxlinks.update(unit._build_odxlinks())
         for dim in self.physical_dimensions:

--- a/odxtools/utils.py
+++ b/odxtools/utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import dataclasses
 import re
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from xml.etree import ElementTree
 
 from .exceptions import odxraise
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .snrefcontext import SnRefContext
 
 
-def read_hex_binary(et_element: Optional[ElementTree.Element]) -> Optional[int]:
+def read_hex_binary(et_element: ElementTree.Element | None) -> int | None:
     """Convert the contents of an xsd:hexBinary to an integer
     """
     if et_element is None:
@@ -76,7 +76,7 @@ def retarget_snrefs(database: "Database",
             retarget_snrefs(database, pr.layer, context)
 
 
-def dataclass_fields_asdict(obj: Any) -> Dict[str, Any]:
+def dataclass_fields_asdict(obj: Any) -> dict[str, Any]:
     """Extract all attributes from a dataclass object that are fields.
 
     This is a non-recursive version of `dataclasses.asdict()`. Its

--- a/odxtools/variablegroup.py
+++ b/odxtools/variablegroup.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import typing
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, runtime_checkable
+from typing import TYPE_CHECKING, runtime_checkable
 from xml.etree import ElementTree
 
 from .element import IdentifiableElement, NamedElement
@@ -26,7 +26,7 @@ class VariableGroup(IdentifiableElement):
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "VariableGroup":
+                doc_frags: list[OdxDocFragment]) -> "VariableGroup":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
 
         return VariableGroup(**kwargs)

--- a/odxtools/variantmatcher.py
+++ b/odxtools/variantmatcher.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
+from collections.abc import Generator
 from copy import copy
 from enum import Enum
-from typing import Dict, Generator, List, Optional, Tuple, Union
 
 from .diaglayers.basevariant import BaseVariant
 from .diaglayers.ecuvariant import EcuVariant
@@ -56,18 +56,18 @@ class VariantMatcher:
         MATCH = 2
 
     def __init__(self,
-                 variant_candidates: Union[List[EcuVariant], List[BaseVariant]],
+                 variant_candidates: list[EcuVariant] | list[BaseVariant],
                  use_cache: bool = True):
 
         self.variant_candidates = variant_candidates
         self.use_cache = use_cache
-        self.req_resp_cache: Dict[bytes, bytes] = {}
-        self._recent_ident_response: Optional[bytes] = None
+        self.req_resp_cache: dict[bytes, bytes] = {}
+        self._recent_ident_response: bytes | None = None
 
         self._state = VariantMatcher.State.PENDING
-        self._matching_variant: Optional[Union[EcuVariant, BaseVariant]] = None
+        self._matching_variant: EcuVariant | BaseVariant | None = None
 
-    def request_loop(self) -> Generator[Tuple[bool, bytes], None, None]:
+    def request_loop(self) -> Generator[tuple[bool, bytes], None, None]:
         """The request loop yielding tuples of byte sequences of
         requests and the whether physical addressing ought to be used
         to send them
@@ -86,7 +86,7 @@ class VariantMatcher:
 
         self._matching_variant = None
         for variant in self.variant_candidates:
-            variant_patterns: Union[List[EcuVariantPattern], List[BaseVariantPattern]]
+            variant_patterns: list[EcuVariantPattern] | list[BaseVariantPattern]
             if isinstance(variant, EcuVariant):
                 variant_patterns = variant.ecu_variant_patterns
             elif isinstance(variant, BaseVariant):
@@ -158,13 +158,13 @@ class VariantMatcher:
         return self._state == VariantMatcher.State.MATCH
 
     @property
-    def matching_variant(self) -> Optional[Union[EcuVariant, BaseVariant]]:
+    def matching_variant(self) -> EcuVariant | BaseVariant | None:
         """Returns the matched, i.e., active ecu variant if such a variant has been found."""
         return self._matching_variant
 
     def _ident_response_matches(
         self,
-        variant: Union[EcuVariant, BaseVariant],
+        variant: EcuVariant | BaseVariant,
         matching_param: MatchingParameter,
         response_bytes: bytes,
     ) -> bool:
@@ -175,7 +175,7 @@ class VariantMatcher:
 
         # ISO 22901 requires that snref or snpathref is resolvable in
         # at least one POS-RESPONSE or NEG-RESPONSE
-        all_responses: List[Response] = []
+        all_responses: list[Response] = []
         all_responses.extend(service.positive_responses)
         all_responses.extend(service.negative_responses)
         all_responses.extend(variant.global_negative_responses)

--- a/odxtools/variantpattern.py
+++ b/odxtools/variantpattern.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
 from .exceptions import odxraise
@@ -26,7 +26,7 @@ class VariantPattern:
     """
 
     def get_matching_parameters(
-            self) -> Union[List["MatchingParameter"], List["MatchingBaseVariantParameter"]]:
+            self) -> list["MatchingParameter"] | list["MatchingBaseVariantParameter"]:
         odxraise(
             f"VariantPattern subclass `{type(self).__name__}` does not "
             f"implement `.get_match_parameters()`", RuntimeError)
@@ -34,5 +34,5 @@ class VariantPattern:
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,
-                doc_frags: List[OdxDocFragment]) -> "VariantPattern":
+                doc_frags: list[OdxDocFragment]) -> "VariantPattern":
         return VariantPattern()

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -5,7 +5,7 @@ import mimetypes
 import os
 import time
 import zipfile
-from typing import Any, Dict, Optional
+from typing import Any
 
 import jinja2
 
@@ -14,7 +14,7 @@ import odxtools
 from .database import Database
 from .odxtypes import bool_to_odxstr
 
-odxdatabase: Optional[Database] = None
+odxdatabase: Database | None = None
 
 
 def jinja2_odxraise_helper(msg: str) -> None:
@@ -39,14 +39,14 @@ def get_parent_container_name(dl_short_name: str) -> str:
                        f"container for diagnostic layer '{dl_short_name}'.")
 
 
-def make_xml_attrib(attrib_name: str, attrib_val: Optional[Any]) -> str:
+def make_xml_attrib(attrib_name: str, attrib_val: Any | None) -> str:
     if attrib_val is None:
         return ""
 
     return f' {attrib_name}="{attrib_val}"'
 
 
-def make_bool_xml_attrib(attrib_name: str, attrib_val: Optional[bool]) -> str:
+def make_bool_xml_attrib(attrib_name: str, attrib_val: bool | None) -> str:
     if attrib_val is None:
         return ""
 
@@ -147,7 +147,7 @@ def write_pdx_file(
         jinja_env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
         jinja_env.globals["get_parent_container_name"] = get_parent_container_name
 
-        vars: Dict[str, Any] = {}
+        vars: dict[str, Any] = {}
         vars["odxtools_version"] = odxtools.__version__
         vars["database"] = database
 

--- a/odxtools/xdoc.py
+++ b/odxtools/xdoc.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 from xml.etree import ElementTree
 
 from .element import NamedElement
@@ -11,15 +11,15 @@ from .utils import dataclass_fields_asdict
 
 @dataclass
 class XDoc(NamedElement):
-    number: Optional[str]
-    state: Optional[str]
-    date: Optional[str]
-    publisher: Optional[str]
-    url: Optional[str]
-    position: Optional[str]
+    number: str | None
+    state: str | None
+    date: str | None
+    publisher: str | None
+    url: str | None
+    position: str | None
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element, doc_frags: List[OdxDocFragment]) -> "XDoc":
+    def from_et(et_element: ElementTree.Element, doc_frags: list[OdxDocFragment]) -> "XDoc":
         kwargs = dataclass_fields_asdict(NamedElement.from_et(et_element, doc_frags))
         number = et_element.findtext("NUMBER")
         state = et_element.findtext("STATE")
@@ -37,7 +37,7 @@ class XDoc(NamedElement):
             position=position,
             **kwargs)
 
-    def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
+    def _build_odxlinks(self) -> dict[OdxLinkId, Any]:
         return {}
 
     def _resolve_odxlinks(self, odxlinks: OdxLinkDatabase) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ maintainers = [
     {name = "Ayoub Kaanich", email = "kayoub5@live.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ['can', 'can bus', 'DoIP', 'odx', 'pdx', 'obd', 'uds', 'automotive', 'diagnostics']
 classifiers = [
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
     'Intended Audience :: Developers',
@@ -54,7 +54,6 @@ browse-tool = [
 
 test = [
      "mypy >= 1.5",
-     "types-tabulate >= 0.9.0.3", # Libary stubs for "tabulate" (mypy)
      "ruff >= 0.0.290",
      "pytest >= 7.4",
      "coverage >= 7.3",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 import unittest
 from argparse import Namespace
 from types import ModuleType
-from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
 import odxtools.cli.compare as compare
@@ -11,7 +10,7 @@ import odxtools.cli.decode as decode
 import odxtools.cli.find as find
 import odxtools.cli.list as list_tool
 
-browse: Optional[ModuleType]
+browse: ModuleType | None
 try:
     import odxtools.cli.browse as browse
 except ImportError:
@@ -23,9 +22,9 @@ class UtilFunctions:
     @staticmethod
     def run_list_tool(path_to_pdx_file: str = "./examples/somersault.pdx",
                       no_strict: bool = False,
-                      ecu_variants: Optional[List[str]] = None,
+                      ecu_variants: list[str] | None = None,
                       print_neg_responses: bool = False,
-                      ecu_services: Optional[List[str]] = None,
+                      ecu_services: list[str] | None = None,
                       print_params: bool = False,
                       print_dops: bool = False,
                       print_all: bool = False,
@@ -48,7 +47,7 @@ class UtilFunctions:
         data: str,
         decode_data: bool = False,
         path_to_pdx_file: str = "./examples/somersault.pdx",
-        ecu_variants: Optional[List[str]] = None,
+        ecu_variants: list[str] | None = None,
     ) -> None:
         decode_args = Namespace(
             pdx_file=path_to_pdx_file, variants=ecu_variants, data=data, decode=decode_data)
@@ -56,9 +55,9 @@ class UtilFunctions:
         decode.run(decode_args)
 
     @staticmethod
-    def run_find_tool(service_names: List[str],
+    def run_find_tool(service_names: list[str],
                       path_to_pdx_file: str = "./examples/somersault.pdx",
-                      ecu_variants: Optional[List[str]] = None,
+                      ecu_variants: list[str] | None = None,
                       allow_unknown_bit_lengths: bool = False,
                       no_details: bool = False,
                       dump_database: bool = False) -> None:
@@ -75,8 +74,8 @@ class UtilFunctions:
     @staticmethod
     def run_compare_tool(path_to_pdx_file: str = "./examples/somersault.pdx",
                          no_strict: bool = False,
-                         ecu_variants: Optional[List[str]] = None,
-                         database: Optional[List[str]] = None,
+                         ecu_variants: list[str] | None = None,
+                         database: list[str] | None = None,
                          no_details: bool = True) -> None:
 
         compare_args = Namespace(

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -485,7 +485,9 @@ class TestRatFuncCompuMethod(unittest.TestCase):
             internal_type=DataType.A_FLOAT32,
             physical_type=DataType.A_FLOAT32)
 
-        self.assertTrue(abs(float(compu_method.convert_internal_to_physical(2.5)) - 28.5) < 1e-5)
+        phys_val = compu_method.convert_internal_to_physical(2.5)
+        assert isinstance(phys_val, float)
+        self.assertTrue(abs(phys_val - 28.5) < 1e-5)
 
         # out of range
         with self.assertRaises(DecodeError):
@@ -559,13 +561,18 @@ class TestRatFuncCompuMethod(unittest.TestCase):
 
         self.assertEqual(compu_method.convert_internal_to_physical(2), 4)
         self.assertEqual(compu_method.convert_internal_to_physical(2.5), 6.25)
-        self.assertTrue(abs(float(compu_method.convert_internal_to_physical(3)) - 9) < 1e-8)
+        phys_val = compu_method.convert_internal_to_physical(3)
+        assert isinstance(phys_val, float)
+        self.assertTrue(abs(phys_val - 9) < 1e-8)
 
         # note that the inverse values are pretty inaccurate because
-        # the Taylor series was cut off way quite early.
-        self.assertTrue(abs(float(compu_method.convert_physical_to_internal(4)) - 1.375) < 1e-4)
-        self.assertTrue(
-            abs(float(compu_method.convert_physical_to_internal(6.25)) - 0.17969) < 1e-4)
+        # the Taylor series was cut off quite early.
+        int_val = compu_method.convert_physical_to_internal(4)
+        assert isinstance(int_val, float)
+        self.assertTrue(abs(int_val - 1.375) < 1e-4)
+        int_val = compu_method.convert_physical_to_internal(6.25)
+        assert isinstance(int_val, float)
+        self.assertTrue(abs(int_val - 0.17969) < 1e-4)
         self.assertEqual(compu_method.convert_physical_to_internal(9), -3)
 
         # ensure that we stay in bounds
@@ -610,7 +617,9 @@ class TestScaleRatFuncCompuMethod(unittest.TestCase):
             internal_type=DataType.A_FLOAT32,
             physical_type=DataType.A_FLOAT32)
 
-        self.assertTrue(abs(float(compu_method.convert_internal_to_physical(2.5)) - 28.5) < 1e-5)
+        phys_val = compu_method.convert_internal_to_physical(2.5)
+        assert isinstance(phys_val, float)
+        self.assertTrue(abs(phys_val - 28.5) < 1e-5)
 
         # out of range
         with self.assertRaises(DecodeError):
@@ -726,16 +735,25 @@ class TestScaleRatFuncCompuMethod(unittest.TestCase):
 
         self.assertEqual(compu_method.convert_internal_to_physical(2), 4)
         self.assertEqual(compu_method.convert_internal_to_physical(2.5), 6.25)
-        self.assertTrue(abs(float(compu_method.convert_internal_to_physical(3)) - 9) < 1e-8)
+        phys_val = compu_method.convert_internal_to_physical(3)
+        assert isinstance(phys_val, float)
+        self.assertTrue(abs(phys_val - 9) < 1e-8)
 
-        self.assertTrue(abs(float(compu_method.convert_internal_to_physical(4)) - 22) < 1e-8)
-        self.assertTrue(abs(float(compu_method.convert_physical_to_internal(22)) - 4) < 1e-8)
+        phys_val = compu_method.convert_internal_to_physical(4)
+        assert isinstance(phys_val, float)
+        self.assertTrue(abs(phys_val - 22) < 1e-8)
+        int_val = compu_method.convert_physical_to_internal(22)
+        assert isinstance(int_val, float)
+        self.assertTrue(abs(int_val - 4) < 1e-8)
 
         # note that the inverse values are pretty inaccurate because
         # the Taylor series was cut off way quite early.
-        self.assertTrue(abs(float(compu_method.convert_physical_to_internal(4)) - 1.375) < 1e-4)
-        self.assertTrue(
-            abs(float(compu_method.convert_physical_to_internal(6.25)) - 0.17969) < 1e-4)
+        int_val = compu_method.convert_physical_to_internal(4)
+        assert isinstance(int_val, float)
+        self.assertTrue(abs(int_val - 1.375) < 1e-4)
+        int_val = compu_method.convert_physical_to_internal(6.25)
+        assert isinstance(int_val, float)
+        self.assertTrue(abs(int_val - 0.17969) < 1e-4)
         self.assertEqual(compu_method.convert_physical_to_internal(9), -3)
 
         # make sure that we stay in bounds

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -2,7 +2,6 @@
 import math
 import unittest
 from datetime import datetime
-from typing import List
 
 from odxtools.compumethods.compucategory import CompuCategory
 from odxtools.compumethods.compuinternaltophys import CompuInternalToPhys
@@ -361,7 +360,8 @@ class TestEncodeRequest(unittest.TestCase):
             is_highlow_byte_order=True)
         # allow rounding errors due to python's float objects
         # potentially using a different representation
-        self.assertTrue(abs(float(decoded) - (-1.234)) < 1e-6)
+        assert isinstance(decoded, float)
+        self.assertTrue(abs(decoded - (-1.234)) < 1e-6)
 
         # FLOAT32 little-endian
         encode_state = EncodeState()
@@ -382,7 +382,8 @@ class TestEncodeRequest(unittest.TestCase):
             is_highlow_byte_order=False)
         # allow rounding errors due to python's float objects
         # potentially using a different representation
-        self.assertTrue(abs(float(decoded) - (-1.234)) < 1e-6)
+        assert isinstance(decoded, float)
+        self.assertTrue(abs(decoded - (-1.234)) < 1e-6)
 
         # check if NaN can be handled
         encode_state = EncodeState()
@@ -401,7 +402,8 @@ class TestEncodeRequest(unittest.TestCase):
             base_data_type=DataType.A_FLOAT32,
             base_type_encoding=Encoding.NONE,
             is_highlow_byte_order=True)
-        self.assertTrue(math.isnan(float(decoded)))
+        assert isinstance(decoded, float)
+        self.assertTrue(math.isnan(decoded))
 
         # FLOAT64
         encode_state = EncodeState()
@@ -436,7 +438,8 @@ class TestEncodeRequest(unittest.TestCase):
             is_highlow_byte_order=True)
         # allow rounding errors due to python's float objects
         # potentially using a different representation
-        self.assertTrue(abs(float(decoded) - (-1.234)) < 1e-9)
+        assert isinstance(decoded, float)
+        self.assertTrue(abs(decoded - (-1.234)) < 1e-9)
 
     def test_encode_coded_const_reorder(self) -> None:
         diag_coded_type = StandardLengthType(
@@ -1177,7 +1180,7 @@ class TestEncodeRequest(unittest.TestCase):
         self.assertEqual(req.encode().hex(), "123456")
         self.assertEqual(req.get_static_bit_length(), 24)
 
-    def _create_request(self, parameters: List[Parameter]) -> Request:
+    def _create_request(self, parameters: list[Parameter]) -> Request:
         return Request(
             odx_id=OdxLinkId("request_id", doc_frags),
             oid=None,

--- a/tests/test_odxtools.py
+++ b/tests/test_odxtools.py
@@ -2,7 +2,6 @@
 import pickle
 import unittest
 from dataclasses import dataclass
-from typing import List
 
 import odxtools
 import odxtools.exceptions
@@ -166,7 +165,7 @@ class TestNamedItemList(unittest.TestCase):
 
         # ensure that mypy accepts NamedItemList objecs where List
         # objects are expected
-        def bar(x: List[X]) -> None:
+        def bar(x: list[X]) -> None:
             pass
 
         bar(foo)

--- a/tests/test_variant_matching.py
+++ b/tests/test_variant_matching.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
@@ -42,7 +42,7 @@ def dummy_response(monkeypatch: pytest.MonkeyPatch) -> Response:
     )
     odxlinks.update({resp.odx_id: resp})
 
-    def decode(message: bytes) -> Dict[str, Any]:
+    def decode(message: bytes) -> dict[str, Any]:
         msg_str = message.decode(encoding="utf-8")
         msg_dict = json.loads(msg_str)
         assert isinstance(msg_dict, dict)
@@ -540,7 +540,7 @@ def base_variant_3(
 
 @pytest.fixture
 def base_variants(base_variant_1: BaseVariant, base_variant_2: BaseVariant,
-                  base_variant_3: BaseVariant) -> List[BaseVariant]:
+                  base_variant_3: BaseVariant) -> list[BaseVariant]:
     return [base_variant_1, base_variant_2, base_variant_3]
 
 
@@ -676,11 +676,11 @@ def ecu_variant_3(
 
 @pytest.fixture
 def ecu_variants(ecu_variant_1: EcuVariant, ecu_variant_2: EcuVariant,
-                 ecu_variant_3: EcuVariant) -> List[EcuVariant]:
+                 ecu_variant_3: EcuVariant) -> list[EcuVariant]:
     return [ecu_variant_1, ecu_variant_2, ecu_variant_3]
 
 
-def as_bytes(dikt: Dict[str, Any]) -> bytes:
+def as_bytes(dikt: dict[str, Any]) -> bytes:
     return bytes(json.dumps(dikt), "utf-8")
 
 
@@ -711,9 +711,9 @@ def as_bytes(dikt: Dict[str, Any]) -> bytes:
     ],
 )
 def test_base_variant_matching(
-    base_variants: List[BaseVariant],
+    base_variants: list[BaseVariant],
     use_cache: bool,
-    req_resp_mapping: Dict[bytes, bytes],
+    req_resp_mapping: dict[bytes, bytes],
     expected_variant: str,
 ) -> None:
 
@@ -776,9 +776,9 @@ def test_base_variant_matching(
     ],
 )
 def test_ecu_variant_matching(
-    ecu_variants: List[EcuVariant],
+    ecu_variants: list[EcuVariant],
     use_cache: bool,
-    req_resp_mapping: Dict[bytes, bytes],
+    req_resp_mapping: dict[bytes, bytes],
     expected_variant: str,
 ) -> None:
     matcher = VariantMatcher(
@@ -794,7 +794,7 @@ def test_ecu_variant_matching(
 
 
 @pytest.mark.parametrize("use_cache", [True, False])
-def test_no_match(ecu_variants: List[EcuVariant], use_cache: bool) -> None:
+def test_no_match(ecu_variants: list[EcuVariant], use_cache: bool) -> None:
     # stores the responses for each request for the ecu-under-test
     req_resp_mapping = {
         b"\x22\x10\x00": as_bytes({"id": 1000}),
@@ -817,7 +817,7 @@ def test_no_match(ecu_variants: List[EcuVariant], use_cache: bool) -> None:
 
 @pytest.mark.parametrize("use_cache", [True, False])
 # test if pending matchers reject the has_match() or active variant query
-def test_no_request_loop(ecu_variants: List[EcuVariant], use_cache: bool) -> None:
+def test_no_request_loop(ecu_variants: list[EcuVariant], use_cache: bool) -> None:
     matcher = VariantMatcher(
         variant_candidates=ecu_variants,
         use_cache=use_cache,
@@ -829,7 +829,7 @@ def test_no_request_loop(ecu_variants: List[EcuVariant], use_cache: bool) -> Non
 
 @pytest.mark.parametrize("use_cache", [True, False])
 # test if runs of the request loop without calling `evaluate(...)` are rejected
-def test_request_loop_misuse(ecu_variants: List[EcuVariant], use_cache: bool) -> None:
+def test_request_loop_misuse(ecu_variants: list[EcuVariant], use_cache: bool) -> None:
     matcher = VariantMatcher(
         variant_candidates=ecu_variants,
         use_cache=use_cache,
@@ -841,7 +841,7 @@ def test_request_loop_misuse(ecu_variants: List[EcuVariant], use_cache: bool) ->
 
 @pytest.mark.parametrize("use_cache", [True, False])
 # test if request loop is idempotent, i.e., the matching is the same regardless of how often the request loop is run
-def test_request_loop_idempotency(ecu_variants: List[EcuVariant], use_cache: bool) -> None:
+def test_request_loop_idempotency(ecu_variants: list[EcuVariant], use_cache: bool) -> None:
     req_resp_mapping = {
         b"\x22\x10\x00": as_bytes({"id": 2000}),
         b"\x22\x20\x00": as_bytes({"name": {
@@ -870,7 +870,7 @@ def test_request_loop_idempotency(ecu_variants: List[EcuVariant], use_cache: boo
 
 
 @pytest.mark.parametrize("use_cache", [True, False])
-def test_unresolvable_snpathref(ecu_variants: List[EcuVariant], use_cache: bool) -> None:
+def test_unresolvable_snpathref(ecu_variants: list[EcuVariant], use_cache: bool) -> None:
     # stores the responses for each request for the ecu-under-test
     req_resp_mapping = {
         b"\x22\x10\x00": as_bytes({"id": 1000}),


### PR DESCRIPTION
Finally! With Ubuntu 20.04 reaching EOL this month, we don't need to continue to carry the baggage that is python 3.8 support anymore.

The reason why this pull request is so large is that `ruff` is adaptive to the minimum python version specified in `pyproject.toml`  and for python >=3.10 it requires to use the build-in lower case type annotations instead the their equivalents from `typing` (i.e., `list` instead of `List`), `|` instead of `typing.Union`, and `| None` instead of `Optional` (in most cases). Fortunately, ruff can fix the vast majority of these issues automatically using the `--fix` option...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 

