### PR TITLE
Specify defaults for all optional dataclass fields

### DIFF
--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 from xml.etree import ElementTree
 
@@ -13,8 +13,8 @@ from .snrefcontext import SnRefContext
 @dataclass(kw_only=True)
 class AdminData:
     language: str | None = None
-    company_doc_infos: list[CompanyDocInfo]
-    doc_revisions: list[DocRevision]
+    company_doc_infos: list[CompanyDocInfo] = field(default_factory=list)
+    doc_revisions: list[DocRevision] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element | None,

--- a/odxtools/admindata.py
+++ b/odxtools/admindata.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 
 @dataclass(kw_only=True)
 class AdminData:
-    language: str | None
+    language: str | None = None
     company_doc_infos: list[CompanyDocInfo]
     doc_revisions: list[DocRevision]
 

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -16,11 +16,11 @@ class Audience:
     enabled_audience_refs: list[OdxLinkRef]
     disabled_audience_refs: list[OdxLinkRef]
 
-    is_supplier_raw: bool | None
-    is_development_raw: bool | None
-    is_manufacturing_raw: bool | None
-    is_aftersales_raw: bool | None
-    is_aftermarket_raw: bool | None
+    is_supplier_raw: bool | None = None
+    is_development_raw: bool | None = None
+    is_manufacturing_raw: bool | None = None
+    is_aftersales_raw: bool | None = None
+    is_aftermarket_raw: bool | None = None
 
     @property
     def is_supplier(self) -> bool:

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -13,8 +13,8 @@ from .snrefcontext import SnRefContext
 
 @dataclass(kw_only=True)
 class Audience:
-    enabled_audience_refs: list[OdxLinkRef]
-    disabled_audience_refs: list[OdxLinkRef]
+    enabled_audience_refs: list[OdxLinkRef] = field(default_factory=list)
+    disabled_audience_refs: list[OdxLinkRef] = field(default_factory=list)
 
     is_supplier_raw: bool | None = None
     is_development_raw: bool | None = None

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -17,7 +17,7 @@ from .utils import dataclass_fields_asdict
 class BaseComparam(IdentifiableElement):
     param_class: str
     cptype: StandardizationLevel
-    display_level: int | None
+    display_level: int | None = None
     cpusage: Usage | None  # Required in ODX 2.2, missing in ODX 2.0
 
     @staticmethod

--- a/odxtools/basecomparam.py
+++ b/odxtools/basecomparam.py
@@ -18,7 +18,7 @@ class BaseComparam(IdentifiableElement):
     param_class: str
     cptype: StandardizationLevel
     display_level: int | None = None
-    cpusage: Usage | None  # Required in ODX 2.2, missing in ODX 2.0
+    cpusage: Usage | None = None  # Required in ODX 2.2, missing in ODX 2.0
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BaseComparam":

--- a/odxtools/basevariantpattern.py
+++ b/odxtools/basevariantpattern.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -16,7 +16,8 @@ class BaseVariantPattern(VariantPattern):
     """Base variant patterns are variant patterns used to identify the
     base variant of an ECU.
     """
