### PR TITLE
support computing the MUX static length if all the cases have the same size

### DIFF
--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -263,4 +263,5 @@ class Multiplexer(ComplexDop):
         if switch_key_size is None:
             return None
 
-        return max(switch_key_size + self.switch_key.byte_position, reference_size + self.byte_position)
+        return max(switch_key_size + self.switch_key.byte_position,
+                   reference_size + self.byte_position)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -247,15 +247,20 @@ class Multiplexer(ComplexDop):
         Otherwise, returns None to indicate that the size is dynamic.
         """
         reference_case = self.default_case if self.default_case else self.cases[0]
+
+        case_bit_length: int | None
         if reference_case.structure is None:
-            return None
-        case_bit_length = reference_case.structure.get_static_bit_length()
+            case_bit_length = 0
+        else:
+            case_bit_length = reference_case.structure.get_static_bit_length()
         if case_bit_length is None:
             return None
+        case_size: int | None
         for mux_case in self.cases:
             if mux_case.structure is None:
-                return None
-            case_size = mux_case.structure.get_static_bit_length()
+                case_size = 0
+            else:
+                case_size = mux_case.structure.get_static_bit_length()
             if case_size != case_bit_length:
                 return None  # Found a case with a different or unknown size
 

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -265,5 +265,4 @@ class Multiplexer(ComplexDop):
 
         return max(
             switch_key_size + self.switch_key.byte_position * 8 +
-            (self.switch_key.bit_position if self.switch_key.bit_position else 0),
-            case_bit_length + self.byte_position * 8)
+            (self.switch_key.bit_position or 0), case_bit_length + self.byte_position * 8)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -236,3 +236,21 @@ class Multiplexer(ComplexDop):
         decode_state.origin_byte_position = orig_origin
 
         return result
+
+    @override
+    def get_static_bit_length(self) -> int | None:
+        """
+        Returns the static bit length of the multiplexer structure, if determinable.
+        If all cases (including the default, if present) have the same static bit length,
+        the codec length is considered static and is returned.
+        Otherwise, returns None to indicate that the size is dynamic.
+        """
+        reference_case = self.default_case if self.default_case else self.cases[0]
+        reference_size = reference_case.structure.get_static_bit_length()
+
+        for mux_case in self.cases:
+            case_size = mux_case.structure.get_static_bit_length()
+            if case_size != reference_size:
+                return None  # Found a case with a different or unknown size
+
+        return reference_size

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -249,7 +249,7 @@ class Multiplexer(ComplexDop):
         reference_case = self.default_case if self.default_case else self.cases[0]
         if reference_case.structure is None:
             return None
-        reference_size = reference_case.structure.get_static_bit_length()
+        case_bit_length = reference_case.structure.get_static_bit_length()
         if reference_size is None:
             return None
         for mux_case in self.cases:

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -241,6 +241,7 @@ class Multiplexer(ComplexDop):
     def get_static_bit_length(self) -> int | None:
         """
         Returns the static bit length of the multiplexer structure, if determinable.
+
         If all cases (including the default, if present) have the same static bit length,
         the codec length is considered static and is returned.
         Otherwise, returns None to indicate that the size is dynamic.
@@ -249,7 +250,8 @@ class Multiplexer(ComplexDop):
         if reference_case.structure is None:
             return None
         reference_size = reference_case.structure.get_static_bit_length()
-
+        if reference_size is None:
+            return None
         for mux_case in self.cases:
             if mux_case.structure is None:
                 return None
@@ -257,4 +259,8 @@ class Multiplexer(ComplexDop):
             if case_size != reference_size:
                 return None  # Found a case with a different or unknown size
 
-        return reference_size
+        switch_key_size = self.switch_key.dop.get_static_bit_length()
+        if switch_key_size is None:
+            return None
+
+        return max(switch_key_size + self.switch_key.byte_position, reference_size + self.byte_position)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -250,18 +250,20 @@ class Multiplexer(ComplexDop):
         if reference_case.structure is None:
             return None
         case_bit_length = reference_case.structure.get_static_bit_length()
-        if reference_size is None:
+        if case_bit_length is None:
             return None
         for mux_case in self.cases:
             if mux_case.structure is None:
                 return None
             case_size = mux_case.structure.get_static_bit_length()
-            if case_size != reference_size:
+            if case_size != case_bit_length:
                 return None  # Found a case with a different or unknown size
 
         switch_key_size = self.switch_key.dop.get_static_bit_length()
         if switch_key_size is None:
             return None
 
