### PR TITLE
Declare (almost) all dataclasses as `kw_only`

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -2534,10 +2534,8 @@ somersault_lazy_ecu_raw = EcuVariantRaw(
             oid=None,
             short_name="annoyed_chart",
             long_name=None,
-            description=Description(
-                "<p>State chart for a day where the ECU is grumpy</p>",
-                external_docs=[],
-                text_identifier=None),
+            description=Description.from_string(
+                "<p>State chart for a day where the ECU is grumpy</p>"),
             states=NamedItemList([
                 State(
                     odx_id=OdxLinkId("charts.annoyed.states.in_bed", doc_frags),
@@ -2637,10 +2635,8 @@ somersault_lazy_ecu_raw = EcuVariantRaw(
             oid=None,
             short_name="angry_chart",
             long_name=None,
-            description=Description(
-                "<p>State chart for a day where the ECU has a hissy fit</p>",
-                external_docs=[],
-                text_identifier=None),
+            description=Description.from_string(
+                "<p>State chart for a day where the ECU has a hissy fit</p>"),
             states=NamedItemList([
                 State(
                     odx_id=OdxLinkId("charts.angry.states.in_bed", doc_frags),

--- a/odxtools/additionalaudience.py
+++ b/odxtools/additionalaudience.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class AdditionalAudience(IdentifiableElement):
     """
     Corresponds to ADDITIONAL-AUDIENCE.

--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -9,7 +9,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class AdminData:
     language: str | None
     company_doc_infos: list[CompanyDocInfo]

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -10,7 +10,7 @@ from .odxtypes import odxstr_to_bool
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Audience:
     enabled_audience_refs: list[OdxLinkRef]
     disabled_audience_refs: list[OdxLinkRef]

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -12,7 +12,7 @@ from .usage import Usage
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BaseComparam(IdentifiableElement):
     param_class: str
     cptype: StandardizationLevel

--- a/odxtools/basevariantpattern.py
+++ b/odxtools/basevariantpattern.py
@@ -11,7 +11,7 @@ from .odxlink import OdxDocFragment
 from .variantpattern import VariantPattern
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BaseVariantPattern(VariantPattern):
     """Base variant patterns are variant patterns used to identify the
     base variant of an ECU.

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -22,7 +22,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BasicStructure(ComplexDop):
     """Base class for structure-like objects
 

--- a/odxtools/commrelation.py
+++ b/odxtools/commrelation.py
@@ -14,7 +14,7 @@ from .parameters.parameter import Parameter
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CommRelation:
     description: Description | None
     relation_type: str

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -13,7 +13,7 @@ from .teammember import TeamMember
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompanyData(IdentifiableElement):
     roles: list[str]
     team_members: NamedItemList[TeamMember]

--- a/odxtools/companydocinfo.py
+++ b/odxtools/companydocinfo.py
@@ -11,7 +11,7 @@ from .specialdatagroup import SpecialDataGroup
 from .teammember import TeamMember
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompanyDocInfo:
     company_data_ref: OdxLinkRef
     team_member_ref: OdxLinkRef | None

--- a/odxtools/companyrevisioninfo.py
+++ b/odxtools/companyrevisioninfo.py
@@ -9,7 +9,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompanyRevisionInfo:
     company_data_ref: OdxLinkRef
     revision_label: str | None

--- a/odxtools/companyspecificinfo.py
+++ b/odxtools/companyspecificinfo.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .specialdatagroup import SpecialDataGroup
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompanySpecificInfo:
     related_docs: list[RelatedDoc]
     sdgs: list[SpecialDataGroup]

--- a/odxtools/comparam.py
+++ b/odxtools/comparam.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Comparam(BaseComparam):
     physical_default_value_raw: str
     dop_ref: OdxLinkRef

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -13,7 +13,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ComparamInstance:
     """
     This class represents a communication parameter.

--- a/odxtools/comparamspec.py
+++ b/odxtools/comparamspec.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .database import Database
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ComparamSpec(OdxCategory):
 
     prot_stacks: NamedItemList[ProtStack]

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .database import Database
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ComparamSubset(OdxCategory):
     comparams: NamedItemList[Comparam]
     complex_comparams: NamedItemList[ComplexComparam]

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -23,7 +23,7 @@ def create_complex_value_from_et(et_element: ElementTree.Element) -> ComplexValu
     return result
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ComplexComparam(BaseComparam):
     subparams: NamedItemList[BaseComparam]
     physical_default_value: ComplexValue | None

--- a/odxtools/complexdop.py
+++ b/odxtools/complexdop.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from .dopbase import DopBase
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ComplexDop(DopBase):
     """Base class for all complex data object properties.
 

--- a/odxtools/compumethods/compucodecompumethod.py
+++ b/odxtools/compumethods/compucodecompumethod.py
@@ -12,7 +12,7 @@ from .compucategory import CompuCategory
 from .compumethod import CompuMethod
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuCodeCompuMethod(CompuMethod):
     """A compu method specifies the tranfer functions using Java bytecode
 

--- a/odxtools/compumethods/compuconst.py
+++ b/odxtools/compumethods/compuconst.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 from ..odxtypes import AtomicOdxType, DataType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuConst:
     v: str | None
     vt: str | None

--- a/odxtools/compumethods/compudefaultvalue.py
+++ b/odxtools/compumethods/compudefaultvalue.py
@@ -8,7 +8,7 @@ from .compuconst import CompuConst
 from .compuinversevalue import CompuInverseValue
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuDefaultValue(CompuConst):
     compu_inverse_value: CompuInverseValue | None
 

--- a/odxtools/compumethods/compuinternaltophys.py
+++ b/odxtools/compumethods/compuinternaltophys.py
@@ -11,7 +11,7 @@ from .compudefaultvalue import CompuDefaultValue
 from .compuscale import CompuScale
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuInternalToPhys:
     compu_scales: list[CompuScale]
     prog_code: ProgCode | None

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -12,7 +12,7 @@ from .compuinternaltophys import CompuInternalToPhys
 from .compuphystointernal import CompuPhysToInternal
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuMethod:
     """A compu method translates between the internal representation
     of a value and their physical representation.

--- a/odxtools/compumethods/compuphystointernal.py
+++ b/odxtools/compumethods/compuphystointernal.py
@@ -11,7 +11,7 @@ from .compudefaultvalue import CompuDefaultValue
 from .compuscale import CompuScale
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuPhysToInternal:
     compu_scales: list[CompuScale]
     prog_code: ProgCode | None

--- a/odxtools/compumethods/compurationalcoeffs.py
+++ b/odxtools/compumethods/compurationalcoeffs.py
@@ -8,7 +8,7 @@ from ..odxlink import OdxDocFragment
 from ..odxtypes import DataType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuRationalCoeffs:
     value_type: DataType
 

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -11,7 +11,7 @@ from .compurationalcoeffs import CompuRationalCoeffs
 from .limit import Limit
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompuScale:
     """A COMPU-SCALE represents one value range of a COMPU-METHOD.
     """

--- a/odxtools/compumethods/identicalcompumethod.py
+++ b/odxtools/compumethods/identicalcompumethod.py
@@ -9,7 +9,7 @@ from ..utils import dataclass_fields_asdict
 from .compumethod import CompuMethod
 
 
-@dataclass
+@dataclass(kw_only=True)
 class IdenticalCompuMethod(CompuMethod):
     """Identical compu methods just pass through the internal value.
 

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -9,7 +9,7 @@ from ..odxtypes import AtomicOdxType, DataType, compare_odx_values
 from .intervaltype import IntervalType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Limit:
     value_raw: str | None
     value_type: DataType | None

--- a/odxtools/compumethods/linearcompumethod.py
+++ b/odxtools/compumethods/linearcompumethod.py
@@ -12,7 +12,7 @@ from .compumethod import CompuMethod
 from .linearsegment import LinearSegment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class LinearCompuMethod(CompuMethod):
     """A compu method which does linear interpoation
 

--- a/odxtools/compumethods/linearsegment.py
+++ b/odxtools/compumethods/linearsegment.py
@@ -7,7 +7,7 @@ from .compuscale import CompuScale
 from .limit import Limit
 
 
-@dataclass
+@dataclass(kw_only=True)
 class LinearSegment:
     """Helper class to represent a segment of a piecewise-linear interpolation.
 

--- a/odxtools/compumethods/ratfunccompumethod.py
+++ b/odxtools/compumethods/ratfunccompumethod.py
@@ -12,7 +12,7 @@ from .compumethod import CompuMethod
 from .ratfuncsegment import RatFuncSegment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RatFuncCompuMethod(CompuMethod):
     """A compu method using a rational function
 

--- a/odxtools/compumethods/ratfuncsegment.py
+++ b/odxtools/compumethods/ratfuncsegment.py
@@ -7,7 +7,7 @@ from .compuscale import CompuScale
 from .limit import Limit
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RatFuncSegment:
     """Helper class to represent a segment of a piecewise rational function.
     """

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -13,7 +13,7 @@ from .intervaltype import IntervalType
 from .linearsegment import LinearSegment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ScaleLinearCompuMethod(CompuMethod):
     """A piecewise linear compu method which may feature discontinuities.
 

--- a/odxtools/compumethods/scaleratfunccompumethod.py
+++ b/odxtools/compumethods/scaleratfunccompumethod.py
@@ -12,7 +12,7 @@ from .compumethod import CompuMethod
 from .ratfuncsegment import RatFuncSegment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ScaleRatFuncCompuMethod(CompuMethod):
     """A compu method using a piecewise rational function
 

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -12,7 +12,7 @@ from .intervaltype import IntervalType
 from .limit import Limit
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TabIntpCompuMethod(CompuMethod):
     """A table-based interpolated compu method provides a continuous
     transfer function based on piecewise linear interpolation.

--- a/odxtools/compumethods/texttablecompumethod.py
+++ b/odxtools/compumethods/texttablecompumethod.py
@@ -12,7 +12,7 @@ from .compumethod import CompuMethod
 from .compuscale import CompuScale
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TexttableCompuMethod(CompuMethod):
     """Text table compute methods translate numbers to human readable
     textual descriptions.

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -20,7 +20,7 @@ from .unit import Unit
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DataObjectProperty(DopBase):
     """This class represents a DATA-OBJECT-PROP.
 

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -7,7 +7,7 @@ from .externaldoc import ExternalDoc
 from .odxlink import OdxDocFragment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Description:
     text: str
     external_docs: list[ExternalDoc]

--- a/odxtools/determinenumberofitems.py
+++ b/odxtools/determinenumberofitems.py
@@ -9,7 +9,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DetermineNumberOfItems:
     """
     The object that determines the number of items of dynamic fields

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -20,7 +20,7 @@ DctType = Literal[
 ]
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagCodedType:
     base_type_encoding: Encoding | None
     base_data_type: DataType

--- a/odxtools/diagcomm.py
+++ b/odxtools/diagcomm.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from .diaglayers.protocol import Protocol
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagComm(IdentifiableElement):
     """Representation of a diagnostic communication object.
 

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -24,7 +24,7 @@ from .table import Table
 from .unitspec import UnitSpec
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagDataDictionarySpec:
     admin_data: AdminData | None
     dtc_dops: NamedItemList[DtcDop]

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from .database import Database
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagLayerContainer(OdxCategory):
     protocols: NamedItemList[Protocol]
     functional_groups: NamedItemList[FunctionalGroup]

--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -20,7 +20,7 @@ from .diaglayer import DiagLayer
 from .hierarchyelement import HierarchyElement
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BaseVariant(HierarchyElement):
     """This is a diagnostic layer for common functionality of an ECU
     """

--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -16,7 +16,7 @@ from ..variablegroup import VariableGroup
 from .hierarchyelementraw import HierarchyElementRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BaseVariantRaw(HierarchyElementRaw):
     """This is a diagnostic layer for common functionality of an ECU
     """

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -33,7 +33,7 @@ from .diaglayertype import DiagLayerType
 PrefixTree = dict[int, Union[list[DiagService], "PrefixTree"]]
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagLayer:
     """This class represents a "logical view" upon a diagnostic layer
     according to the ODX standard.

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -27,7 +27,7 @@ from ..utils import dataclass_fields_asdict
 from .diaglayertype import DiagLayerType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagLayerRaw(IdentifiableElement):
     """This class internalizes all data represented by the DIAG-LAYER
     XML tag and its derivatives.

--- a/odxtools/diaglayers/ecushareddata.py
+++ b/odxtools/diaglayers/ecushareddata.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .database import Database
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EcuSharedData(DiagLayer):
     """This is a diagnostic layer for data shared across others
     """

--- a/odxtools/diaglayers/ecushareddataraw.py
+++ b/odxtools/diaglayers/ecushareddataraw.py
@@ -13,7 +13,7 @@ from ..variablegroup import VariableGroup
 from .diaglayerraw import DiagLayerRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EcuSharedDataRaw(DiagLayerRaw):
     """This is a diagnostic layer for data shared accross others
     """

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -21,7 +21,7 @@ from .ecuvariantraw import EcuVariantRaw
 from .hierarchyelement import HierarchyElement
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EcuVariant(HierarchyElement):
 
     @property

--- a/odxtools/diaglayers/ecuvariantraw.py
+++ b/odxtools/diaglayers/ecuvariantraw.py
@@ -16,7 +16,7 @@ from ..variablegroup import VariableGroup
 from .hierarchyelementraw import HierarchyElementRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EcuVariantRaw(HierarchyElementRaw):
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -18,7 +18,7 @@ from .functionalgroupraw import FunctionalGroupRaw
 from .hierarchyelement import HierarchyElement
 
 
-@dataclass
+@dataclass(kw_only=True)
 class FunctionalGroup(HierarchyElement):
     """This is a diagnostic layer for functionality shared between multiple ECU variants
     """

--- a/odxtools/diaglayers/functionalgroupraw.py
+++ b/odxtools/diaglayers/functionalgroupraw.py
@@ -14,7 +14,7 @@ from ..variablegroup import VariableGroup
 from .hierarchyelementraw import HierarchyElementRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class FunctionalGroupRaw(HierarchyElementRaw):
     """This is a diagnostic layer for common functionality of an ECU
     """

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 TNamed = TypeVar("TNamed", bound=OdxNamed)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class HierarchyElement(DiagLayer):
     """This is the base class for diagnostic layers that may be involved in value inheritance
     """

--- a/odxtools/diaglayers/hierarchyelementraw.py
+++ b/odxtools/diaglayers/hierarchyelementraw.py
@@ -10,7 +10,7 @@ from ..utils import dataclass_fields_asdict
 from .diaglayerraw import DiagLayerRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class HierarchyElementRaw(DiagLayerRaw):
     """This is the base class for diagnostic layers that may be involved in value inheritance
 

--- a/odxtools/diaglayers/protocol.py
+++ b/odxtools/diaglayers/protocol.py
@@ -12,7 +12,7 @@ from .hierarchyelement import HierarchyElement
 from .protocolraw import ProtocolRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Protocol(HierarchyElement):
     """This is the class for primitives that are common for a given communication protocol
 

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -14,7 +14,7 @@ from ..utils import dataclass_fields_asdict
 from .hierarchyelementraw import HierarchyElementRaw
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ProtocolRaw(HierarchyElementRaw):
     """This is the base class for diagnostic layers that describe a
     protocol which can be used to communicate with an ECU

--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -13,7 +13,7 @@ from .text import Text
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagnosticTroubleCode(IdentifiableElement):
     trouble_code: int
     display_trouble_code: str | None

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -20,7 +20,7 @@ from .transmode import TransMode
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagService(DiagComm):
     """Representation of a diagnostic service description.
     """

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -28,7 +28,7 @@ class HasDiagVariables(typing.Protocol):
         ...
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DiagVariable(IdentifiableElement):
     """Representation of a diagnostic variable
     """

--- a/odxtools/docrevision.py
+++ b/odxtools/docrevision.py
@@ -11,7 +11,7 @@ from .snrefcontext import SnRefContext
 from .teammember import TeamMember
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DocRevision:
     """
     Representation of a single revision of the relevant object.

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -14,7 +14,7 @@ from .specialdatagroup import SpecialDataGroup
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DopBase(IdentifiableElement):
     """Base class for all (simple and complex) data object properties.
 

--- a/odxtools/dtcconnector.py
+++ b/odxtools/dtcconnector.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DtcConnector(NamedElement):
     dtc_dop_ref: OdxLinkRef
     dtc_snref: str

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -23,7 +23,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DtcDop(DopBase):
     """A DOP describing a diagnostic trouble code"""
 

--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -18,7 +18,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DynamicEndmarkerField(Field):
     """Array of a structure with variable length determined by a termination sequence"""
 

--- a/odxtools/dynamiclengthfield.py
+++ b/odxtools/dynamiclengthfield.py
@@ -17,7 +17,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DynamicLengthField(Field):
     """Array of structure with length field"""
     offset: int

--- a/odxtools/dyndefinedspec.py
+++ b/odxtools/dyndefinedspec.py
@@ -8,7 +8,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DynDefinedSpec:
     dyn_id_def_mode_infos: list[DynIdDefModeInfo]
 

--- a/odxtools/dynenddopref.py
+++ b/odxtools/dynenddopref.py
@@ -8,7 +8,7 @@ from .odxlink import OdxDocFragment, OdxLinkRef
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DynEndDopRef(OdxLinkRef):
     termination_value_raw: str
 

--- a/odxtools/dyniddefmodeinfo.py
+++ b/odxtools/dyniddefmodeinfo.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 from .table import Table
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DynIdDefModeInfo:
     def_mode: str
 

--- a/odxtools/ecuvariantpattern.py
+++ b/odxtools/ecuvariantpattern.py
@@ -11,7 +11,7 @@ from .odxlink import OdxDocFragment
 from .variantpattern import VariantPattern
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EcuVariantPattern(VariantPattern):
     """ECU variant patterns are variant patterns used to identify the
     concrete variant of an ECU.

--- a/odxtools/element.py
+++ b/odxtools/element.py
@@ -7,7 +7,7 @@ from .odxlink import OdxDocFragment, OdxLinkId
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class NamedElement:
     short_name: str
     long_name: str | None
@@ -23,7 +23,7 @@ class NamedElement:
         )
 
 
-@dataclass
+@dataclass(kw_only=True)
 class IdentifiableElement(NamedElement):
     odx_id: OdxLinkId
     oid: str | None

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -14,7 +14,7 @@ from .odxtypes import ParameterValue
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EndOfPduField(Field):
     """End of PDU fields are structures that are repeated until the end of the PDU"""
     max_number_of_items: int | None

--- a/odxtools/envdataconnector.py
+++ b/odxtools/envdataconnector.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EnvDataConnector(NamedElement):
     env_data_desc_ref: OdxLinkRef
     env_data_snref: str

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -8,7 +8,7 @@ from .odxlink import OdxDocFragment
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EnvironmentData(BasicStructure):
     """This class represents Environment Data that describes the
     circumstances in which the error occurred.

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -24,7 +24,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class EnvironmentDataDescription(ComplexDop):
     """This class represents environment data descriptions
 

--- a/odxtools/externalaccessmethod.py
+++ b/odxtools/externalaccessmethod.py
@@ -8,7 +8,7 @@ from .odxlink import OdxDocFragment
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ExternalAccessMethod(IdentifiableElement):
     method: str
 

--- a/odxtools/externaldoc.py
+++ b/odxtools/externaldoc.py
@@ -6,7 +6,7 @@ from .exceptions import odxrequire
 from .odxlink import OdxDocFragment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ExternalDoc:
     description: str | None
     href: str

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Field(ComplexDop):
     structure_ref: OdxLinkRef | None
     structure_snref: str | None

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -10,7 +10,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class FunctionalClass(IdentifiableElement):
     """
     Corresponds to FUNCT-CLASS.

--- a/odxtools/inputparam.py
+++ b/odxtools/inputparam.py
@@ -13,7 +13,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class InputParam(NamedElement):
     physical_default_value: str | None
     dop_base_ref: OdxLinkRef

--- a/odxtools/internalconstr.py
+++ b/odxtools/internalconstr.py
@@ -8,7 +8,7 @@ from .odxtypes import DataType
 from .scaleconstr import ScaleConstr
 
 
-@dataclass
+@dataclass(kw_only=True)
 class InternalConstr:
     """This class represents INTERNAL-CONSTR objects.
     """

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -13,7 +13,7 @@ from .odxtypes import AtomicOdxType, DataType
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class LeadingLengthInfoType(DiagCodedType):
     #: bit length of the length specifier field
     #:

--- a/odxtools/library.py
+++ b/odxtools/library.py
@@ -10,7 +10,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Library(IdentifiableElement):
     """
     A library defines a shared library used for single ECU jobs etc.

--- a/odxtools/linkeddtcdop.py
+++ b/odxtools/linkeddtcdop.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .dtcdop import DtcDop
 
 
-@dataclass
+@dataclass(kw_only=True)
 class LinkedDtcDop:
     not_inherited_dtc_snrefs: list[str]
     dtc_dop_ref: OdxLinkRef

--- a/odxtools/matchingbasevariantparameter.py
+++ b/odxtools/matchingbasevariantparameter.py
@@ -8,7 +8,7 @@ from .odxtypes import odxstr_to_bool
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MatchingBaseVariantParameter(MatchingParameter):
     """A description of a parameter used for base variant matching.
 

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -12,7 +12,7 @@ from .odxtypes import BytesTypes, ParameterValue, ParameterValueDict
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MatchingParameter:
     """According to ISO 22901, a MatchingParameter contains a string
     value identifying the active ECU or base variant. Moreover, it

--- a/odxtools/message.py
+++ b/odxtools/message.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .response import Response
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Message:
     """A diagnostic message with its interpretation.
 

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -16,7 +16,7 @@ from .termination import Termination
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MinMaxLengthType(DiagCodedType):
     max_length: int | None
     min_length: int

--- a/odxtools/modification.py
+++ b/odxtools/modification.py
@@ -8,7 +8,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Modification:
     change: str
     reason: str | None

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -19,7 +19,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Multiplexer(ComplexDop):
     """This class represents a Multiplexer (MUX)
 

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -13,7 +13,7 @@ from .structure import Structure
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MultiplexerCase(NamedElement):
     """This class represents a case which represents a range of keys of a multiplexer."""
 

--- a/odxtools/multiplexerdefaultcase.py
+++ b/odxtools/multiplexerdefaultcase.py
@@ -11,7 +11,7 @@ from .structure import Structure
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MultiplexerDefaultCase(NamedElement):
     """This class represents a Default Case, which is selected when there are no cases defined in the Multiplexer."""
     structure_ref: OdxLinkRef | None

--- a/odxtools/multiplexerswitchkey.py
+++ b/odxtools/multiplexerswitchkey.py
@@ -9,7 +9,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MultiplexerSwitchKey:
     """
     The object that determines the case to be used by a multiplexer

--- a/odxtools/negoutputparam.py
+++ b/odxtools/negoutputparam.py
@@ -11,7 +11,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class NegOutputParam(NamedElement):
     dop_base_ref: OdxLinkRef
 

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .database import Database
 
 
-@dataclass
+@dataclass(kw_only=True)
 class OdxCategory(IdentifiableElement):
     """This is the base class for all top-level container classes in ODX"""
 

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -13,7 +13,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class OutputParam(IdentifiableElement):
     dop_base_ref: OdxLinkRef
     semantic: str | None

--- a/odxtools/parameters/codedconstparameter.py
+++ b/odxtools/parameters/codedconstparameter.py
@@ -17,7 +17,7 @@ from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CodedConstParameter(Parameter):
 
     coded_value_raw: str

--- a/odxtools/parameters/dynamicparameter.py
+++ b/odxtools/parameters/dynamicparameter.py
@@ -12,7 +12,7 @@ from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DynamicParameter(Parameter):
 
     @property

--- a/odxtools/parameters/lengthkeyparameter.py
+++ b/odxtools/parameters/lengthkeyparameter.py
@@ -15,7 +15,7 @@ from .parameter import ParameterType
 from .parameterwithdop import ParameterWithDOP
 
 
-@dataclass
+@dataclass(kw_only=True)
 class LengthKeyParameter(ParameterWithDOP):
     """Length Keys specify the bit (!) length of another parameter.
 

--- a/odxtools/parameters/matchingrequestparameter.py
+++ b/odxtools/parameters/matchingrequestparameter.py
@@ -13,7 +13,7 @@ from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class MatchingRequestParameter(Parameter):
     request_byte_position: int
     byte_length: int

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -16,7 +16,7 @@ from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class NrcConstParameter(Parameter):
     """A parameter of type NRC-CONST defines a set of values to be
     matched for a negative response object to apply

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -30,7 +30,7 @@ ParameterType = Literal[
 ]
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Parameter(NamedElement):
     """This class corresponds to POSITIONABLE-PARAM in the ODX
     specification

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -19,7 +19,7 @@ from ..utils import dataclass_fields_asdict
 from .parameter import Parameter
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ParameterWithDOP(Parameter):
     dop_ref: OdxLinkRef | None
     dop_snref: str | None

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -17,7 +17,7 @@ from .parameter import ParameterType
 from .parameterwithdop import ParameterWithDOP
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PhysicalConstantParameter(ParameterWithDOP):
     physical_constant_value_raw: str
 

--- a/odxtools/parameters/reservedparameter.py
+++ b/odxtools/parameters/reservedparameter.py
@@ -13,7 +13,7 @@ from ..utils import dataclass_fields_asdict
 from .parameter import Parameter, ParameterType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ReservedParameter(Parameter):
     bit_length: int
 

--- a/odxtools/parameters/systemparameter.py
+++ b/odxtools/parameters/systemparameter.py
@@ -24,7 +24,7 @@ PREDEFINED_SYSPARAM_VALUES = [
 ]
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SystemParameter(ParameterWithDOP):
     sysparam: str
 

--- a/odxtools/parameters/tableentryparameter.py
+++ b/odxtools/parameters/tableentryparameter.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ..tablerow import TableRow
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TableEntryParameter(Parameter):
     target: RowFragment
     table_row_ref: OdxLinkRef

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ..tablerow import TableRow
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TableKeyParameter(Parameter):
 
     odx_id: OdxLinkId

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ..table import Table
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TableStructParameter(Parameter):
     table_key_ref: OdxLinkRef | None
     table_key_snref: str | None

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -16,7 +16,7 @@ from .parameter import ParameterType
 from .parameterwithdop import ParameterWithDOP
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ValueParameter(ParameterWithDOP):
     physical_default_value_raw: str | None
 

--- a/odxtools/paramlengthinfotype.py
+++ b/odxtools/paramlengthinfotype.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .parameters.lengthkeyparameter import LengthKeyParameter
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ParamLengthInfoType(DiagCodedType):
     length_key_ref: OdxLinkRef
 

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .diaglayers.diaglayer import DiagLayer
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ParentRef:
     layer_ref: OdxLinkRef
     not_inherited_diag_comms: list[str]  # short_name references

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PhysicalDimension(IdentifiableElement):
     """A physical dimension is a formal definition of a unit.
 

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -8,7 +8,7 @@ from .odxtypes import DataType
 from .radix import Radix
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PhysicalType:
     """The physical type describes the base data type of a parameter.
 

--- a/odxtools/posresponsesuppressible.py
+++ b/odxtools/posresponsesuppressible.py
@@ -9,7 +9,7 @@ from .utils import read_hex_binary
 
 # note that the spec has a typo here: it calls the corresponding
 # XML tag POS-RESPONSE-SUPPRESSABLE...
-@dataclass
+@dataclass(kw_only=True)
 class PosResponseSuppressible:
     bit_mask: int
 

--- a/odxtools/preconditionstateref.py
+++ b/odxtools/preconditionstateref.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .statemachine import StateMachine
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PreConditionStateRef(OdxLinkRef):
     """
     This class represents the PRE-CONDITION-STATE-REF XML tag.

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -10,7 +10,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ProgCode:
     """A reference to code that is executed by a single ECU job"""
     code_file: str

--- a/odxtools/protstack.py
+++ b/odxtools/protstack.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ProtStack(IdentifiableElement):
     # mandatory in ODX 2.2, but non existent in ODX 2.0
     pdu_protocol_type: str

--- a/odxtools/relateddiagcommref.py
+++ b/odxtools/relateddiagcommref.py
@@ -7,7 +7,7 @@ from .odxlink import OdxDocFragment, OdxLinkRef
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RelatedDiagCommRef(OdxLinkRef):
     relation_type: str
 

--- a/odxtools/relateddoc.py
+++ b/odxtools/relateddoc.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .xdoc import XDoc
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RelatedDoc:
     xdoc: XDoc | None
     description: Description | None

--- a/odxtools/request.py
+++ b/odxtools/request.py
@@ -23,7 +23,7 @@ from .specialdatagroup import SpecialDataGroup
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Request(IdentifiableElement):
     """Represents all information related to an UDS request
 

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -30,7 +30,7 @@ class ResponseType(Enum):
     GLOBAL_NEGATIVE = "GLOBAL-NEG-RESPONSE"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Response(IdentifiableElement):
     """Represents all information related to an UDS response
 

--- a/odxtools/scaleconstr.py
+++ b/odxtools/scaleconstr.py
@@ -10,7 +10,7 @@ from .odxtypes import DataType
 from .validtype import ValidType
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ScaleConstr:
     """This class represents a SCALE-CONSTR.
     """

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -14,7 +14,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SingleEcuJob(DiagComm):
     """A single ECU job is a diagnostic communication primitive.
 

--- a/odxtools/snrefcontext.py
+++ b/odxtools/snrefcontext.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .statechart import StateChart
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SnRefContext:
     """Represents the context for which a short name reference ought
     to be resolved

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -7,7 +7,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SpecialData:
     """This corresponds to the SD XML tag"""
     semantic_info: str | None  # the "SI" attribute

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -9,7 +9,7 @@ from .specialdata import SpecialData
 from .specialdatagroupcaption import SpecialDataGroupCaption
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SpecialDataGroup:
     """This corresponds to the SDG XML tag"""
     sdg_caption: SpecialDataGroupCaption | None

--- a/odxtools/specialdatagroupcaption.py
+++ b/odxtools/specialdatagroupcaption.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SpecialDataGroupCaption(IdentifiableElement):
 
     @staticmethod

--- a/odxtools/state.py
+++ b/odxtools/state.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class State(IdentifiableElement):
     """
     Corresponds to STATE.

--- a/odxtools/statechart.py
+++ b/odxtools/statechart.py
@@ -13,7 +13,7 @@ from .statetransition import StateTransition
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class StateChart(IdentifiableElement):
     """
     Corresponds to STATE-CHART.

--- a/odxtools/statemachine.py
+++ b/odxtools/statemachine.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .diagservice import DiagService
 
 
-@dataclass
+@dataclass(kw_only=True)
 class StateMachine:
     """Objects of this class represent the runtime state of a state chart
 

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -12,7 +12,7 @@ from .state import State
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class StateTransition(IdentifiableElement):
     """
     Corresponds to STATE-TRANSITION.

--- a/odxtools/statetransitionref.py
+++ b/odxtools/statetransitionref.py
@@ -146,7 +146,7 @@ def _check_applies(ref: Union["StateTransitionRef",
     return True
 
 
-@dataclass
+@dataclass(kw_only=True)
 class StateTransitionRef(OdxLinkRef):
     """Describes a state transition that is to be potentially taken if
     a diagnostic communication is executed

--- a/odxtools/staticfield.py
+++ b/odxtools/staticfield.py
@@ -16,7 +16,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class StaticField(Field):
     """Array of a fixed number of structure objects"""
     fixed_number_of_items: int

--- a/odxtools/structure.py
+++ b/odxtools/structure.py
@@ -8,7 +8,7 @@ from .odxtypes import odxstr_to_bool
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Structure(BasicStructure):
     is_visible_raw: bool | None
 

--- a/odxtools/subcomponent.py
+++ b/odxtools/subcomponent.py
@@ -15,7 +15,7 @@ from .tablerowconnector import TableRowConnector
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SubComponent(IdentifiableElement):
     """Sub-components describe collections of related diagnostic variables
 

--- a/odxtools/subcomponentparamconnector.py
+++ b/odxtools/subcomponentparamconnector.py
@@ -13,7 +13,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SubComponentParamConnector(IdentifiableElement):
     diag_comm_snref: str
 

--- a/odxtools/subcomponentpattern.py
+++ b/odxtools/subcomponentpattern.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .matchingparameter import MatchingParameter
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SubComponentPattern:
     matching_parameters: list["MatchingParameter"]
 

--- a/odxtools/swvariable.py
+++ b/odxtools/swvariable.py
@@ -7,7 +7,7 @@ from .odxlink import OdxDocFragment
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SwVariable(NamedElement):
     origin: str | None
     oid: str | None

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -16,7 +16,7 @@ from .tablerow import TableRow
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Table(IdentifiableElement):
     """This class represents a TABLE."""
     key_label: str | None

--- a/odxtools/tablediagcommconnector.py
+++ b/odxtools/tablediagcommconnector.py
@@ -9,7 +9,7 @@ from .odxlink import OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef, res
 from .snrefcontext import SnRefContext
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TableDiagCommConnector:
     semantic: str
 

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from .table import Table
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TableRow(IdentifiableElement):
     """This class represents a TABLE-ROW."""
     table_ref: OdxLinkRef

--- a/odxtools/tablerowconnector.py
+++ b/odxtools/tablerowconnector.py
@@ -12,7 +12,7 @@ from .tablerow import TableRow
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TableRowConnector(NamedElement):
     table_ref: OdxLinkRef
     table_row_snref: str

--- a/odxtools/teammember.py
+++ b/odxtools/teammember.py
@@ -10,7 +10,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TeamMember(IdentifiableElement):
     roles: list[str]
     department: str | None

--- a/odxtools/text.py
+++ b/odxtools/text.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 from .odxlink import OdxDocFragment
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Text:
     text: str
     text_identifier: str | None

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -11,7 +11,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Unit(IdentifiableElement):
     """
     A unit consists of an ID, short name and a display name.

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -13,7 +13,7 @@ from .unitgroupcategory import UnitGroupCategory
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class UnitGroup(NamedElement):
     """A group of units.
 

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -13,7 +13,7 @@ from .unit import Unit
 from .unitgroup import UnitGroup
 
 
-@dataclass
+@dataclass(kw_only=True)
 class UnitSpec:
     """
     A unit spec encapsulates three lists:

--- a/odxtools/variablegroup.py
+++ b/odxtools/variablegroup.py
@@ -21,7 +21,7 @@ class HasVariableGroups(typing.Protocol):
         ...
 
 
-@dataclass
+@dataclass(kw_only=True)
 class VariableGroup(IdentifiableElement):
 
     @staticmethod

--- a/odxtools/variantpattern.py
+++ b/odxtools/variantpattern.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .matchingparameter import MatchingParameter
 
 
-@dataclass
+@dataclass(kw_only=True)
 class VariantPattern:
     """Variant patterns are used to identify the concrete variant of an ECU
 

--- a/odxtools/xdoc.py
+++ b/odxtools/xdoc.py
@@ -9,7 +9,7 @@ from .snrefcontext import SnRefContext
 from .utils import dataclass_fields_asdict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class XDoc(NamedElement):
     number: str | None
     state: str | None

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -880,10 +880,8 @@ class TestEncodeRequest(unittest.TestCase):
             oid=None,
             short_name="dtcdop_sn",
             long_name=None,
-            description=Description(
-                "DOP containing all possible diagnostic trouble codes",
-                external_docs=[],
-                text_identifier=None),
+            description=Description.from_string(
+                "DOP containing all possible diagnostic trouble codes"),
             admin_data=None,
             sdgs=[],
             diag_coded_type=dtc_dct,
@@ -1056,8 +1054,7 @@ class TestEncodeRequest(unittest.TestCase):
             oid=None,
             short_name="dtc_info",
             long_name=None,
-            description=Description(
-                "Supplemental info why the error happened", external_docs=[], text_identifier=None),
+            description=Description.from_string("Supplemental info why the error happened"),
             semantic=None,
             dop_ref=OdxLinkRef.from_id(env_data_desc.odx_id),
             dop_snref=None,

--- a/tests/test_singleecujob.py
+++ b/tests/test_singleecujob.py
@@ -103,7 +103,7 @@ class TestSingleEcuJob(unittest.TestCase):
                     compu_internal_to_phys=CompuInternalToPhys(
                         compu_scales=[
                             CompuScale(
-                                "yes",
+                                short_label="yes",
                                 lower_limit=Limit(
                                     value_raw="0", value_type=DataType.A_INT32, interval_type=None),
                                 compu_const=CompuConst(
@@ -116,7 +116,7 @@ class TestSingleEcuJob(unittest.TestCase):
                                 range_type=DataType.A_UNICODE2STRING,
                             ),
                             CompuScale(
-                                "no",
+                                short_label="no",
                                 lower_limit=Limit(
                                     value_raw="1", value_type=DataType.A_INT32, interval_type=None),
                                 compu_const=CompuConst(


### PR DESCRIPTION
This finally allows to use inheritance in conjunction defaulted fields. (This will be done in a future PR.)

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