-    matching_base_variant_parameters: list[MatchingBaseVariantParameter]
+    matching_base_variant_parameters: list[MatchingBaseVariantParameter] = field(
+        default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "BaseVariantPattern":

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -31,7 +31,7 @@ class BasicStructure(ComplexDop):
     data objects. All structure-like objects adhere to the
     `CompositeCodec` type protocol.
     """
-    byte_size: int | None
+    byte_size: int | None = None
     parameters: NamedItemList[Parameter]
 
     @property

--- a/odxtools/basicstructure.py
+++ b/odxtools/basicstructure.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -32,7 +32,7 @@ class BasicStructure(ComplexDop):
     `CompositeCodec` type protocol.
     """
     byte_size: int | None = None
-    parameters: NamedItemList[Parameter]
+    parameters: NamedItemList[Parameter] = field(default_factory=NamedItemList)
 
     @property
     def required_parameters(self) -> list[Parameter]:

--- a/odxtools/commrelation.py
+++ b/odxtools/commrelation.py
@@ -17,15 +17,15 @@ from .snrefcontext import SnRefContext
 
 @dataclass(kw_only=True)
 class CommRelation:
-    description: Description | None
+    description: Description | None = None
     relation_type: str
-    diag_comm_ref: OdxLinkRef | None
-    diag_comm_snref: str | None
-    in_param_if_snref: str | None
-    #in_param_if_snpathref: Optional[str] # TODO
-    out_param_if_snref: str | None
-    #out_param_if_snpathref: Optional[str] # TODO
-    value_type_raw: CommRelationValueType | None
+    diag_comm_ref: OdxLinkRef | None = None
+    diag_comm_snref: str | None = None
+    in_param_if_snref: str | None = None
+    #in_param_if_snpathref: Optional[str] = None # TODO
+    out_param_if_snref: str | None = None
+    #out_param_if_snpathref: Optional[str] = None # TODO
+    value_type_raw: CommRelationValueType | None = None
 
     @property
     def diag_comm(self) -> DiagComm:

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -17,7 +17,7 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class CompanyData(IdentifiableElement):
     roles: list[str]
-    team_members: NamedItemList[TeamMember]
+    team_members: NamedItemList[TeamMember] = field(default_factory=NamedItemList)
     company_specific_info: CompanySpecificInfo | None = None
 
     @staticmethod

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -16,7 +16,7 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class CompanyData(IdentifiableElement):
-    roles: list[str]
+    roles: list[str] = field(default_factory=list)
     team_members: NamedItemList[TeamMember] = field(default_factory=NamedItemList)
     company_specific_info: CompanySpecificInfo | None = None
 

--- a/odxtools/companydata.py
+++ b/odxtools/companydata.py
@@ -18,7 +18,7 @@ from .utils import dataclass_fields_asdict
 class CompanyData(IdentifiableElement):
     roles: list[str]
     team_members: NamedItemList[TeamMember]
-    company_specific_info: CompanySpecificInfo | None
+    company_specific_info: CompanySpecificInfo | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CompanyData":

--- a/odxtools/companydocinfo.py
+++ b/odxtools/companydocinfo.py
@@ -15,8 +15,8 @@ from .teammember import TeamMember
 @dataclass(kw_only=True)
 class CompanyDocInfo:
     company_data_ref: OdxLinkRef
-    team_member_ref: OdxLinkRef | None
-    doc_label: str | None
+    team_member_ref: OdxLinkRef | None = None
+    doc_label: str | None = None
     sdgs: list[SpecialDataGroup]
 
     @property

--- a/odxtools/companydocinfo.py
+++ b/odxtools/companydocinfo.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -17,7 +17,7 @@ class CompanyDocInfo:
     company_data_ref: OdxLinkRef
     team_member_ref: OdxLinkRef | None = None
     doc_label: str | None = None
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @property
     def company_data(self) -> CompanyData:

--- a/odxtools/companyrevisioninfo.py
+++ b/odxtools/companyrevisioninfo.py
@@ -13,8 +13,8 @@ from .snrefcontext import SnRefContext
 @dataclass(kw_only=True)
 class CompanyRevisionInfo:
     company_data_ref: OdxLinkRef
-    revision_label: str | None
-    state: str | None
+    revision_label: str | None = None
+    state: str | None = None
 
     @property
     def company_data(self) -> CompanyData:

--- a/odxtools/companyspecificinfo.py
+++ b/odxtools/companyspecificinfo.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -12,8 +12,8 @@ from .specialdatagroup import SpecialDataGroup
 
 @dataclass(kw_only=True)
 class CompanySpecificInfo:
-    related_docs: list[RelatedDoc]
-    sdgs: list[SpecialDataGroup]
+    related_docs: list[RelatedDoc] = field(default_factory=list)
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "CompanySpecificInfo":

--- a/odxtools/comparaminstance.py
+++ b/odxtools/comparaminstance.py
@@ -22,9 +22,9 @@ class ComparamInstance:
     Be aware that the ODX specification calls this class COMPARAM-REF!
     """
     value: str | ComplexValue
-    description: Description | None
-    protocol_snref: str | None
-    prot_stack_snref: str | None
+    description: Description | None = None
+    protocol_snref: str | None = None
+    prot_stack_snref: str | None = None
     spec_ref: OdxLinkRef
 
     @property

--- a/odxtools/comparamspec.py
+++ b/odxtools/comparamspec.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @dataclass(kw_only=True)
 class ComparamSpec(OdxCategory):
 
-    prot_stacks: NamedItemList[ProtStack]
+    prot_stacks: NamedItemList[ProtStack] = field(default_factory=NamedItemList)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ComparamSpec":

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -23,7 +23,7 @@ class ComparamSubset(OdxCategory):
     comparams: NamedItemList[Comparam]
     complex_comparams: NamedItemList[ComplexComparam]
     data_object_props: NamedItemList[DataObjectProperty]
-    unit_spec: UnitSpec | None
+    unit_spec: UnitSpec | None = None
     category: str | None  # mandatory in ODX 2.2, but non-existent in ODX 2.0
 
     @staticmethod

--- a/odxtools/comparamsubset.py
+++ b/odxtools/comparamsubset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class ComparamSubset(OdxCategory):
-    comparams: NamedItemList[Comparam]
-    complex_comparams: NamedItemList[ComplexComparam]
-    data_object_props: NamedItemList[DataObjectProperty]
+    comparams: NamedItemList[Comparam] = field(default_factory=NamedItemList)
+    complex_comparams: NamedItemList[ComplexComparam] = field(default_factory=NamedItemList)
+    data_object_props: NamedItemList[DataObjectProperty] = field(default_factory=NamedItemList)
     unit_spec: UnitSpec | None = None
     category: str | None  # mandatory in ODX 2.2, but non-existent in ODX 2.0
 

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -27,8 +27,8 @@ def create_complex_value_from_et(et_element: ElementTree.Element) -> ComplexValu
 @dataclass(kw_only=True)
 class ComplexComparam(BaseComparam):
     subparams: NamedItemList[BaseComparam]
-    physical_default_value: ComplexValue | None
-    allow_multiple_values_raw: bool | None
+    physical_default_value: ComplexValue | None = None
+    allow_multiple_values_raw: bool | None = None
 
     @property
     def allow_multiple_values(self) -> bool:

--- a/odxtools/complexcomparam.py
+++ b/odxtools/complexcomparam.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Union
 from xml.etree import ElementTree
 
@@ -26,7 +26,7 @@ def create_complex_value_from_et(et_element: ElementTree.Element) -> ComplexValu
 
 @dataclass(kw_only=True)
 class ComplexComparam(BaseComparam):
-    subparams: NamedItemList[BaseComparam]
+    subparams: NamedItemList[BaseComparam] = field(default_factory=NamedItemList)
     physical_default_value: ComplexValue | None = None
     allow_multiple_values_raw: bool | None = None
 

--- a/odxtools/compumethods/compuconst.py
+++ b/odxtools/compumethods/compuconst.py
@@ -7,8 +7,8 @@ from ..odxtypes import AtomicOdxType, DataType
 
 @dataclass(kw_only=True)
 class CompuConst:
-    v: str | None
-    vt: str | None
+    v: str | None = None
+    vt: str | None = None
 
     data_type: DataType
 

--- a/odxtools/compumethods/compudefaultvalue.py
+++ b/odxtools/compumethods/compudefaultvalue.py
@@ -10,7 +10,7 @@ from .compuinversevalue import CompuInverseValue
 
 @dataclass(kw_only=True)
 class CompuDefaultValue(CompuConst):
-    compu_inverse_value: CompuInverseValue | None
+    compu_inverse_value: CompuInverseValue | None = None
 
     @staticmethod
     def compuvalue_from_et(et_element: ElementTree.Element, *,

--- a/odxtools/compumethods/compuinternaltophys.py
+++ b/odxtools/compumethods/compuinternaltophys.py
@@ -15,8 +15,8 @@ from .compuscale import CompuScale
 @dataclass(kw_only=True)
 class CompuInternalToPhys:
     compu_scales: list[CompuScale]
-    prog_code: ProgCode | None
-    compu_default_value: CompuDefaultValue | None
+    prog_code: ProgCode | None = None
+    compu_default_value: CompuDefaultValue | None = None
 
     @staticmethod
     def compu_internal_to_phys_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,

--- a/odxtools/compumethods/compuinternaltophys.py
+++ b/odxtools/compumethods/compuinternaltophys.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -14,7 +14,7 @@ from .compuscale import CompuScale
 
 @dataclass(kw_only=True)
 class CompuInternalToPhys:
-    compu_scales: list[CompuScale]
+    compu_scales: list[CompuScale] = field(default_factory=list)
     prog_code: ProgCode | None = None
     compu_default_value: CompuDefaultValue | None = None
 

--- a/odxtools/compumethods/compumethod.py
+++ b/odxtools/compumethods/compumethod.py
@@ -32,8 +32,8 @@ class CompuMethod:
     """
 
     category: CompuCategory
-    compu_internal_to_phys: CompuInternalToPhys | None
-    compu_phys_to_internal: CompuPhysToInternal | None
+    compu_internal_to_phys: CompuInternalToPhys | None = None
+    compu_phys_to_internal: CompuPhysToInternal | None = None
 
     physical_type: DataType
     internal_type: DataType

--- a/odxtools/compumethods/compuphystointernal.py
+++ b/odxtools/compumethods/compuphystointernal.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -14,7 +14,7 @@ from .compuscale import CompuScale
 
 @dataclass(kw_only=True)
 class CompuPhysToInternal:
-    compu_scales: list[CompuScale]
+    compu_scales: list[CompuScale] = field(default_factory=list)
     prog_code: ProgCode | None = None
     compu_default_value: CompuDefaultValue | None = None
 

--- a/odxtools/compumethods/compuphystointernal.py
+++ b/odxtools/compumethods/compuphystointernal.py
@@ -15,8 +15,8 @@ from .compuscale import CompuScale
 @dataclass(kw_only=True)
 class CompuPhysToInternal:
     compu_scales: list[CompuScale]
-    prog_code: ProgCode | None
-    compu_default_value: CompuDefaultValue | None
+    prog_code: ProgCode | None = None
+    compu_default_value: CompuDefaultValue | None = None
 
     @staticmethod
     def compu_phys_to_internal_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,

--- a/odxtools/compumethods/compurationalcoeffs.py
+++ b/odxtools/compumethods/compurationalcoeffs.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import cast
 from xml.etree import ElementTree
 
@@ -12,8 +12,8 @@ from ..odxtypes import DataType
 class CompuRationalCoeffs:
     value_type: DataType
 
-    numerators: list[int | float]
-    denominators: list[int | float]
+    numerators: list[int | float] = field(default_factory=list)
+    denominators: list[int | float] = field(default_factory=list)
 
     @staticmethod
     def coeffs_from_et(et_element: ElementTree.Element, context: OdxDocContext, *,

--- a/odxtools/compumethods/compuscale.py
+++ b/odxtools/compumethods/compuscale.py
@@ -16,13 +16,13 @@ class CompuScale:
     """A COMPU-SCALE represents one value range of a COMPU-METHOD.
     """
 
-    short_label: str | None
-    description: Description | None
-    lower_limit: Limit | None
-    upper_limit: Limit | None
-    compu_inverse_value: CompuInverseValue | None
-    compu_const: CompuConst | None
-    compu_rational_coeffs: CompuRationalCoeffs | None
+    short_label: str | None = None
+    description: Description | None = None
+    lower_limit: Limit | None = None
+    upper_limit: Limit | None = None
+    compu_inverse_value: CompuInverseValue | None = None
+    compu_const: CompuConst | None = None
+    compu_rational_coeffs: CompuRationalCoeffs | None = None
 
     # the following two attributes are not specified for COMPU-SCALE
     # tags in the XML, but they are required to do anything useful

--- a/odxtools/compumethods/limit.py
+++ b/odxtools/compumethods/limit.py
@@ -11,9 +11,9 @@ from .intervaltype import IntervalType
 
 @dataclass(kw_only=True)
 class Limit:
-    value_raw: str | None
-    value_type: DataType | None
-    interval_type: IntervalType | None
+    value_raw: str | None = None
+    value_type: DataType | None = None
+    interval_type: IntervalType | None = None
 
     @property
     def value(self) -> AtomicOdxType | None:

--- a/odxtools/compumethods/linearsegment.py
+++ b/odxtools/compumethods/linearsegment.py
@@ -23,8 +23,8 @@ class LinearSegment:
     offset: float
     factor: float
     denominator: float
-    internal_lower_limit: Limit | None
-    internal_upper_limit: Limit | None
+    internal_lower_limit: Limit | None = None
+    internal_upper_limit: Limit | None = None
 
     inverse_value: int | float  # value used as inverse if factor is 0
 

--- a/odxtools/compumethods/ratfuncsegment.py
+++ b/odxtools/compumethods/ratfuncsegment.py
@@ -16,8 +16,8 @@ class RatFuncSegment:
     numerator_coeffs: list[int | float]
     denominator_coeffs: list[int | float]
 
-    lower_limit: Limit | None
-    upper_limit: Limit | None
+    lower_limit: Limit | None = None
+    upper_limit: Limit | None = None
 
     @staticmethod
     def from_compu_scale(scale: CompuScale, value_type: DataType) -> "RatFuncSegment":

--- a/odxtools/compumethods/ratfuncsegment.py
+++ b/odxtools/compumethods/ratfuncsegment.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ..exceptions import odxraise, odxrequire
 from ..odxtypes import AtomicOdxType, DataType
@@ -13,8 +13,8 @@ class RatFuncSegment:
     """
     value_type: DataType
 
-    numerator_coeffs: list[int | float]
-    denominator_coeffs: list[int | float]
+    numerator_coeffs: list[int | float] = field(default_factory=list)
+    denominator_coeffs: list[int | float] = field(default_factory=list)
 
     lower_limit: Limit | None = None
     upper_limit: Limit | None = None

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -38,12 +38,12 @@ class DataObjectProperty(DopBase):
     #: The type of the value in the physical world
     physical_type: PhysicalType
 
-    internal_constr: InternalConstr | None
+    internal_constr: InternalConstr | None = None
 
     #: The unit associated with physical values (e.g. 'm/s^2')
-    unit_ref: OdxLinkRef | None
+    unit_ref: OdxLinkRef | None = None
 
-    physical_constr: InternalConstr | None
+    physical_constr: InternalConstr | None = None
 
     @property
     def unit(self) -> Unit | None:

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -12,7 +12,7 @@ class Description:
     text: str
     external_docs: list[ExternalDoc]
 
-    text_identifier: str | None
+    text_identifier: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element | None,

--- a/odxtools/description.py
+++ b/odxtools/description.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 from xml.etree import ElementTree
 
@@ -10,7 +10,7 @@ from .odxdoccontext import OdxDocContext
 @dataclass(kw_only=True)
 class Description:
     text: str
-    external_docs: list[ExternalDoc]
+    external_docs: list[ExternalDoc] = field(default_factory=list)
 
     text_identifier: str | None = None
 

--- a/odxtools/determinenumberofitems.py
+++ b/odxtools/determinenumberofitems.py
@@ -16,7 +16,7 @@ class DetermineNumberOfItems:
     The object that determines the number of items of dynamic fields
     """
     byte_position: int
-    bit_position: int | None
+    bit_position: int | None = None
     dop_ref: OdxLinkRef
 
     @property

--- a/odxtools/diagcodedtype.py
+++ b/odxtools/diagcodedtype.py
@@ -23,10 +23,10 @@ DctType = Literal[
 
 @dataclass(kw_only=True)
 class DiagCodedType:
-    base_type_encoding: Encoding | None
+    base_type_encoding: Encoding | None = None
     base_data_type: DataType
 
-    is_highlow_byte_order_raw: bool | None
+    is_highlow_byte_order_raw: bool | None = None
 
     @property
     def dct_type(self) -> DctType:

--- a/odxtools/diagcomm.py
+++ b/odxtools/diagcomm.py
@@ -35,21 +35,21 @@ class DiagComm(IdentifiableElement):
 
     """
 
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     sdgs: list[SpecialDataGroup]
     functional_class_refs: list[OdxLinkRef]
-    audience: Audience | None
+    audience: Audience | None = None
     protocol_snrefs: list[str]
     related_diag_comm_refs: list[RelatedDiagCommRef]
     pre_condition_state_refs: list[PreConditionStateRef]
     state_transition_refs: list[StateTransitionRef]
 
     # attributes
-    semantic: str | None
-    diagnostic_class: DiagClassType | None
-    is_mandatory_raw: bool | None
-    is_executable_raw: bool | None
-    is_final_raw: bool | None
+    semantic: str | None = None
+    diagnostic_class: DiagClassType | None = None
+    is_mandatory_raw: bool | None = None
+    is_executable_raw: bool | None = None
+    is_final_raw: bool | None = None
 
     @property
     def functional_classes(self) -> NamedItemList[FunctionalClass]:

--- a/odxtools/diagcomm.py
+++ b/odxtools/diagcomm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -36,13 +36,13 @@ class DiagComm(IdentifiableElement):
     """
 
     admin_data: AdminData | None = None
-    sdgs: list[SpecialDataGroup]
-    functional_class_refs: list[OdxLinkRef]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
+    functional_class_refs: list[OdxLinkRef] = field(default_factory=list)
     audience: Audience | None = None
-    protocol_snrefs: list[str]
-    related_diag_comm_refs: list[RelatedDiagCommRef]
-    pre_condition_state_refs: list[PreConditionStateRef]
-    state_transition_refs: list[StateTransitionRef]
+    protocol_snrefs: list[str] = field(default_factory=list)
+    related_diag_comm_refs: list[RelatedDiagCommRef] = field(default_factory=list)
+    pre_condition_state_refs: list[PreConditionStateRef] = field(default_factory=list)
+    state_transition_refs: list[StateTransitionRef] = field(default_factory=list)
 
     # attributes
     semantic: str | None = None

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain
 from typing import Any
 from xml.etree import ElementTree
@@ -28,18 +28,19 @@ from .unitspec import UnitSpec
 @dataclass(kw_only=True)
 class DiagDataDictionarySpec:
     admin_data: AdminData | None = None
-    dtc_dops: NamedItemList[DtcDop]
-    env_data_descs: NamedItemList[EnvironmentDataDescription]
-    data_object_props: NamedItemList[DataObjectProperty]
-    structures: NamedItemList[Structure]
-    static_fields: NamedItemList[StaticField]
-    dynamic_length_fields: NamedItemList[DynamicLengthField]
-    dynamic_endmarker_fields: NamedItemList[DynamicEndmarkerField]
-    end_of_pdu_fields: NamedItemList[EndOfPduField]
-    muxs: NamedItemList[Multiplexer]
-    env_datas: NamedItemList[EnvironmentData]
+    dtc_dops: NamedItemList[DtcDop] = field(default_factory=NamedItemList)
+    env_data_descs: NamedItemList[EnvironmentDataDescription] = field(default_factory=NamedItemList)
+    data_object_props: NamedItemList[DataObjectProperty] = field(default_factory=NamedItemList)
+    structures: NamedItemList[Structure] = field(default_factory=NamedItemList)
+    static_fields: NamedItemList[StaticField] = field(default_factory=NamedItemList)
+    dynamic_length_fields: NamedItemList[DynamicLengthField] = field(default_factory=NamedItemList)
+    dynamic_endmarker_fields: NamedItemList[DynamicEndmarkerField] = field(
+        default_factory=NamedItemList)
+    end_of_pdu_fields: NamedItemList[EndOfPduField] = field(default_factory=NamedItemList)
+    muxs: NamedItemList[Multiplexer] = field(default_factory=NamedItemList)
+    env_datas: NamedItemList[EnvironmentData] = field(default_factory=NamedItemList)
     unit_spec: UnitSpec | None = None
-    tables: NamedItemList[Table]
+    tables: NamedItemList[Table] = field(default_factory=NamedItemList)
     sdgs: list[SpecialDataGroup]
 
     @staticmethod

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -41,7 +41,7 @@ class DiagDataDictionarySpec:
     env_datas: NamedItemList[EnvironmentData] = field(default_factory=NamedItemList)
     unit_spec: UnitSpec | None = None
     tables: NamedItemList[Table] = field(default_factory=NamedItemList)
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,

--- a/odxtools/diagdatadictionaryspec.py
+++ b/odxtools/diagdatadictionaryspec.py
@@ -27,7 +27,7 @@ from .unitspec import UnitSpec
 
 @dataclass(kw_only=True)
 class DiagDataDictionarySpec:
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     dtc_dops: NamedItemList[DtcDop]
     env_data_descs: NamedItemList[EnvironmentDataDescription]
     data_object_props: NamedItemList[DataObjectProperty]
@@ -38,7 +38,7 @@ class DiagDataDictionarySpec:
     end_of_pdu_fields: NamedItemList[EndOfPduField]
     muxs: NamedItemList[Multiplexer]
     env_datas: NamedItemList[EnvironmentData]
-    unit_spec: UnitSpec | None
+    unit_spec: UnitSpec | None = None
     tables: NamedItemList[Table]
     sdgs: list[SpecialDataGroup]
 

--- a/odxtools/diaglayercontainer.py
+++ b/odxtools/diaglayercontainer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
@@ -23,11 +23,11 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class DiagLayerContainer(OdxCategory):
-    protocols: NamedItemList[Protocol]
-    functional_groups: NamedItemList[FunctionalGroup]
-    ecu_shared_datas: NamedItemList[EcuSharedData]
-    base_variants: NamedItemList[BaseVariant]
-    ecu_variants: NamedItemList[EcuVariant]
+    protocols: NamedItemList[Protocol] = field(default_factory=NamedItemList)
+    functional_groups: NamedItemList[FunctionalGroup] = field(default_factory=NamedItemList)
+    ecu_shared_datas: NamedItemList[EcuSharedData] = field(default_factory=NamedItemList)
+    base_variants: NamedItemList[BaseVariant] = field(default_factory=NamedItemList)
+    ecu_variants: NamedItemList[EcuVariant] = field(default_factory=NamedItemList)
 
     @property
     def diag_layers(self) -> NamedItemList[DiagLayer]:

--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -23,7 +23,7 @@ class BaseVariantRaw(HierarchyElementRaw):
     """
 
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
-    variable_groups: NamedItemList[VariableGroup]
+    variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
     dyn_defined_spec: DynDefinedSpec | None = None
     base_variant_pattern: BaseVariantPattern | None = None
     parent_refs: list[ParentRef]

--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -22,11 +22,11 @@ class BaseVariantRaw(HierarchyElementRaw):
     """This is a diagnostic layer for common functionality of an ECU
     """
 
-    diag_variables_raw: list[DiagVariable | OdxLinkRef]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef] = field(default_factory=list)
     variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
     dyn_defined_spec: DynDefinedSpec | None = None
     base_variant_pattern: BaseVariantPattern | None = None
-    parent_refs: list[ParentRef]
+    parent_refs: list[ParentRef] = field(default_factory=list)
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:

--- a/odxtools/diaglayers/basevariantraw.py
+++ b/odxtools/diaglayers/basevariantraw.py
@@ -24,8 +24,8 @@ class BaseVariantRaw(HierarchyElementRaw):
 
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]
-    dyn_defined_spec: DynDefinedSpec | None
-    base_variant_pattern: BaseVariantPattern | None
+    dyn_defined_spec: DynDefinedSpec | None = None
+    base_variant_pattern: BaseVariantPattern | None = None
     parent_refs: list[ParentRef]
 
     @property

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -40,17 +40,17 @@ class DiagLayerRaw(IdentifiableElement):
     company_datas: NamedItemList[CompanyData] = field(default_factory=NamedItemList)
     functional_classes: NamedItemList[FunctionalClass] = field(default_factory=NamedItemList)
     diag_data_dictionary_spec: DiagDataDictionarySpec | None = None
-    diag_comms_raw: list[OdxLinkRef | DiagComm]
+    diag_comms_raw: list[OdxLinkRef | DiagComm] = field(default_factory=list)
     requests: NamedItemList[Request] = field(default_factory=NamedItemList)
     positive_responses: NamedItemList[Response] = field(default_factory=NamedItemList)
     negative_responses: NamedItemList[Response] = field(default_factory=NamedItemList)
     global_negative_responses: NamedItemList[Response] = field(default_factory=NamedItemList)
-    import_refs: list[OdxLinkRef]
+    import_refs: list[OdxLinkRef] = field(default_factory=list)
     state_charts: NamedItemList[StateChart] = field(default_factory=NamedItemList)
     additional_audiences: NamedItemList[AdditionalAudience] = field(default_factory=NamedItemList)
     sub_components: NamedItemList[SubComponent] = field(default_factory=NamedItemList)
     libraries: NamedItemList[Library] = field(default_factory=NamedItemList)
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @property
     def diag_comms(self) -> NamedItemList[DiagComm]:

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -37,19 +37,19 @@ class DiagLayerRaw(IdentifiableElement):
 
     variant_type: DiagLayerType
     admin_data: AdminData | None = None
-    company_datas: NamedItemList[CompanyData]
-    functional_classes: NamedItemList[FunctionalClass]
+    company_datas: NamedItemList[CompanyData] = field(default_factory=NamedItemList)
+    functional_classes: NamedItemList[FunctionalClass] = field(default_factory=NamedItemList)
     diag_data_dictionary_spec: DiagDataDictionarySpec | None = None
     diag_comms_raw: list[OdxLinkRef | DiagComm]
-    requests: NamedItemList[Request]
-    positive_responses: NamedItemList[Response]
-    negative_responses: NamedItemList[Response]
-    global_negative_responses: NamedItemList[Response]
+    requests: NamedItemList[Request] = field(default_factory=NamedItemList)
+    positive_responses: NamedItemList[Response] = field(default_factory=NamedItemList)
+    negative_responses: NamedItemList[Response] = field(default_factory=NamedItemList)
+    global_negative_responses: NamedItemList[Response] = field(default_factory=NamedItemList)
     import_refs: list[OdxLinkRef]
-    state_charts: NamedItemList[StateChart]
-    additional_audiences: NamedItemList[AdditionalAudience]
-    sub_components: NamedItemList[SubComponent]
-    libraries: NamedItemList[Library]
+    state_charts: NamedItemList[StateChart] = field(default_factory=NamedItemList)
+    additional_audiences: NamedItemList[AdditionalAudience] = field(default_factory=NamedItemList)
+    sub_components: NamedItemList[SubComponent] = field(default_factory=NamedItemList)
+    libraries: NamedItemList[Library] = field(default_factory=NamedItemList)
     sdgs: list[SpecialDataGroup]
 
     @property

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -36,10 +36,10 @@ class DiagLayerRaw(IdentifiableElement):
     """
 
     variant_type: DiagLayerType
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     company_datas: NamedItemList[CompanyData]
     functional_classes: NamedItemList[FunctionalClass]
-    diag_data_dictionary_spec: DiagDataDictionarySpec | None
+    diag_data_dictionary_spec: DiagDataDictionarySpec | None = None
     diag_comms_raw: list[OdxLinkRef | DiagComm]
     requests: NamedItemList[Request]
     positive_responses: NamedItemList[Response]

--- a/odxtools/diaglayers/ecushareddataraw.py
+++ b/odxtools/diaglayers/ecushareddataraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -20,7 +20,7 @@ class EcuSharedDataRaw(DiagLayerRaw):
     """
 
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
-    variable_groups: NamedItemList[VariableGroup]
+    variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:

--- a/odxtools/diaglayers/ecushareddataraw.py
+++ b/odxtools/diaglayers/ecushareddataraw.py
@@ -19,7 +19,7 @@ class EcuSharedDataRaw(DiagLayerRaw):
     """This is a diagnostic layer for data shared accross others
     """
 
-    diag_variables_raw: list[DiagVariable | OdxLinkRef]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef] = field(default_factory=list)
     variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
 
     @property

--- a/odxtools/diaglayers/ecuvariantraw.py
+++ b/odxtools/diaglayers/ecuvariantraw.py
@@ -22,7 +22,7 @@ class EcuVariantRaw(HierarchyElementRaw):
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
     variable_groups: NamedItemList[VariableGroup]
     ecu_variant_patterns: list[EcuVariantPattern]
-    dyn_defined_spec: DynDefinedSpec | None
+    dyn_defined_spec: DynDefinedSpec | None = None
     parent_refs: list[ParentRef]
 
     @property

--- a/odxtools/diaglayers/ecuvariantraw.py
+++ b/odxtools/diaglayers/ecuvariantraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -20,7 +20,7 @@ from .hierarchyelementraw import HierarchyElementRaw
 @dataclass(kw_only=True)
 class EcuVariantRaw(HierarchyElementRaw):
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
-    variable_groups: NamedItemList[VariableGroup]
+    variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
     ecu_variant_patterns: list[EcuVariantPattern]
     dyn_defined_spec: DynDefinedSpec | None = None
     parent_refs: list[ParentRef]

--- a/odxtools/diaglayers/ecuvariantraw.py
+++ b/odxtools/diaglayers/ecuvariantraw.py
@@ -19,11 +19,11 @@ from .hierarchyelementraw import HierarchyElementRaw
 
 @dataclass(kw_only=True)
 class EcuVariantRaw(HierarchyElementRaw):
-    diag_variables_raw: list[DiagVariable | OdxLinkRef]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef] = field(default_factory=list)
     variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
-    ecu_variant_patterns: list[EcuVariantPattern]
+    ecu_variant_patterns: list[EcuVariantPattern] = field(default_factory=list)
     dyn_defined_spec: DynDefinedSpec | None = None
-    parent_refs: list[ParentRef]
+    parent_refs: list[ParentRef] = field(default_factory=list)
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:

--- a/odxtools/diaglayers/functionalgroupraw.py
+++ b/odxtools/diaglayers/functionalgroupraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -21,7 +21,7 @@ class FunctionalGroupRaw(HierarchyElementRaw):
     """
 
     diag_variables_raw: list[DiagVariable | OdxLinkRef]
-    variable_groups: NamedItemList[VariableGroup]
+    variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
     parent_refs: list[ParentRef]
 
     @property

--- a/odxtools/diaglayers/functionalgroupraw.py
+++ b/odxtools/diaglayers/functionalgroupraw.py
@@ -20,9 +20,9 @@ class FunctionalGroupRaw(HierarchyElementRaw):
     """This is a diagnostic layer for common functionality of an ECU
     """
 
-    diag_variables_raw: list[DiagVariable | OdxLinkRef]
+    diag_variables_raw: list[DiagVariable | OdxLinkRef] = field(default_factory=list)
     variable_groups: NamedItemList[VariableGroup] = field(default_factory=NamedItemList)
-    parent_refs: list[ParentRef]
+    parent_refs: list[ParentRef] = field(default_factory=list)
 
     @property
     def diag_variables(self) -> NamedItemList[DiagVariable]:

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -3,7 +3,7 @@ import re
 import warnings
 from collections.abc import Callable, Iterable
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 from xml.etree import ElementTree
@@ -55,7 +55,8 @@ class HierarchyElement(DiagLayer):
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        self._global_negative_responses: NamedItemList[Response]
+        self._global_negative_responses: NamedItemList[Response] = field(
+            default_factory=NamedItemList)
 
         odxassert(
             isinstance(self.diag_layer_raw, HierarchyElementRaw),

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -121,13 +121,13 @@ class HierarchyElement(DiagLayer):
         unit_groups = self._compute_available_unit_groups()
 
         # convenience variable for the locally-defined unit spec
-        local_unit_spec: UnitSpec | None
+        local_unit_spec: UnitSpec | None = None
         if self.diag_layer_raw.diag_data_dictionary_spec is not None:
             local_unit_spec = self.diag_layer_raw.diag_data_dictionary_spec.unit_spec
         else:
             local_unit_spec = None
 
-        unit_spec: UnitSpec | None
+        unit_spec: UnitSpec | None = None
         if local_unit_spec is None and not unit_groups:
             # no locally defined unit spec and no inherited unit groups
             unit_spec = None
@@ -587,7 +587,7 @@ class HierarchyElement(DiagLayer):
 
         from .protocol import Protocol
 
-        protocol_name: str | None
+        protocol_name: str | None = None
         if isinstance(protocol, Protocol):
             protocol_name = protocol.short_name
         else:

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -3,7 +3,7 @@ import re
 import warnings
 from collections.abc import Callable, Iterable
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 from xml.etree import ElementTree
@@ -55,8 +55,7 @@ class HierarchyElement(DiagLayer):
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        self._global_negative_responses: NamedItemList[Response] = field(
-            default_factory=NamedItemList)
+        self._global_negative_responses: NamedItemList[Response]
 
         odxassert(
             isinstance(self.diag_layer_raw, HierarchyElementRaw),

--- a/odxtools/diaglayers/hierarchyelementraw.py
+++ b/odxtools/diaglayers/hierarchyelementraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -18,7 +18,7 @@ class HierarchyElementRaw(DiagLayerRaw):
     This class represents the data present in the XML, not the "logical" view.
     """
 
-    comparam_refs: list[ComparamInstance]
+    comparam_refs: list[ComparamInstance] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "HierarchyElementRaw":

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -24,7 +24,7 @@ class ProtocolRaw(HierarchyElementRaw):
     """
 
     comparam_spec_ref: OdxLinkRef
-    prot_stack_snref: str | None
+    prot_stack_snref: str | None = None
     parent_refs: list[ParentRef]
 
     @property

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -25,7 +25,7 @@ class ProtocolRaw(HierarchyElementRaw):
 
     comparam_spec_ref: OdxLinkRef
     prot_stack_snref: str | None = None
-    parent_refs: list[ParentRef]
+    parent_refs: list[ParentRef] = field(default_factory=list)
 
     @property
     def comparam_spec(self) -> ComparamSpec:

--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -20,7 +20,7 @@ class DiagnosticTroubleCode(IdentifiableElement):
     display_trouble_code: str | None = None
     text: Text
     level: int | None = None
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     is_temporary_raw: bool | None = None
 

--- a/odxtools/diagnostictroublecode.py
+++ b/odxtools/diagnostictroublecode.py
@@ -17,12 +17,12 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class DiagnosticTroubleCode(IdentifiableElement):
     trouble_code: int
-    display_trouble_code: str | None
+    display_trouble_code: str | None = None
     text: Text
-    level: int | None
+    level: int | None = None
     sdgs: list[SpecialDataGroup]
 
-    is_temporary_raw: bool | None
+    is_temporary_raw: bool | None = None
 
     @property
     def is_temporary(self) -> bool:

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -30,12 +30,12 @@ class DiagService(DiagComm):
     request_ref: OdxLinkRef
     pos_response_refs: list[OdxLinkRef]
     neg_response_refs: list[OdxLinkRef]
-    pos_response_suppressible: PosResponseSuppressible | None
+    pos_response_suppressible: PosResponseSuppressible | None = None
 
-    is_cyclic_raw: bool | None
-    is_multiple_raw: bool | None
-    addressing_raw: Addressing | None
-    transmission_mode_raw: TransMode | None
+    is_cyclic_raw: bool | None = None
+    is_multiple_raw: bool | None = None
+    addressing_raw: Addressing | None = None
+    transmission_mode_raw: TransMode | None = None
 
     @property
     def comparams(self) -> NamedItemList[ComparamInstance]:

--- a/odxtools/diagservice.py
+++ b/odxtools/diagservice.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -26,10 +26,10 @@ class DiagService(DiagComm):
     """Representation of a diagnostic service description.
     """
 
-    comparam_refs: list[ComparamInstance]
+    comparam_refs: list[ComparamInstance] = field(default_factory=list)
     request_ref: OdxLinkRef
-    pos_response_refs: list[OdxLinkRef]
-    neg_response_refs: list[OdxLinkRef]
+    pos_response_refs: list[OdxLinkRef] = field(default_factory=list)
+    neg_response_refs: list[OdxLinkRef] = field(default_factory=list)
     pos_response_suppressible: PosResponseSuppressible | None = None
 
     is_cyclic_raw: bool | None = None

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, runtime_checkable
 from xml.etree import ElementTree
 
@@ -36,17 +36,17 @@ class DiagVariable(IdentifiableElement):
 
     admin_data: AdminData | None = None
     variable_group_ref: OdxLinkRef | None = None
-    sw_variables: list[SwVariable]
+    sw_variables: list[SwVariable] = field(default_factory=list)
 
     # a diag variable must specify either COMM-RELATIONS or a
     # reference to a table row
-    comm_relations: list[CommRelation]
+    comm_relations: list[CommRelation] = field(default_factory=list)
 
     # these are nested inside the SNREF-TO-TABLEROW tag
     table_snref: str | None = None
     table_row_snref: str | None = None
 
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     is_read_before_write_raw: bool | None = None
 

--- a/odxtools/diagvariable.py
+++ b/odxtools/diagvariable.py
@@ -34,8 +34,8 @@ class DiagVariable(IdentifiableElement):
     """Representation of a diagnostic variable
     """
 
-    admin_data: AdminData | None
-    variable_group_ref: OdxLinkRef | None
+    admin_data: AdminData | None = None
+    variable_group_ref: OdxLinkRef | None = None
     sw_variables: list[SwVariable]
 
     # a diag variable must specify either COMM-RELATIONS or a
@@ -43,12 +43,12 @@ class DiagVariable(IdentifiableElement):
     comm_relations: list[CommRelation]
 
     # these are nested inside the SNREF-TO-TABLEROW tag
-    table_snref: str | None
-    table_row_snref: str | None
+    table_snref: str | None = None
+    table_row_snref: str | None = None
 
     sdgs: list[SpecialDataGroup]
 
-    is_read_before_write_raw: bool | None
+    is_read_before_write_raw: bool | None = None
 
     @property
     def table(self) -> Table | None:

--- a/odxtools/docrevision.py
+++ b/odxtools/docrevision.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -23,8 +23,8 @@ class DocRevision:
     state: str | None = None
     date: str
     tool: str | None = None
-    company_revision_infos: list[CompanyRevisionInfo]
-    modifications: list[Modification]
+    company_revision_infos: list[CompanyRevisionInfo] = field(default_factory=list)
+    modifications: list[Modification] = field(default_factory=list)
 
     @property
     def team_member(self) -> TeamMember | None:

--- a/odxtools/docrevision.py
+++ b/odxtools/docrevision.py
@@ -18,11 +18,11 @@ class DocRevision:
     Representation of a single revision of the relevant object.
     """
 
-    team_member_ref: OdxLinkRef | None
-    revision_label: str | None
-    state: str | None
+    team_member_ref: OdxLinkRef | None = None
+    revision_label: str | None = None
+    state: str | None = None
     date: str
-    tool: str | None
+    tool: str | None = None
     company_revision_infos: list[CompanyRevisionInfo]
     modifications: list[Modification]
 

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -26,7 +26,7 @@ class DopBase(IdentifiableElement):
     """
 
     admin_data: AdminData | None = None
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DopBase":

--- a/odxtools/dopbase.py
+++ b/odxtools/dopbase.py
@@ -25,7 +25,7 @@ class DopBase(IdentifiableElement):
 
     """
 
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     sdgs: list[SpecialDataGroup]
 
     @staticmethod

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -31,8 +31,8 @@ class DtcDop(DopBase):
     diag_coded_type: DiagCodedType
     physical_type: PhysicalType
     compu_method: CompuMethod
-    dtcs_raw: list[DiagnosticTroubleCode | OdxLinkRef]
-    linked_dtc_dops_raw: list[LinkedDtcDop]
+    dtcs_raw: list[DiagnosticTroubleCode | OdxLinkRef] = field(default_factory=list)
+    linked_dtc_dops_raw: list[LinkedDtcDop] = field(default_factory=list)
     is_visible_raw: bool | None = None
 
     @property

--- a/odxtools/dtcdop.py
+++ b/odxtools/dtcdop.py
@@ -33,7 +33,7 @@ class DtcDop(DopBase):
     compu_method: CompuMethod
     dtcs_raw: list[DiagnosticTroubleCode | OdxLinkRef]
     linked_dtc_dops_raw: list[LinkedDtcDop]
-    is_visible_raw: bool | None
+    is_visible_raw: bool | None = None
 
     @property
     def dtcs(self) -> NamedItemList[DiagnosticTroubleCode]:

--- a/odxtools/dyndefinedspec.py
+++ b/odxtools/dyndefinedspec.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -11,7 +11,7 @@ from .snrefcontext import SnRefContext
 
 @dataclass(kw_only=True)
 class DynDefinedSpec:
-    dyn_id_def_mode_infos: list[DynIdDefModeInfo]
+    dyn_id_def_mode_infos: list[DynIdDefModeInfo] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "DynDefinedSpec":

--- a/odxtools/dyniddefmodeinfo.py
+++ b/odxtools/dyniddefmodeinfo.py
@@ -17,14 +17,14 @@ from .table import Table
 class DynIdDefModeInfo:
     def_mode: str
 
-    clear_dyn_def_message_ref: OdxLinkRef | None
-    clear_dyn_def_message_snref: str | None
+    clear_dyn_def_message_ref: OdxLinkRef | None = None
+    clear_dyn_def_message_snref: str | None = None
 
-    read_dyn_def_message_ref: OdxLinkRef | None
-    read_dyn_def_message_snref: str | None
+    read_dyn_def_message_ref: OdxLinkRef | None = None
+    read_dyn_def_message_snref: str | None = None
 
-    dyn_def_message_ref: OdxLinkRef | None
-    dyn_def_message_snref: str | None
+    dyn_def_message_ref: OdxLinkRef | None = None
+    dyn_def_message_snref: str | None = None
 
     supported_dyn_ids: list[bytes]
     selection_table_refs: list[OdxLinkRef | str]

--- a/odxtools/dyniddefmodeinfo.py
+++ b/odxtools/dyniddefmodeinfo.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -26,8 +26,8 @@ class DynIdDefModeInfo:
     dyn_def_message_ref: OdxLinkRef | None = None
     dyn_def_message_snref: str | None = None
 
-    supported_dyn_ids: list[bytes]
-    selection_table_refs: list[OdxLinkRef | str]
+    supported_dyn_ids: list[bytes] = field(default_factory=list)
+    selection_table_refs: list[OdxLinkRef | str] = field(default_factory=list)
 
     @property
     def clear_dyn_def_message(self) -> DiagComm:

--- a/odxtools/ecuvariantpattern.py
+++ b/odxtools/ecuvariantpattern.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -16,7 +16,7 @@ class EcuVariantPattern(VariantPattern):
     """ECU variant patterns are variant patterns used to identify the
     concrete variant of an ECU.
     """
-    matching_parameters: list[MatchingParameter]
+    matching_parameters: list[MatchingParameter] = field(default_factory=list)
 
     @override
     def get_matching_parameters(self

--- a/odxtools/element.py
+++ b/odxtools/element.py
@@ -11,8 +11,8 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class NamedElement:
     short_name: str
-    long_name: str | None
-    description: Description | None
+    long_name: str | None = None
+    description: Description | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "NamedElement":
@@ -27,7 +27,7 @@ class NamedElement:
 @dataclass(kw_only=True)
 class IdentifiableElement(NamedElement):
     odx_id: OdxLinkId
-    oid: str | None
+    oid: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "IdentifiableElement":

--- a/odxtools/endofpdufield.py
+++ b/odxtools/endofpdufield.py
@@ -17,8 +17,8 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class EndOfPduField(Field):
     """End of PDU fields are structures that are repeated until the end of the PDU"""
-    max_number_of_items: int | None
-    min_number_of_items: int | None
+    max_number_of_items: int | None = None
+    min_number_of_items: int | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EndOfPduField":

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
@@ -20,7 +20,7 @@ class EnvironmentData(BasicStructure):
     """
 
     all_value: bool | None = None
-    dtc_values: list[int]
+    dtc_values: list[int] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "EnvironmentData":

--- a/odxtools/environmentdata.py
+++ b/odxtools/environmentdata.py
@@ -19,7 +19,7 @@ class EnvironmentData(BasicStructure):
     sense, it is quite similar to NRC-CONST parameters.)
     """
 
-    all_value: bool | None
+    all_value: bool | None = None
     dtc_values: list[int]
 
     @staticmethod

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -43,7 +43,7 @@ class EnvironmentDataDescription(ComplexDop):
     # sub-element of ENV-DATA-DESC, in ODX 2.2 it is not
     # present
     env_datas: NamedItemList[EnvironmentData] = field(default_factory=NamedItemList)
-    env_data_refs: list[OdxLinkRef]
+    env_data_refs: list[OdxLinkRef] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -42,7 +42,7 @@ class EnvironmentDataDescription(ComplexDop):
     # in ODX 2.0.0, ENV-DATAS seems to be a mandatory
     # sub-element of ENV-DATA-DESC, in ODX 2.2 it is not
     # present
-    env_datas: NamedItemList[EnvironmentData]
+    env_datas: NamedItemList[EnvironmentData] = field(default_factory=NamedItemList)
     env_data_refs: list[OdxLinkRef]
 
     @staticmethod

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -36,8 +36,8 @@ class EnvironmentDataDescription(ComplexDop):
 
     """
 
-    param_snref: str | None
-    param_snpathref: str | None
+    param_snref: str | None = None
+    param_snpathref: str | None = None
 
     # in ODX 2.0.0, ENV-DATAS seems to be a mandatory
     # sub-element of ENV-DATA-DESC, in ODX 2.2 it is not

--- a/odxtools/externaldoc.py
+++ b/odxtools/externaldoc.py
@@ -8,7 +8,7 @@ from .odxdoccontext import OdxDocContext
 
 @dataclass(kw_only=True)
 class ExternalDoc:
-    description: str | None
+    description: str | None = None
     href: str
 
     @staticmethod

--- a/odxtools/field.py
+++ b/odxtools/field.py
@@ -15,11 +15,11 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class Field(ComplexDop):
-    structure_ref: OdxLinkRef | None
-    structure_snref: str | None
-    env_data_desc_ref: OdxLinkRef | None
-    env_data_desc_snref: str | None
-    is_visible_raw: bool | None
+    structure_ref: OdxLinkRef | None = None
+    structure_snref: str | None = None
+    env_data_desc_ref: OdxLinkRef | None = None
+    env_data_desc_snref: str | None = None
+    is_visible_raw: bool | None = None
 
     @property
     def structure(self) -> BasicStructure:

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -17,7 +17,7 @@ class FunctionalClass(IdentifiableElement):
     Corresponds to FUNCT-CLASS.
     """
 
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "FunctionalClass":

--- a/odxtools/inputparam.py
+++ b/odxtools/inputparam.py
@@ -16,10 +16,10 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class InputParam(NamedElement):
-    physical_default_value: str | None
+    physical_default_value: str | None = None
     dop_base_ref: OdxLinkRef
-    oid: str | None
-    semantic: str | None
+    oid: str | None = None
+    semantic: str | None = None
 
     @property
     def dop(self) -> DopBase:

--- a/odxtools/internalconstr.py
+++ b/odxtools/internalconstr.py
@@ -15,8 +15,8 @@ class InternalConstr:
 
     # TODO: Enforce the internal and physical constraints.
 
-    lower_limit: Limit | None
-    upper_limit: Limit | None
+    lower_limit: Limit | None = None
+    upper_limit: Limit | None = None
     scale_constrs: list[ScaleConstr]
 
     value_type: DataType

--- a/odxtools/internalconstr.py
+++ b/odxtools/internalconstr.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from xml.etree import ElementTree
 
 from .compumethods.limit import Limit
@@ -17,7 +17,7 @@ class InternalConstr:
 
     lower_limit: Limit | None = None
     upper_limit: Limit | None = None
-    scale_constrs: list[ScaleConstr]
+    scale_constrs: list[ScaleConstr] = field(default_factory=list)
 
     value_type: DataType
 

--- a/odxtools/library.py
+++ b/odxtools/library.py
@@ -20,10 +20,10 @@ class Library(IdentifiableElement):
     """
 
     code_file: str
-    encryption: str | None
+    encryption: str | None = None
     syntax: str
     revision: str
-    entrypoint: str | None
+    entrypoint: str | None = None
 
     @property
     def code(self) -> bytes:

--- a/odxtools/linkeddtcdop.py
+++ b/odxtools/linkeddtcdop.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class LinkedDtcDop:
-    not_inherited_dtc_snrefs: list[str]
+    not_inherited_dtc_snrefs: list[str] = field(default_factory=list)
     dtc_dop_ref: OdxLinkRef
 
     @property

--- a/odxtools/matchingbasevariantparameter.py
+++ b/odxtools/matchingbasevariantparameter.py
@@ -17,7 +17,7 @@ class MatchingBaseVariantParameter(MatchingParameter):
     additional subtag `USE-PHYSICAL-ADDRESSING`.
     """
 
-    use_physical_addressing_raw: bool | None
+    use_physical_addressing_raw: bool | None = None
 
     @property
     def use_physical_addressing(self) -> bool:

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -35,8 +35,8 @@ class MatchingParameter:
     # or negative response. What it probably actually wants to say is
     # that any response that can possibly be received shall exhibit
     # the referenced parameter.
-    out_param_if_snref: str | None
-    out_param_if_snpathref: str | None
+    out_param_if_snref: str | None = None
+    out_param_if_snpathref: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "MatchingParameter":

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -18,7 +18,7 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class MinMaxLengthType(DiagCodedType):
-    max_length: int | None
+    max_length: int | None = None
     min_length: int
     termination: Termination
 

--- a/odxtools/modification.py
+++ b/odxtools/modification.py
@@ -12,7 +12,7 @@ from .snrefcontext import SnRefContext
 @dataclass(kw_only=True)
 class Modification:
     change: str
-    reason: str | None
+    reason: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Modification":

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -32,7 +32,7 @@ class Multiplexer(ComplexDop):
     byte_position: int
     switch_key: MultiplexerSwitchKey
     default_case: MultiplexerDefaultCase | None = None
-    cases: NamedItemList[MultiplexerCase]
+    cases: NamedItemList[MultiplexerCase] = field(default_factory=NamedItemList)
     is_visible_raw: bool | None = None
 
     @property

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -31,9 +31,9 @@ class Multiplexer(ComplexDop):
 
     byte_position: int
     switch_key: MultiplexerSwitchKey
-    default_case: MultiplexerDefaultCase | None
+    default_case: MultiplexerDefaultCase | None = None
     cases: NamedItemList[MultiplexerCase]
-    is_visible_raw: bool | None
+    is_visible_raw: bool | None = None
 
     @property
     def is_visible(self) -> bool:

--- a/odxtools/multiplexercase.py
+++ b/odxtools/multiplexercase.py
@@ -18,8 +18,8 @@ from .utils import dataclass_fields_asdict
 class MultiplexerCase(NamedElement):
     """This class represents a case which represents a range of keys of a multiplexer."""
 
-    structure_ref: OdxLinkRef | None
-    structure_snref: str | None
+    structure_ref: OdxLinkRef | None = None
+    structure_snref: str | None = None
     lower_limit: Limit
     upper_limit: Limit
 

--- a/odxtools/multiplexerdefaultcase.py
+++ b/odxtools/multiplexerdefaultcase.py
@@ -15,8 +15,8 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class MultiplexerDefaultCase(NamedElement):
     """This class represents a Default Case, which is selected when there are no cases defined in the Multiplexer."""
-    structure_ref: OdxLinkRef | None
-    structure_snref: str | None
+    structure_ref: OdxLinkRef | None = None
+    structure_snref: str | None = None
 
     @property
     def structure(self) -> Structure | None:

--- a/odxtools/multiplexerswitchkey.py
+++ b/odxtools/multiplexerswitchkey.py
@@ -16,7 +16,7 @@ class MultiplexerSwitchKey:
     The object that determines the case to be used by a multiplexer
     """
     byte_position: int
-    bit_position: int | None
+    bit_position: int | None = None
     dop_ref: OdxLinkRef
 
     @property

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class OdxCategory(IdentifiableElement):
     """This is the base class for all top-level container classes in ODX"""
 
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     company_datas: NamedItemList[CompanyData]
     sdgs: list[SpecialDataGroup]
 

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -24,7 +24,7 @@ class OdxCategory(IdentifiableElement):
 
     admin_data: AdminData | None = None
     company_datas: NamedItemList[CompanyData] = field(default_factory=NamedItemList)
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "OdxCategory":

--- a/odxtools/odxcategory.py
+++ b/odxtools/odxcategory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -23,7 +23,7 @@ class OdxCategory(IdentifiableElement):
     """This is the base class for all top-level container classes in ODX"""
 
     admin_data: AdminData | None = None
-    company_datas: NamedItemList[CompanyData]
+    company_datas: NamedItemList[CompanyData] = field(default_factory=NamedItemList)
     sdgs: list[SpecialDataGroup]
 
     @staticmethod

--- a/odxtools/odxlink.py
+++ b/odxtools/odxlink.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 import warnings
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional, TypeVar, overload
 from xml.etree import ElementTree
@@ -46,7 +46,7 @@ class OdxLinkId:
 
     #: The name and type of the document fragment to which the
     #: `local_id` is relative to
-    doc_fragments: list[OdxDocFragment]
+    doc_fragments: list[OdxDocFragment] = field(default_factory=list)
 
     def __hash__(self) -> int:
         # we do not hash about the document fragment here, because
@@ -95,7 +95,7 @@ class OdxLinkRef:
     ref_id: str
 
     #: The document fragments to which the `ref_id` refers to (in reverse order)
-    ref_docs: list[OdxDocFragment]
+    ref_docs: list[OdxDocFragment] = field(default_factory=list)
 
     # TODO: this is difficult because OdxLinkRef is derived from and
     # we do not want having to specify it mandatorily

--- a/odxtools/outputparam.py
+++ b/odxtools/outputparam.py
@@ -17,7 +17,7 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class OutputParam(IdentifiableElement):
     dop_base_ref: OdxLinkRef
-    semantic: str | None
+    semantic: str | None = None
 
     @property
     def dop(self) -> DopBase:

--- a/odxtools/parameters/nrcconstparameter.py
+++ b/odxtools/parameters/nrcconstparameter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -35,7 +35,7 @@ class NrcConstParameter(Parameter):
 
     """
 
-    coded_values_raw: list[str]
+    coded_values_raw: list[str] = field(default_factory=list)
     diag_coded_type: DiagCodedType
 
     @property

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -44,10 +44,10 @@ class Parameter(NamedElement):
 
     """
     sdgs: list[SpecialDataGroup]
-    semantic: str | None
-    oid: str | None
-    byte_position: int | None
-    bit_position: int | None
+    semantic: str | None = None
+    oid: str | None = None
+    byte_position: int | None = None
+    bit_position: int | None = None
 
     @property
     def parameter_type(self) -> ParameterType:

--- a/odxtools/parameters/parameter.py
+++ b/odxtools/parameters/parameter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 from xml.etree import ElementTree
 
@@ -43,7 +43,7 @@ class Parameter(NamedElement):
     non-positionable parameter types.
 
     """
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
     semantic: str | None = None
     oid: str | None = None
     byte_position: int | None = None

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -22,8 +22,8 @@ from .parameter import Parameter
 
 @dataclass(kw_only=True)
 class ParameterWithDOP(Parameter):
-    dop_ref: OdxLinkRef | None
-    dop_snref: str | None
+    dop_ref: OdxLinkRef | None = None
+    dop_snref: str | None = None
 
     @property
     def dop(self) -> DopBase:

--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -27,13 +27,13 @@ class TableKeyParameter(Parameter):
 
     # the spec mandates that exactly one of the two attributes must
     # be non-None
-    table_ref: OdxLinkRef | None
-    table_snref: str | None
+    table_ref: OdxLinkRef | None = None
+    table_snref: str | None = None
 
     # the spec mandates that exactly one of the two attributes must
     # be non-None
-    table_row_ref: OdxLinkRef | None
-    table_row_snref: str | None
+    table_row_ref: OdxLinkRef | None = None
+    table_row_snref: str | None = None
 
     @staticmethod
     @override

--- a/odxtools/parameters/tablestructparameter.py
+++ b/odxtools/parameters/tablestructparameter.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class TableStructParameter(Parameter):
-    table_key_ref: OdxLinkRef | None
-    table_key_snref: str | None
+    table_key_ref: OdxLinkRef | None = None
+    table_key_snref: str | None = None
 
     @property
     @override

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -19,7 +19,7 @@ from .parameterwithdop import ParameterWithDOP
 
 @dataclass(kw_only=True)
 class ValueParameter(ParameterWithDOP):
-    physical_default_value_raw: str | None
+    physical_default_value_raw: str | None = None
 
     @property
     @override

--- a/odxtools/parentref.py
+++ b/odxtools/parentref.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -17,11 +17,12 @@ if TYPE_CHECKING:
 @dataclass(kw_only=True)
 class ParentRef:
     layer_ref: OdxLinkRef
-    not_inherited_diag_comms: list[str]  # short_name references
-    not_inherited_variables: list[str]  # short_name references
-    not_inherited_dops: list[str]  # short_name references
-    not_inherited_tables: list[str]  # short_name references
-    not_inherited_global_neg_responses: list[str]  # short_name references
+    not_inherited_diag_comms: list[str] = field(default_factory=list)  # short_name references
+    not_inherited_variables: list[str] = field(default_factory=list)  # short_name references
+    not_inherited_dops: list[str] = field(default_factory=list)  # short_name references
+    not_inherited_tables: list[str] = field(default_factory=list)  # short_name references
+    not_inherited_global_neg_responses: list[str] = field(
+        default_factory=list)  # short_name references
 
     @property
     def layer(self) -> "DiagLayer":

--- a/odxtools/physicaldimension.py
+++ b/odxtools/physicaldimension.py
@@ -42,13 +42,13 @@ class PhysicalDimension(IdentifiableElement):
     )
     ```
     """
-    length_exp: int | None
-    mass_exp: int | None
-    time_exp: int | None
-    current_exp: int | None
-    temperature_exp: int | None
-    molar_amount_exp: int | None
-    luminous_intensity_exp: int | None
+    length_exp: int | None = None
+    mass_exp: int | None = None
+    time_exp: int | None = None
+    current_exp: int | None = None
+    temperature_exp: int | None = None
+    molar_amount_exp: int | None = None
+    luminous_intensity_exp: int | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "PhysicalDimension":

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -31,14 +31,14 @@ class PhysicalType:
     PhysicalType(DataType.A_FLOAT64, precision=2)
     """
 
-    precision: int | None
+    precision: int | None = None
     """Number of digits after the decimal point to display to the user
     The precision is only applicable if the base data type is A_FLOAT32 or A_FLOAT64.
     """
 
     base_data_type: DataType
 
-    display_radix: Radix | None
+    display_radix: Radix | None = None
     """The display radix defines how integers are displayed to the user.
     The display radix is only applicable if the base data type is A_UINT32.
     """

--- a/odxtools/posresponsesuppressible.py
+++ b/odxtools/posresponsesuppressible.py
@@ -13,17 +13,17 @@ from .utils import read_hex_binary
 class PosResponseSuppressible:
     bit_mask: int
 
-    coded_const_snref: str | None
-    coded_const_snpathref: str | None
+    coded_const_snref: str | None = None
+    coded_const_snpathref: str | None = None
 
-    value_snref: str | None
-    value_snpathref: str | None
+    value_snref: str | None = None
+    value_snpathref: str | None = None
 
-    phys_const_snref: str | None
-    phys_const_snpathref: str | None
+    phys_const_snref: str | None = None
+    phys_const_snpathref: str | None = None
 
-    table_key_snref: str | None
-    table_key_snpathref: str | None
+    table_key_snref: str | None = None
+    table_key_snpathref: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element,

--- a/odxtools/preconditionstateref.py
+++ b/odxtools/preconditionstateref.py
@@ -22,10 +22,10 @@ class PreConditionStateRef(OdxLinkRef):
     """
     This class represents the PRE-CONDITION-STATE-REF XML tag.
     """
-    value: str | None
+    value: str | None = None
 
-    in_param_if_snref: str | None
-    in_param_if_snpathref: str | None
+    in_param_if_snref: str | None = None
+    in_param_if_snpathref: str | None = None
 
     @property
     def state(self) -> "State":

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -15,10 +15,10 @@ from .snrefcontext import SnRefContext
 class ProgCode:
     """A reference to code that is executed by a single ECU job"""
     code_file: str
-    encryption: str | None
+    encryption: str | None = None
     syntax: str
     revision: str
-    entrypoint: str | None
+    entrypoint: str | None = None
     library_refs: list[OdxLinkRef]
 
     @property

--- a/odxtools/progcode.py
+++ b/odxtools/progcode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -19,7 +19,7 @@ class ProgCode:
     syntax: str
     revision: str
     entrypoint: str | None = None
-    library_refs: list[OdxLinkRef]
+    library_refs: list[OdxLinkRef] = field(default_factory=list)
 
     @property
     def code(self) -> bytes:

--- a/odxtools/protstack.py
+++ b/odxtools/protstack.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -18,7 +18,7 @@ class ProtStack(IdentifiableElement):
     # mandatory in ODX 2.2, but non existent in ODX 2.0
     pdu_protocol_type: str
     physical_link_type: str
-    comparam_subset_refs: list[OdxLinkRef]
+    comparam_subset_refs: list[OdxLinkRef] = field(default_factory=list)
 
     @property
     def comparam_subsets(self) -> NamedItemList[ComparamSubset]:

--- a/odxtools/relateddoc.py
+++ b/odxtools/relateddoc.py
@@ -12,8 +12,8 @@ from .xdoc import XDoc
 
 @dataclass(kw_only=True)
 class RelatedDoc:
-    xdoc: XDoc | None
-    description: Description | None
+    xdoc: XDoc | None = None
+    description: Description | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "RelatedDoc":

--- a/odxtools/request.py
+++ b/odxtools/request.py
@@ -30,7 +30,7 @@ class Request(IdentifiableElement):
 
     This class implements the `CompositeCodec` interface.
     """
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     parameters: NamedItemList[Parameter]
     sdgs: list[SpecialDataGroup]
 

--- a/odxtools/request.py
+++ b/odxtools/request.py
@@ -32,7 +32,7 @@ class Request(IdentifiableElement):
     """
     admin_data: AdminData | None = None
     parameters: NamedItemList[Parameter] = field(default_factory=NamedItemList)
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @property
     def required_parameters(self) -> list[Parameter]:

--- a/odxtools/request.py
+++ b/odxtools/request.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -31,7 +31,7 @@ class Request(IdentifiableElement):
     This class implements the `CompositeCodec` interface.
     """
     admin_data: AdminData | None = None
-    parameters: NamedItemList[Parameter]
+    parameters: NamedItemList[Parameter] = field(default_factory=NamedItemList)
     sdgs: list[SpecialDataGroup]
 
     @property

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, cast
 from xml.etree import ElementTree
@@ -41,7 +41,7 @@ class Response(IdentifiableElement):
     response_type: ResponseType
 
     admin_data: AdminData | None = None
-    parameters: NamedItemList[Parameter]
+    parameters: NamedItemList[Parameter] = field(default_factory=NamedItemList)
     sdgs: list[SpecialDataGroup]
 
     @staticmethod

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -40,7 +40,7 @@ class Response(IdentifiableElement):
 
     response_type: ResponseType
 
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     parameters: NamedItemList[Parameter]
     sdgs: list[SpecialDataGroup]
 

--- a/odxtools/response.py
+++ b/odxtools/response.py
@@ -42,7 +42,7 @@ class Response(IdentifiableElement):
 
     admin_data: AdminData | None = None
     parameters: NamedItemList[Parameter] = field(default_factory=NamedItemList)
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Response":

--- a/odxtools/scaleconstr.py
+++ b/odxtools/scaleconstr.py
@@ -15,8 +15,8 @@ class ScaleConstr:
     """This class represents a SCALE-CONSTR.
     """
 
-    short_label: str | None
-    description: Description | None
+    short_label: str | None = None
+    description: Description | None = None
     lower_limit: Limit
     upper_limit: Limit
     validity: ValidType

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -32,9 +32,9 @@ class SingleEcuJob(DiagComm):
     """
 
     prog_codes: list[ProgCode]
-    input_params: NamedItemList[InputParam]
-    output_params: NamedItemList[OutputParam]
-    neg_output_params: NamedItemList[NegOutputParam]
+    input_params: NamedItemList[InputParam] = field(default_factory=NamedItemList)
+    output_params: NamedItemList[OutputParam] = field(default_factory=NamedItemList)
+    neg_output_params: NamedItemList[NegOutputParam] = field(default_factory=NamedItemList)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SingleEcuJob":

--- a/odxtools/singleecujob.py
+++ b/odxtools/singleecujob.py
@@ -31,7 +31,7 @@ class SingleEcuJob(DiagComm):
     standard.
     """
 
-    prog_codes: list[ProgCode]
+    prog_codes: list[ProgCode] = field(default_factory=list)
     input_params: NamedItemList[InputParam] = field(default_factory=NamedItemList)
     output_params: NamedItemList[OutputParam] = field(default_factory=NamedItemList)
     neg_output_params: NamedItemList[NegOutputParam] = field(default_factory=NamedItemList)

--- a/odxtools/specialdata.py
+++ b/odxtools/specialdata.py
@@ -11,8 +11,8 @@ from .snrefcontext import SnRefContext
 @dataclass(kw_only=True)
 class SpecialData:
     """This corresponds to the SD XML tag"""
-    semantic_info: str | None  # the "SI" attribute
-    text_identifier: str | None  # the "TI" attribute, specifies the language used
+    semantic_info: str | None = None  # the "SI" attribute
+    text_identifier: str | None = None  # the "TI" attribute, specifies the language used
     value: str
 
     @staticmethod

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -16,7 +16,7 @@ class SpecialDataGroup:
     sdg_caption: SpecialDataGroupCaption | None = None
     sdg_caption_ref: OdxLinkRef | None = None
     values: list[Union["SpecialDataGroup", SpecialData]] = field(default_factory=list)
-    semantic_info: str | None  # the "SI" attribute
+    semantic_info: str | None = None  # the "SI" attribute
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SpecialDataGroup":

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -13,8 +13,8 @@ from .specialdatagroupcaption import SpecialDataGroupCaption
 @dataclass(kw_only=True)
 class SpecialDataGroup:
     """This corresponds to the SDG XML tag"""
-    sdg_caption: SpecialDataGroupCaption | None
-    sdg_caption_ref: OdxLinkRef | None
+    sdg_caption: SpecialDataGroupCaption | None = None
+    sdg_caption_ref: OdxLinkRef | None = None
     values: list[Union["SpecialDataGroup", SpecialData]]
     semantic_info: str | None  # the "SI" attribute
 

--- a/odxtools/specialdatagroup.py
+++ b/odxtools/specialdatagroup.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Union
 from xml.etree import ElementTree
 
@@ -15,7 +15,7 @@ class SpecialDataGroup:
     """This corresponds to the SDG XML tag"""
     sdg_caption: SpecialDataGroupCaption | None = None
     sdg_caption_ref: OdxLinkRef | None = None
-    values: list[Union["SpecialDataGroup", SpecialData]]
+    values: list[Union["SpecialDataGroup", SpecialData]] = field(default_factory=list)
     semantic_info: str | None  # the "SI" attribute
 
     @staticmethod

--- a/odxtools/statechart.py
+++ b/odxtools/statechart.py
@@ -20,7 +20,7 @@ class StateChart(IdentifiableElement):
     Corresponds to STATE-CHART.
     """
     semantic: str
-    state_transitions: list[StateTransition]
+    state_transitions: list[StateTransition] = field(default_factory=list)
     start_state_snref: str
     states: NamedItemList[State] = field(default_factory=NamedItemList)
 

--- a/odxtools/statechart.py
+++ b/odxtools/statechart.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -22,7 +22,7 @@ class StateChart(IdentifiableElement):
     semantic: str
     state_transitions: list[StateTransition]
     start_state_snref: str
-    states: NamedItemList[State]
+    states: NamedItemList[State] = field(default_factory=NamedItemList)
 
     @property
     def start_state(self) -> State:

--- a/odxtools/statetransition.py
+++ b/odxtools/statetransition.py
@@ -20,7 +20,7 @@ class StateTransition(IdentifiableElement):
     """
     source_snref: str
     target_snref: str
-    external_access_method: ExternalAccessMethod | None
+    external_access_method: ExternalAccessMethod | None = None
 
     @property
     def source_state(self) -> State:

--- a/odxtools/statetransitionref.py
+++ b/odxtools/statetransitionref.py
@@ -156,10 +156,10 @@ class StateTransitionRef(OdxLinkRef):
     may also be conditional on the observed response of the ECU.
 
     """
-    value: str | None
+    value: str | None = None
 
-    in_param_if_snref: str | None
-    in_param_if_snpathref: str | None
+    in_param_if_snref: str | None = None
+    in_param_if_snpathref: str | None = None
 
     @property
     def state_transition(self) -> StateTransition:

--- a/odxtools/structure.py
+++ b/odxtools/structure.py
@@ -10,7 +10,7 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class Structure(BasicStructure):
-    is_visible_raw: bool | None
+    is_visible_raw: bool | None = None
 
     @property
     def is_visible(self) -> bool:

--- a/odxtools/subcomponent.py
+++ b/odxtools/subcomponent.py
@@ -26,7 +26,7 @@ class SubComponent(IdentifiableElement):
 
     """
 
-    sub_component_patterns: list[SubComponentPattern]
+    sub_component_patterns: list[SubComponentPattern] = field(default_factory=list)
     sub_component_param_connectors: NamedItemList[SubComponentParamConnector] = field(
         default_factory=NamedItemList)
     table_row_connectors: NamedItemList[TableRowConnector] = field(default_factory=NamedItemList)

--- a/odxtools/subcomponent.py
+++ b/odxtools/subcomponent.py
@@ -32,7 +32,7 @@ class SubComponent(IdentifiableElement):
     env_data_connectors: NamedItemList[EnvDataConnector]
     dtc_connectors: NamedItemList[DtcConnector]
 
-    semantic: str | None
+    semantic: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SubComponent":

--- a/odxtools/subcomponent.py
+++ b/odxtools/subcomponent.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -27,10 +27,11 @@ class SubComponent(IdentifiableElement):
     """
 
     sub_component_patterns: list[SubComponentPattern]
-    sub_component_param_connectors: NamedItemList[SubComponentParamConnector]
-    table_row_connectors: NamedItemList[TableRowConnector]
-    env_data_connectors: NamedItemList[EnvDataConnector]
-    dtc_connectors: NamedItemList[DtcConnector]
+    sub_component_param_connectors: NamedItemList[SubComponentParamConnector] = field(
+        default_factory=NamedItemList)
+    table_row_connectors: NamedItemList[TableRowConnector] = field(default_factory=NamedItemList)
+    env_data_connectors: NamedItemList[EnvDataConnector] = field(default_factory=NamedItemList)
+    dtc_connectors: NamedItemList[DtcConnector] = field(default_factory=NamedItemList)
 
     semantic: str | None = None
 

--- a/odxtools/subcomponentparamconnector.py
+++ b/odxtools/subcomponentparamconnector.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -19,8 +19,8 @@ class SubComponentParamConnector(IdentifiableElement):
     diag_comm_snref: str
 
     # TODO: we currently only support SNREFs, not SNPATHREFs
-    out_param_if_refs: list[str]
-    in_param_if_refs: list[str]
+    out_param_if_refs: list[str] = field(default_factory=list)
+    in_param_if_refs: list[str] = field(default_factory=list)
 
     @property
     def service(self) -> DiagService:

--- a/odxtools/subcomponentpattern.py
+++ b/odxtools/subcomponentpattern.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class SubComponentPattern:
-    matching_parameters: list["MatchingParameter"]
+    matching_parameters: list["MatchingParameter"] = field(default_factory=list)
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SubComponentPattern":

--- a/odxtools/swvariable.py
+++ b/odxtools/swvariable.py
@@ -9,8 +9,8 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class SwVariable(NamedElement):
-    origin: str | None
-    oid: str | None
+    origin: str | None = None
+    oid: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "SwVariable":

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -20,14 +20,14 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class Table(IdentifiableElement):
     """This class represents a TABLE."""
-    key_label: str | None
-    struct_label: str | None
-    admin_data: AdminData | None
-    key_dop_ref: OdxLinkRef | None
+    key_label: str | None = None
+    struct_label: str | None = None
+    admin_data: AdminData | None = None
+    key_dop_ref: OdxLinkRef | None = None
     table_rows_raw: list[TableRow | OdxLinkRef]
     table_diag_comm_connectors: list[TableDiagCommConnector]
     sdgs: list[SpecialDataGroup]
-    semantic: str | None
+    semantic: str | None = None
 
     @property
     def key_dop(self) -> DataObjectProperty | None:

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -24,9 +24,9 @@ class Table(IdentifiableElement):
     struct_label: str | None = None
     admin_data: AdminData | None = None
     key_dop_ref: OdxLinkRef | None = None
-    table_rows_raw: list[TableRow | OdxLinkRef]
-    table_diag_comm_connectors: list[TableDiagCommConnector]
-    sdgs: list[SpecialDataGroup]
+    table_rows_raw: list[TableRow | OdxLinkRef] = field(default_factory=list)
+    table_diag_comm_connectors: list[TableDiagCommConnector] = field(default_factory=list)
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
     semantic: str | None = None
 
     @property

--- a/odxtools/tablediagcommconnector.py
+++ b/odxtools/tablediagcommconnector.py
@@ -14,8 +14,8 @@ from .snrefcontext import SnRefContext
 class TableDiagCommConnector:
     semantic: str
 
-    diag_comm_ref: OdxLinkRef | None
-    diag_comm_snref: str | None
+    diag_comm_ref: OdxLinkRef | None = None
+    diag_comm_snref: str | None = None
 
     @property
     def diag_comm(self) -> DiagComm:

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
@@ -39,11 +39,11 @@ class TableRow(IdentifiableElement):
     structure_ref: OdxLinkRef | None = None
     structure_snref: str | None = None
 
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
     audience: Audience | None = None
-    functional_class_refs: list[OdxLinkRef]
-    state_transition_refs: list[StateTransitionRef]
-    pre_condition_state_refs: list[PreConditionStateRef]
+    functional_class_refs: list[OdxLinkRef] = field(default_factory=list)
+    state_transition_refs: list[StateTransitionRef] = field(default_factory=list)
+    pre_condition_state_refs: list[PreConditionStateRef] = field(default_factory=list)
     admin_data: AdminData | None = None
 
     is_executable_raw: bool | None = None

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -34,22 +34,22 @@ class TableRow(IdentifiableElement):
     # The spec mandates that either a structure or a non-complex DOP
     # must be referenced here, i.e., exactly one of the four
     # attributes below is not None
-    dop_ref: OdxLinkRef | None
-    dop_snref: str | None
-    structure_ref: OdxLinkRef | None
-    structure_snref: str | None
+    dop_ref: OdxLinkRef | None = None
+    dop_snref: str | None = None
+    structure_ref: OdxLinkRef | None = None
+    structure_snref: str | None = None
 
     sdgs: list[SpecialDataGroup]
-    audience: Audience | None
+    audience: Audience | None = None
     functional_class_refs: list[OdxLinkRef]
     state_transition_refs: list[StateTransitionRef]
     pre_condition_state_refs: list[PreConditionStateRef]
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
 
-    is_executable_raw: bool | None
-    semantic: str | None
-    is_mandatory_raw: bool | None
-    is_final_raw: bool | None
+    is_executable_raw: bool | None = None
+    semantic: str | None = None
+    is_mandatory_raw: bool | None = None
+    is_final_raw: bool | None = None
 
     @property
     def table(self) -> "Table":

--- a/odxtools/teammember.py
+++ b/odxtools/teammember.py
@@ -14,13 +14,13 @@ from .utils import dataclass_fields_asdict
 @dataclass(kw_only=True)
 class TeamMember(IdentifiableElement):
     roles: list[str]
-    department: str | None
-    address: str | None
-    zipcode: str | None  # the tag for this is "ZIP", but `zip` is a keyword in python
-    city: str | None
-    phone: str | None
-    fax: str | None
-    email: str | None
+    department: str | None = None
+    address: str | None = None
+    zipcode: str | None = None  # the tag for this is "ZIP", but `zip` is a keyword in python
+    city: str | None = None
+    phone: str | None = None
+    fax: str | None = None
+    email: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "TeamMember":

--- a/odxtools/teammember.py
+++ b/odxtools/teammember.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -13,7 +13,7 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class TeamMember(IdentifiableElement):
-    roles: list[str]
+    roles: list[str] = field(default_factory=list)
     department: str | None = None
     address: str | None = None
     zipcode: str | None = None  # the tag for this is "ZIP", but `zip` is a keyword in python

--- a/odxtools/text.py
+++ b/odxtools/text.py
@@ -7,7 +7,7 @@ from .odxdoccontext import OdxDocContext
 @dataclass(kw_only=True)
 class Text:
     text: str
-    text_identifier: str | None
+    text_identifier: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "Text":

--- a/odxtools/unit.py
+++ b/odxtools/unit.py
@@ -54,9 +54,9 @@ class Unit(IdentifiableElement):
     ```
     """
     display_name: str
-    factor_si_to_unit: float | None
-    offset_si_to_unit: float | None
-    physical_dimension_ref: OdxLinkRef | None
+    factor_si_to_unit: float | None = None
+    offset_si_to_unit: float | None = None
+    physical_dimension_ref: OdxLinkRef | None = None
 
     @property
     def physical_dimension(self) -> PhysicalDimension | None:

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -22,7 +22,7 @@ class UnitGroup(NamedElement):
     """
     category: UnitGroupCategory
     unit_refs: list[OdxLinkRef]
-    oid: str | None
+    oid: str | None = None
 
     @property
     def units(self) -> NamedItemList[Unit]:

--- a/odxtools/unitgroup.py
+++ b/odxtools/unitgroup.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 from xml.etree import ElementTree
 
@@ -21,7 +21,7 @@ class UnitGroup(NamedElement):
     There are two categories of groups: COUNTRY and EQUIV-UNITS.
     """
     category: UnitGroupCategory
-    unit_refs: list[OdxLinkRef]
+    unit_refs: list[OdxLinkRef] = field(default_factory=list)
     oid: str | None = None
 
     @property

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -30,7 +30,7 @@ class UnitSpec:
     unit_groups: NamedItemList[UnitGroup] = field(default_factory=NamedItemList)
     units: NamedItemList[Unit] = field(default_factory=NamedItemList)
     physical_dimensions: NamedItemList[PhysicalDimension] = field(default_factory=NamedItemList)
-    sdgs: list[SpecialDataGroup]
+    sdgs: list[SpecialDataGroup] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.unit_groups = NamedItemList(self.unit_groups)

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from xml.etree import ElementTree
 
@@ -27,9 +27,9 @@ class UnitSpec:
     """
 
     admin_data: AdminData | None = None
-    unit_groups: NamedItemList[UnitGroup]
-    units: NamedItemList[Unit]
-    physical_dimensions: NamedItemList[PhysicalDimension]
+    unit_groups: NamedItemList[UnitGroup] = field(default_factory=NamedItemList)
+    units: NamedItemList[Unit] = field(default_factory=NamedItemList)
+    physical_dimensions: NamedItemList[PhysicalDimension] = field(default_factory=NamedItemList)
     sdgs: list[SpecialDataGroup]
 
     def __post_init__(self) -> None:

--- a/odxtools/unitspec.py
+++ b/odxtools/unitspec.py
@@ -26,7 +26,7 @@ class UnitSpec:
     The following odx elements are not internalized: ADMIN-DATA, SDGS
     """
 
-    admin_data: AdminData | None
+    admin_data: AdminData | None = None
     unit_groups: NamedItemList[UnitGroup]
     units: NamedItemList[Unit]
     physical_dimensions: NamedItemList[PhysicalDimension]

--- a/odxtools/xdoc.py
+++ b/odxtools/xdoc.py
@@ -12,12 +12,12 @@ from .utils import dataclass_fields_asdict
 
 @dataclass(kw_only=True)
 class XDoc(NamedElement):
-    number: str | None
-    state: str | None
-    date: str | None
-    publisher: str | None
-    url: str | None
-    position: str | None
+    number: str | None = None
+    state: str | None = None
+    date: str | None = None
+    publisher: str | None = None
+    url: str | None = None
+    position: str | None = None
 
     @staticmethod
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "XDoc":


### PR DESCRIPTION
This is another PR that firmly belongs into the "long and boring" category: It specifies default values for all optional fields of dataclasses, i.e. fields that can be `None` or are a list. (We can do this now, because all these classes are now `kw_only`.) In the interest of keeping the scope of this PR as small as possible, removing the parameter value specifications of defaulted fields when such a class is instantiated in the examples and tests will be done in a follow-up PR...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