-        return max(switch_key_size + self.switch_key.byte_position,
-                   reference_size + self.byte_position)
+        return max(
+            switch_key_size + self.switch_key.byte_position * 8 +
+            (self.switch_key.bit_position if self.switch_key.bit_position else 0),
+            case_bit_length + self.byte_position * 8)

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -246,9 +246,13 @@ class Multiplexer(ComplexDop):
         Otherwise, returns None to indicate that the size is dynamic.
         """
         reference_case = self.default_case if self.default_case else self.cases[0]
+        if reference_case.structure is None:
+            return None
         reference_size = reference_case.structure.get_static_bit_length()
 
         for mux_case in self.cases:
+            if mux_case.structure is None:
+                return None
             case_size = mux_case.structure.get_static_bit_length()
             if case_size != reference_size:
                 return None  # Found a case with a different or unknown size

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -280,8 +280,9 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         if mux.default_case:
             mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
-        self.assertEqual(mux.get_static_bit_length(),  # mux cases doesn't have the same structure size
-                         None)
+        self.assertEqual(  # mux cases doesn't have the same structure size
+            mux.get_static_bit_length(),
+            None)
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(mux.get_static_bit_length(), 16)

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -277,12 +277,15 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         self.assertEqual(decoded, ("default_case", {}))
 
         self.assertEqual(mux.get_static_bit_length(), None)  # mux default case structure is None
-        mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
+        if mux.default_case:
+            mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
-        self.assertEqual(mux.get_static_bit_length(), None)  # mux cases doesn't have the same structure size
+        self.assertEqual(mux.get_static_bit_length(),
+                         None)  # mux cases doesn't have the same structure size
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(mux.get_static_bit_length(), 16)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -276,7 +276,6 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         decoded = mux.decode_from_pdu(decode_state)
         self.assertEqual(decoded, ("default_case", {}))
 
-        self.assertEqual(mux.get_static_bit_length(), None)  # mux default case structure is None
         assert mux.default_case is not None
         mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
@@ -285,6 +284,24 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(mux.get_static_bit_length(), 16)
+
+        # zero-case scenario, only default case is considered
+        cases = mux.cases
+        mux.cases = NamedItemList()
+        ecu._resolve_odxlinks(odxlinks)
+        self.assertEqual(mux.get_static_bit_length(), 16)
+
+        # no default case, but cases have the same structure size
+        mux.default_case = None
+        mux.cases = cases
+        ecu._resolve_odxlinks(odxlinks)
+        self.assertEqual(mux.get_static_bit_length(), 16)
+
+        # no default case, and each case has no associated structure, only the switch key size is considered
+        mux.cases[0].structure_ref = None
+        mux.cases[1].structure_ref = None
+        ecu._resolve_odxlinks(odxlinks)
+        self.assertEqual(mux.get_static_bit_length(), 8)
 
 
 if __name__ == "__main__":

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -276,11 +276,12 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         decoded = mux.decode_from_pdu(decode_state)
         self.assertEqual(decoded, ("default_case", {}))
 
+        # mux cases don't have the same structure size
         assert mux.default_case is not None
         mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
-        self.assertEqual(  # mux cases don't have the same structure size
-            mux.get_static_bit_length(), None)
+        self.assertEqual(mux.get_static_bit_length(), None)
+        # mux cases have the same structure size
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(mux.get_static_bit_length(), 16)

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -277,7 +277,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         self.assertEqual(decoded, ("default_case", {}))
 
         self.assertEqual(mux.get_static_bit_length(), None)  # mux default case structure is None
-        self.assertIsNotNone(mux.default_case)
+        assert mux.default_case is not None
         mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(  # mux cases don't have the same structure size

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -276,6 +276,13 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         decoded = mux.decode_from_pdu(decode_state)
         self.assertEqual(decoded, ("default_case", {}))
 
+        self.assertEqual(mux.get_static_bit_length(), None)  # mux default case structure is None
+        mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
+        ecu._resolve_odxlinks(odxlinks)
+        self.assertEqual(mux.get_static_bit_length(), None)  # mux cases doesn't have the same structure size
+        mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
+        ecu._resolve_odxlinks(odxlinks)
+        self.assertEqual(mux.get_static_bit_length(), 16)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -277,10 +277,10 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         self.assertEqual(decoded, ("default_case", {}))
 
         self.assertEqual(mux.get_static_bit_length(), None)  # mux default case structure is None
-        if mux.default_case:
-            mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
+        self.assertIsNotNone(mux.default_case)
+        mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
-        self.assertEqual(  # mux cases doesn't have the same structure size
+        self.assertEqual(  # mux cases don't have the same structure size
             mux.get_static_bit_length(), None)
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -281,8 +281,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
             mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(  # mux cases doesn't have the same structure size
-            mux.get_static_bit_length(),
-            None)
+            mux.get_static_bit_length(), None)
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(mux.get_static_bit_length(), 16)

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -280,8 +280,8 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         if mux.default_case:
             mux.default_case.structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
-        self.assertEqual(mux.get_static_bit_length(),
-                         None)  # mux cases doesn't have the same structure size
+        self.assertEqual(mux.get_static_bit_length(),  # mux cases doesn't have the same structure size
+                         None)
         mux.cases[0].structure_ref = OdxLinkRef.from_id(mux_case2_struct.odx_id)
         ecu._resolve_odxlinks(odxlinks)
         self.assertEqual(mux.get_static_bit_length(), 16)


### PR DESCRIPTION
This MR introduces support for calculating the static length of the multiplexer when all cases have the same size, enabling the codec length to be considered static.