### PR TITLE
ruff: disable deprecated UP038 check

### DIFF
--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -214,7 +214,7 @@ def extract_parameter_tabulation_data(parameters: list[Parameter]) -> RichTable:
             value_column.append(str(param.coded_values))
             value_type_column.append('coded values')
             dop_column.append("")
-        elif isinstance(param, PhysicalConstantParameter | SystemParameter | ValueParameter):
+        elif isinstance(param, (PhysicalConstantParameter, SystemParameter, ValueParameter)):
             # this is a hack to make this routine work for parameters
             # which reference DOPs of a type that a is not yet
             # internalized. (all parameter objects of the tested types

--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -370,7 +370,7 @@ def browse(odxdb: Database) -> None:
 
             codec = answer.get("message_type")
             if codec is not None:
-                assert isinstance(codec, Request | Response)
+                assert isinstance(codec, (Request, Response))
                 table = extract_parameter_tabulation_data(codec.parameters)
                 print(table)
 

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -61,7 +61,7 @@ def print_summary(odxdb: Database,
 
         all_services: list[DiagComm] = sorted(dl.services, key=lambda x: x.short_name)
 
-        if isinstance(dl, BaseVariant | EcuVariant):
+        if isinstance(dl, (BaseVariant, EcuVariant)):
             for proto in dl.protocols:
                 if (can_rx_id := dl.get_can_receive_id(proto.short_name)) is not None:
                     rich.print(

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -133,7 +133,7 @@ class ComparamInstance:
             return None
 
         result = value_list[idx]
-        if result is None and isinstance(subparam, Comparam | ComplexComparam):
+        if result is None and isinstance(subparam, (Comparam, ComplexComparam)):
             result = subparam.physical_default_value
         if not isinstance(result, str):
             odxraise()

--- a/odxtools/compositecodec.py
+++ b/odxtools/compositecodec.py
@@ -84,7 +84,7 @@ def composite_codec_get_coded_const_prefix(codec: CompositeCodec,
 
     for param in codec.parameters:
         if (isinstance(param, MatchingRequestParameter) and param.request_byte_position < len(request_prefix)) or \
-            isinstance(param, CodedConstParameter|PhysicalConstantParameter) :
+            isinstance(param, (CodedConstParameter, PhysicalConstantParameter)):
             param.encode_into_pdu(physical_value=None, encode_state=encode_state)
         else:
             break
@@ -132,7 +132,7 @@ def composite_codec_encode_into_pdu(codec: CompositeCodec, physical_value: Param
             # the ODX is located last in the PDU...
             encode_state.is_end_of_pdu = orig_is_end_of_pdu
 
-        if isinstance(param, LengthKeyParameter | TableKeyParameter):
+        if isinstance(param, (LengthKeyParameter, TableKeyParameter)):
             # At this point, we encode a placeholder value for length-
             # and table keys, since these can be specified
             # implicitly (i.e., by means of parameters that use
@@ -159,7 +159,7 @@ def composite_codec_encode_into_pdu(codec: CompositeCodec, physical_value: Param
     # because we allow these to be defined implicitly (i.e. they
     # are defined by their respective users)
     for param in codec.parameters:
-        if not isinstance(param, LengthKeyParameter | TableKeyParameter):
+        if not isinstance(param, (LengthKeyParameter, TableKeyParameter)):
             # the current parameter is neither a length- nor a table key
             continue
 

--- a/odxtools/compumethods/linearsegment.py
+++ b/odxtools/compumethods/linearsegment.py
@@ -54,7 +54,7 @@ class LinearSegment:
         inverse_value: int | float = 0
         if scale.compu_inverse_value is not None:
             x = odxrequire(scale.compu_inverse_value).value
-            if not isinstance(x, int | float):
+            if not isinstance(x, (int, float)):
                 odxraise(f"Non-numeric COMPU-INVERSE-VALUE specified ({x!r})")
             inverse_value = x
 
@@ -75,7 +75,7 @@ class LinearSegment:
         self.__compute_physical_limits()
 
     def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> float | int:
-        if not isinstance(internal_value, int | float):
+        if not isinstance(internal_value, (int, float)):
             odxraise(f"Internal values of linear compumethods must "
                      f"either be int or float (is: {type(internal_value).__name__})")
 
@@ -90,7 +90,7 @@ class LinearSegment:
         return result
 
     def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> float | int:
-        if not isinstance(physical_value, int | float):
+        if not isinstance(physical_value, (int, float)):
             odxraise(f"Physical values of linear compumethods must "
                      f"either be int or float (is: {type(physical_value).__name__})")
 
@@ -151,7 +151,7 @@ class LinearSegment:
         # Do type checks
         expected_type = self.physical_type.python_type
         if issubclass(expected_type, float):
-            if not isinstance(physical_value, int | float):
+            if not isinstance(physical_value, (int, float)):
                 return False
         else:
             if not isinstance(physical_value, expected_type):
@@ -172,7 +172,7 @@ class LinearSegment:
         # Do type checks
         expected_type = self.internal_type.python_type
         if issubclass(expected_type, float):
-            if not isinstance(internal_value, int | float):
+            if not isinstance(internal_value, (int, float)):
                 return False
         else:
             if not isinstance(internal_value, expected_type):

--- a/odxtools/compumethods/ratfuncsegment.py
+++ b/odxtools/compumethods/ratfuncsegment.py
@@ -39,7 +39,7 @@ class RatFuncSegment:
             value_type=scale.range_type)
 
     def convert(self, value: AtomicOdxType) -> float | int:
-        if not isinstance(value, int | float):
+        if not isinstance(value, (int, float)):
             odxraise(f"Internal values of linear compumethods must "
                      f"either be int or float (is: {type(value).__name__})")
 
@@ -69,7 +69,7 @@ class RatFuncSegment:
         # Do type checks
         expected_type = self.value_type.python_type
         if issubclass(expected_type, float):
-            if not isinstance(value, int | float):
+            if not isinstance(value, (int, float)):
                 return False
         else:
             if not isinstance(value, expected_type):

--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -100,7 +100,7 @@ class ScaleLinearCompuMethod(CompuMethod):
                 self._is_invertible = False
                 break
 
-            if not isinstance(x, int | float):
+            if not isinstance(x, (int, float)):
                 odxraise("Linear segments must use int or float for all quantities")
 
             # the respective function value at the interval's

--- a/odxtools/compumethods/tabintpcompumethod.py
+++ b/odxtools/compumethods/tabintpcompumethod.py
@@ -79,10 +79,10 @@ class TabIntpCompuMethod(CompuMethod):
             internal_point = odxrequire(scale.lower_limit).value
             physical_point = odxrequire(scale.compu_const).value
 
-            if not isinstance(internal_point, float | int):
+            if not isinstance(internal_point, (float, int)):
                 odxraise("The type of values of tab-intp compumethods must "
                          "either int or float")
-            if not isinstance(physical_point, float | int):
+            if not isinstance(physical_point, (float, int)):
                 odxraise("The type of values of tab-intp compumethods must "
                          "either int or float")
 
@@ -140,13 +140,13 @@ class TabIntpCompuMethod(CompuMethod):
         return None
 
     def convert_physical_to_internal(self, physical_value: AtomicOdxType) -> AtomicOdxType:
-        if not isinstance(physical_value, int | float):
+        if not isinstance(physical_value, (int, float)):
             odxraise("The type of values of tab-intp compumethods must "
                      "either int or float", EncodeError)
             return None
 
         odxassert(
-            isinstance(physical_value, int | float),
+            isinstance(physical_value, (int, float)),
             "Only integers and floats can be piecewise linearly interpolated", EncodeError)
         result = self.__piecewise_linear_interpolate(physical_value, self._physical_points,
                                                      self._internal_points)
@@ -161,14 +161,14 @@ class TabIntpCompuMethod(CompuMethod):
         return res
 
     def convert_internal_to_physical(self, internal_value: AtomicOdxType) -> AtomicOdxType:
-        if not isinstance(internal_value, int | float):
+        if not isinstance(internal_value, (int, float)):
             odxraise(
                 "The internal type of values of tab-intp compumethods must "
                 "either int or float", EncodeError)
             return None
 
         odxassert(
-            isinstance(internal_value, int | float),
+            isinstance(internal_value, (int, float)),
             "Only integers and floats can be piecewise linearly interpolated", DecodeError)
 
         result = self.__piecewise_linear_interpolate(internal_value, self._internal_points,
@@ -185,14 +185,14 @@ class TabIntpCompuMethod(CompuMethod):
         return res
 
     def is_valid_physical_value(self, physical_value: AtomicOdxType) -> bool:
-        if not isinstance(physical_value, int | float):
+        if not isinstance(physical_value, (int, float)):
             return False
 
         return min(self.physical_points) <= physical_value and physical_value <= max(
             self.physical_points)
 
     def is_valid_internal_value(self, internal_value: AtomicOdxType) -> bool:
-        if not isinstance(internal_value, int | float):
+        if not isinstance(internal_value, (int, float)):
             return False
 
         return min(self.internal_points) <= internal_value and internal_value <= max(

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -118,7 +118,7 @@ class DataObjectProperty(DopBase):
                 f"The value {repr(physical_value)} of type {type(physical_value).__name__}"
                 f" is not a valid.")
 
-        if not isinstance(physical_value, int | float | str | BytesTypes):
+        if not isinstance(physical_value, (int, float, str, BytesTypes)):
             odxraise(f"Invalid type '{type(physical_value).__name__}' for physical value. "
                      f"(Expect atomic type!)")
         internal_value = self.compu_method.convert_physical_to_internal(physical_value)

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -207,7 +207,7 @@ class EnvironmentDataDescription(ComplexDop):
                                           param_value: ParameterValue | None) -> int:
         if isinstance(param, ParameterWithDOP):
             dop = param.dop
-            if not isinstance(dop, DataObjectProperty | DtcDop):
+            if not isinstance(dop, (DataObjectProperty, DtcDop)):
                 odxraise(f"The DOP of the parameter referenced by environment data descriptions "
                          f"must use either be DataObjectProperty or a DtcDop (encountered "
                          f"{type(param).__name__} for parameter '{param.short_name}' "

--- a/odxtools/leadinglengthinfotype.py
+++ b/odxtools/leadinglengthinfotype.py
@@ -52,7 +52,7 @@ class LeadingLengthInfoType(DiagCodedType):
     @override
     def encode_into_pdu(self, internal_value: AtomicOdxType, encode_state: EncodeState) -> None:
 
-        if not isinstance(internal_value, str | bytes):
+        if not isinstance(internal_value, (str, bytes)):
             odxraise(
                 f"LEADING-LENGTH-INFO types can only be used for strings and byte fields, "
                 f"not {type(internal_value).__name__}", EncodeError)

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -77,7 +77,7 @@ class MinMaxLengthType(DiagCodedType):
     @override
     def encode_into_pdu(self, internal_value: AtomicOdxType, encode_state: EncodeState) -> None:
 
-        if not isinstance(internal_value, str | BytesTypes):
+        if not isinstance(internal_value, (str, BytesTypes)):
             odxraise("MinMaxLengthType is currently only implemented for strings and byte arrays",
                      EncodeError)
 

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -142,7 +142,7 @@ class ItemAttributeList(list[T]):
         ...
 
     def __getitem__(self, key: SupportsIndex | str | slice) -> T | list[T]:
-        if isinstance(key, SupportsIndex | slice):
+        if isinstance(key, (SupportsIndex, slice)):
             return super().__getitem__(key)
         else:
             return self._item_dict[key]

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -109,8 +109,8 @@ def compare_odx_values(a: AtomicOdxType, b: AtomicOdxType) -> int:
     # specification. (cf section 7.3.6.5)
 
     # numeric values are compared numerically (duh!)
-    if isinstance(a, int | float):
-        if not isinstance(b, int | float):
+    if isinstance(a, (int, float)):
+        if not isinstance(b, (int, float)):
             odxraise()
 
         tmp = a - b
@@ -239,7 +239,7 @@ class DataType(Enum):
         expected_type = self.python_type
         if isinstance(value, expected_type):
             return True
-        elif expected_type is float and isinstance(value, int | float):
+        elif expected_type is float and isinstance(value, (int, float)):
             return True
         elif self == DataType.A_BYTEFIELD and isinstance(value, BytesTypes):
             return True

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -78,7 +78,7 @@ class ParameterWithDOP(Parameter):
 
     @property
     def physical_type(self) -> PhysicalType | None:
-        if isinstance(self.dop, DataObjectProperty | DtcDop):
+        if isinstance(self.dop, (DataObjectProperty, DtcDop)):
             return self.dop.physical_type
         else:
             return None

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -89,7 +89,7 @@ class TableStructParameter(Parameter):
     def _encode_positioned_into_pdu(self, physical_value: ParameterValue | None,
                                     encode_state: EncodeState) -> None:
 
-        if not isinstance(physical_value, tuple|list) or \
+        if not isinstance(physical_value, (tuple, list)) or \
            len(physical_value) != 2 or \
            not isinstance(physical_value[0], str):
             odxraise(

--- a/odxtools/statemachine.py
+++ b/odxtools/statemachine.py
@@ -160,7 +160,7 @@ class StateMachine:
 
         if raw_resp is None:
             raise RuntimeError("The calling code must send back a reply")
-        elif isinstance(raw_resp, bytes | bytearray):
+        elif isinstance(raw_resp, (bytes, bytearray)):
             for decoded_resp_msg in self.diag_layer.decode_response(raw_resp, raw_req):
                 for stransref in service.state_transition_refs:
                     # we only execute the first applicable state

--- a/odxtools/statetransitionref.py
+++ b/odxtools/statetransitionref.py
@@ -108,13 +108,13 @@ def _check_applies(ref: Union["StateTransitionRef",
         return False
     elif not isinstance(
             param,
-            CodedConstParameter | PhysicalConstantParameter | TableKeyParameter | ValueParameter):
+        (CodedConstParameter, PhysicalConstantParameter, TableKeyParameter, ValueParameter)):
         # see checker rule 194 in section B.2 of the spec
         odxraise(f"Parameter referenced by state transition ref is of "
                  f"invalid type {type(param).__name__}")
         return False
-    elif isinstance(param, CodedConstParameter | PhysicalConstantParameter
-                    | TableKeyParameter) and ref.value is not None:
+    elif isinstance(param, (CodedConstParameter, PhysicalConstantParameter,
+                            TableKeyParameter)) and ref.value is not None:
         # see checker rule 193 in section B.2 of the spec. Why can
         # no values for constant parameters be specified? (This
         # seems to be rather inconvenient...)

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -199,7 +199,7 @@ class TableRow(IdentifiableElement):
 
         if self.dop_ref is not None:
             self._dop = odxlinks.resolve(self.dop_ref)
-            if not isinstance(self._dop, DataObjectProperty | DtcDop):
+            if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
                 odxraise("The DOP-REF of TABLE-ROWs must reference a simple DOP!")
         if self.structure_ref is not None:
             self._structure = odxlinks.resolve(self.structure_ref, Structure)
@@ -243,7 +243,7 @@ class TableRow(IdentifiableElement):
             self._structure = resolve_snref(self.structure_snref, ddd_spec.structures, Structure)
         if self.dop_snref is not None:
             self._dop = resolve_snref(self.dop_snref, ddd_spec.data_object_props)
-            if not isinstance(self._dop, DataObjectProperty | DtcDop):
+            if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
                 odxraise("The DOP-SNREF of TABLE-ROWs must reference a simple DOP!")
 
         if self.audience is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ lint.select = [
 lint.ignore = [
     "E501",  # line too long
     "F541",  # f-string-missing-placeholders
+    "UP038",  # non-pep604-isinstance (deprecated)
 ]
 
 exclude = [


### PR DESCRIPTION
This check mandates to pass a union type to `isinstance()` and is [deprecated](https://docs.astral.sh/ruff/rules/non-pep604-isinstance/). This PR is basically a spin-off of #405. All good things about this patch are @zariiii9003's, whilst all bugs are mine.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
