### PR TITLE
Keep track of specialization level in inheritance resolution

### DIFF
--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -17,7 +17,7 @@ from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import VariableGroup
 from .basevariantraw import BaseVariantRaw
-from .diaglayer import DiagLayer
+from .diaglayer import DiagLayer, TInheritedObjects
 from .hierarchyelement import HierarchyElement
 
 
@@ -109,27 +109,31 @@ class BaseVariant(HierarchyElement):
     def _compute_available_diag_variables(self,
                                           odxlinks: OdxLinkDatabase) -> Iterable[DiagVariable]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> Iterable[DiagVariable]:
+        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[DiagVariable]:
             if not hasattr(dl.diag_layer_raw, "diag_variables"):
                 return []
 
-            return dl.diag_layer_raw.diag_variables  # type: ignore[no-any-return]
+            prio = dl.variant_type.inheritance_priority
+            return [(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
 
-        return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        return [x[0] for x in available_objects]
 
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> Iterable[VariableGroup]:
+        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[VariableGroup]:
             if not hasattr(dl.diag_layer_raw, "variable_groups"):
                 return []
 
-            return dl.diag_layer_raw.variable_groups  # type: ignore[no-any-return]
+            prio = dl.variant_type.inheritance_priority
+            return [(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
-        return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        return [x[0] for x in available_objects]

--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -120,7 +120,7 @@ class BaseVariant(HierarchyElement):
             return parent_ref.not_inherited_variables
 
         available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-        return [x[0] for x in available_objects]
+        return [x.object for x in available_objects]
 
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
@@ -136,4 +136,4 @@ class BaseVariant(HierarchyElement):
             return []
 
         available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-        return [x[0] for x in available_objects]
+        return [x.object for x in available_objects]

--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -17,7 +17,7 @@ from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import VariableGroup
 from .basevariantraw import BaseVariantRaw
-from .diaglayer import DiagLayer, TInheritedObjects
+from .diaglayer import DiagLayer, InheritanceTriplet
 from .hierarchyelement import HierarchyElement
 
 
@@ -109,12 +109,12 @@ class BaseVariant(HierarchyElement):
     def _compute_available_diag_variables(self,
                                           odxlinks: OdxLinkDatabase) -> Iterable[DiagVariable]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[DiagVariable]:
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[InheritanceTriplet[DiagVariable]]:
             if not hasattr(dl.diag_layer_raw, "diag_variables"):
                 return []
 
             prio = dl.variant_type.inheritance_priority
-            return [(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
+            return [InheritanceTriplet(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
@@ -125,12 +125,12 @@ class BaseVariant(HierarchyElement):
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[VariableGroup]:
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[InheritanceTriplet[VariableGroup]]:
             if not hasattr(dl.diag_layer_raw, "variable_groups"):
                 return []
 
             prio = dl.variant_type.inheritance_priority
-            return [(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
+            return [InheritanceTriplet(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -29,9 +29,11 @@ from ..specialdatagroup import SpecialDataGroup
 from ..subcomponent import SubComponent
 from ..unitgroup import UnitGroup
 from .diaglayerraw import DiagLayerRaw
-from .diaglayertype import DiagLayerType
+from .diaglayertype import DiagLayerType, TInheritancePrio
 
 PrefixTree = dict[int, Union[list[DiagService], "PrefixTree"]]
+TInheritedObject = tuple[TNamed, "DiagLayer", TInheritancePrio]
+TInheritedObjects = Iterable[tuple[TNamed, "DiagLayer", TInheritancePrio]]
 
 
 @dataclass(kw_only=True)
@@ -156,9 +158,9 @@ class DiagLayer:
 
     def _compute_available_objects(
         self,
-        get_local_objects: Callable[["DiagLayer"], Iterable[TNamed]],
+        get_local_objects: Callable[["DiagLayer"], TInheritedObjects[TNamed]],
         get_not_inherited: Callable[[ParentRef], Iterable[str]],
-    ) -> Iterable[TNamed]:
+    ) -> TInheritedObjects[TNamed]:
         """Helper method to compute the set of all objects applicable
         to the DiagLayer if these objects are subject to the value
         inheritance mechanism

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import sys
 from collections.abc import Callable, Iterable
 from copy import copy, deepcopy
 from dataclasses import dataclass
@@ -30,21 +29,16 @@ from ..specialdatagroup import SpecialDataGroup
 from ..subcomponent import SubComponent
 from ..unitgroup import UnitGroup
 from .diaglayerraw import DiagLayerRaw
-from .diaglayertype import DiagLayerType, InheritancePriority
-
-# python 3.10 does not support generic namedtuples
-if sys.version_info >= (3, 11):
-    from typing import NamedTuple
-else:
-    from typing_extensions import NamedTuple
+from .diaglayertype import DiagLayerType
 
 PrefixTree = dict[int, Union[list[DiagService], "PrefixTree"]]
 
 
-class InheritanceTriplet(Generic[TNamed], NamedTuple):
+@dataclass(slots=True, frozen=True)
+class InheritanceTriplet(Generic[TNamed]):
     object: TNamed
     source: "DiagLayer"
-    prio: InheritancePriority
+    priority: int
 
 
 @dataclass(kw_only=True)

--- a/odxtools/diaglayers/diaglayertype.py
+++ b/odxtools/diaglayers/diaglayertype.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
-from typing import NewType
-
-InheritancePriority = NewType("InheritancePriority", float)
 
 
 class DiagLayerType(Enum):
@@ -13,7 +10,7 @@ class DiagLayerType(Enum):
     ECU_SHARED_DATA = "ECU-SHARED-DATA"
 
     @property
-    def inheritance_priority(self) -> InheritancePriority:
+    def inheritance_priority(self) -> int:
         """Return the inheritance priority of diag layers of the given type
 
         ODX mandates that diagnostic layers can only inherit from
@@ -21,12 +18,12 @@ class DiagLayerType(Enum):
 
         """
 
-        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, InheritancePriority] = {
-            DiagLayerType.ECU_SHARED_DATA: InheritancePriority(0),
-            DiagLayerType.PROTOCOL: InheritancePriority(1),
-            DiagLayerType.FUNCTIONAL_GROUP: InheritancePriority(2),
-            DiagLayerType.BASE_VARIANT: InheritancePriority(3),
-            DiagLayerType.ECU_VARIANT: InheritancePriority(4),
+        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, int] = {
+            DiagLayerType.ECU_SHARED_DATA: 0,
+            DiagLayerType.PROTOCOL: 10,
+            DiagLayerType.FUNCTIONAL_GROUP: 20,
+            DiagLayerType.BASE_VARIANT: 30,
+            DiagLayerType.ECU_VARIANT: 40,
         }
 
         return PRIORITY_OF_DIAG_LAYER_TYPE[self]

--- a/odxtools/diaglayers/diaglayertype.py
+++ b/odxtools/diaglayers/diaglayertype.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import NewType
 
-TInheritancePrio = NewType("TInheritancePrio", float)
+InheritancePriority = NewType("InheritancePriority", float)
 
 
 class DiagLayerType(Enum):
@@ -13,7 +13,7 @@ class DiagLayerType(Enum):
     ECU_SHARED_DATA = "ECU-SHARED-DATA"
 
     @property
-    def inheritance_priority(self) -> TInheritancePrio:
+    def inheritance_priority(self) -> InheritancePriority:
         """Return the inheritance priority of diag layers of the given type
 
         ODX mandates that diagnostic layers can only inherit from
@@ -21,12 +21,12 @@ class DiagLayerType(Enum):
 
         """
 
-        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, TInheritancePrio] = {
-            DiagLayerType.ECU_SHARED_DATA: TInheritancePrio(0),
-            DiagLayerType.PROTOCOL: TInheritancePrio(1),
-            DiagLayerType.FUNCTIONAL_GROUP: TInheritancePrio(2),
-            DiagLayerType.BASE_VARIANT: TInheritancePrio(3),
-            DiagLayerType.ECU_VARIANT: TInheritancePrio(4),
+        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, InheritancePriority] = {
+            DiagLayerType.ECU_SHARED_DATA: InheritancePriority(0),
+            DiagLayerType.PROTOCOL: InheritancePriority(1),
+            DiagLayerType.FUNCTIONAL_GROUP: InheritancePriority(2),
+            DiagLayerType.BASE_VARIANT: InheritancePriority(3),
+            DiagLayerType.ECU_VARIANT: InheritancePriority(4),
         }
 
         return PRIORITY_OF_DIAG_LAYER_TYPE[self]

--- a/odxtools/diaglayers/diaglayertype.py
+++ b/odxtools/diaglayers/diaglayertype.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: MIT
 from enum import Enum
+from typing import NewType
+
+TInheritancePrio = NewType("TInheritancePrio", float)
 
 
 class DiagLayerType(Enum):
@@ -10,7 +13,7 @@ class DiagLayerType(Enum):
     ECU_SHARED_DATA = "ECU-SHARED-DATA"
 
     @property
-    def inheritance_priority(self) -> int:
+    def inheritance_priority(self) -> TInheritancePrio:
         """Return the inheritance priority of diag layers of the given type
 
         ODX mandates that diagnostic layers can only inherit from
@@ -18,24 +21,12 @@ class DiagLayerType(Enum):
 
         """
 
-        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, int] = {
-            DiagLayerType.PROTOCOL:
-                1,
-            DiagLayerType.FUNCTIONAL_GROUP:
-                2,
-            DiagLayerType.BASE_VARIANT:
-                3,
-            DiagLayerType.ECU_VARIANT:
-                4,
-
-            # ECU shared data layers are a bit weird (see section
-            # 7.3.2.4.4 of the ASAM specification): they can be
-            # inherited from by any other layer but they will
-            # override any objects which are also provided by any of
-            # the other parent layers. tl;dr: When it comes to
-            # inheritance, they have the highest priority.
-            DiagLayerType.ECU_SHARED_DATA:
-                100,
+        PRIORITY_OF_DIAG_LAYER_TYPE: dict[DiagLayerType, TInheritancePrio] = {
+            DiagLayerType.ECU_SHARED_DATA: TInheritancePrio(0),
+            DiagLayerType.PROTOCOL: TInheritancePrio(1),
+            DiagLayerType.FUNCTIONAL_GROUP: TInheritancePrio(2),
+            DiagLayerType.BASE_VARIANT: TInheritancePrio(3),
+            DiagLayerType.ECU_VARIANT: TInheritancePrio(4),
         }
 
         return PRIORITY_OF_DIAG_LAYER_TYPE[self]

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -127,7 +127,7 @@ class EcuVariant(HierarchyElement):
             return parent_ref.not_inherited_variables
 
         available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-        return [x[0] for x in available_objects]
+        return [x.object for x in available_objects]
 
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
@@ -143,4 +143,4 @@ class EcuVariant(HierarchyElement):
             return []
 
         available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-        return [x[0] for x in available_objects]
+        return [x.object for x in available_objects]

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -17,7 +17,7 @@ from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import HasVariableGroups, VariableGroup
 from .basevariant import BaseVariant
-from .diaglayer import DiagLayer
+from .diaglayer import DiagLayer, TInheritedObjects
 from .ecuvariantraw import EcuVariantRaw
 from .hierarchyelement import HierarchyElement
 
@@ -116,27 +116,31 @@ class EcuVariant(HierarchyElement):
     def _compute_available_diag_variables(self,
                                           odxlinks: OdxLinkDatabase) -> Iterable[DiagVariable]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> Iterable[DiagVariable]:
+        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[DiagVariable]:
             if not isinstance(dl.diag_layer_raw, HasDiagVariables):
                 return []
 
-            return dl.diag_layer_raw.diag_variables
+            prio = dl.variant_type.inheritance_priority
+            return [(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
 
-        return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        return [x[0] for x in available_objects]
 
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> Iterable[VariableGroup]:
+        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[VariableGroup]:
             if not isinstance(dl.diag_layer_raw, HasVariableGroups):
                 return []
 
-            return dl.diag_layer_raw.variable_groups
+            prio = dl.variant_type.inheritance_priority
+            return [(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
-        return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        return [x[0] for x in available_objects]

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -17,7 +17,7 @@ from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import HasVariableGroups, VariableGroup
 from .basevariant import BaseVariant
-from .diaglayer import DiagLayer, TInheritedObjects
+from .diaglayer import DiagLayer, InheritanceTriplet
 from .ecuvariantraw import EcuVariantRaw
 from .hierarchyelement import HierarchyElement
 
@@ -116,12 +116,12 @@ class EcuVariant(HierarchyElement):
     def _compute_available_diag_variables(self,
                                           odxlinks: OdxLinkDatabase) -> Iterable[DiagVariable]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[DiagVariable]:
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[InheritanceTriplet[DiagVariable]]:
             if not isinstance(dl.diag_layer_raw, HasDiagVariables):
                 return []
 
             prio = dl.variant_type.inheritance_priority
-            return [(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
+            return [InheritanceTriplet(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
@@ -132,12 +132,12 @@ class EcuVariant(HierarchyElement):
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[VariableGroup]:
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[InheritanceTriplet[VariableGroup]]:
             if not isinstance(dl.diag_layer_raw, HasVariableGroups):
                 return []
 
             prio = dl.variant_type.inheritance_priority
-            return [(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
+            return [InheritanceTriplet(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -14,7 +14,7 @@ from ..odxdoccontext import OdxDocContext
 from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import VariableGroup
-from .diaglayer import DiagLayer, TInheritedObjects
+from .diaglayer import DiagLayer, InheritanceTriplet
 from .functionalgroupraw import FunctionalGroupRaw
 from .hierarchyelement import HierarchyElement
 
@@ -68,12 +68,12 @@ class FunctionalGroup(HierarchyElement):
     def _compute_available_diag_variables(self,
                                           odxlinks: OdxLinkDatabase) -> Iterable[DiagVariable]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[DiagVariable]:
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[InheritanceTriplet[DiagVariable]]:
             if not hasattr(dl.diag_layer_raw, "diag_variables"):
                 return []
 
             prio = dl.variant_type.inheritance_priority
-            return [(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
+            return [InheritanceTriplet(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
@@ -84,12 +84,12 @@ class FunctionalGroup(HierarchyElement):
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[VariableGroup]:
+        def get_local_objects_fn(dl: DiagLayer) -> Iterable[InheritanceTriplet[VariableGroup]]:
             if not hasattr(dl.diag_layer_raw, "variable_groups"):
                 return []
 
             prio = dl.variant_type.inheritance_priority
-            return [(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
+            return [InheritanceTriplet(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -14,7 +14,7 @@ from ..odxdoccontext import OdxDocContext
 from ..odxlink import OdxLinkDatabase, OdxLinkRef
 from ..parentref import ParentRef
 from ..variablegroup import VariableGroup
-from .diaglayer import DiagLayer
+from .diaglayer import DiagLayer, TInheritedObjects
 from .functionalgroupraw import FunctionalGroupRaw
 from .hierarchyelement import HierarchyElement
 
@@ -68,30 +68,34 @@ class FunctionalGroup(HierarchyElement):
     def _compute_available_diag_variables(self,
                                           odxlinks: OdxLinkDatabase) -> Iterable[DiagVariable]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> Iterable[DiagVariable]:
+        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[DiagVariable]:
             if not hasattr(dl.diag_layer_raw, "diag_variables"):
                 return []
 
-            return dl.diag_layer_raw.diag_variables  # type: ignore[no-any-return]
+            prio = dl.variant_type.inheritance_priority
+            return [(x, dl, prio) for x in dl.diag_layer_raw.diag_variables]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return parent_ref.not_inherited_variables
 
-        return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        return [x[0] for x in available_objects]
 
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
 
-        def get_local_objects_fn(dl: DiagLayer) -> Iterable[VariableGroup]:
+        def get_local_objects_fn(dl: DiagLayer) -> TInheritedObjects[VariableGroup]:
             if not hasattr(dl.diag_layer_raw, "variable_groups"):
                 return []
 
-            return dl.diag_layer_raw.variable_groups  # type: ignore[no-any-return]
+            prio = dl.variant_type.inheritance_priority
+            return [(x, dl, prio) for x in dl.diag_layer_raw.variable_groups]
 
         def not_inherited_fn(parent_ref: ParentRef) -> list[str]:
             return []
 
-        return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
+        return [x[0] for x in available_objects]
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the functional group layer

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -79,7 +79,7 @@ class FunctionalGroup(HierarchyElement):
             return parent_ref.not_inherited_variables
 
         available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-        return [x[0] for x in available_objects]
+        return [x.object for x in available_objects]
 
     def _compute_available_variable_groups(self,
                                            odxlinks: OdxLinkDatabase) -> Iterable[VariableGroup]:
@@ -95,7 +95,7 @@ class FunctionalGroup(HierarchyElement):
             return []
 
         available_objects = self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-        return [x[0] for x in available_objects]
+        return [x.object for x in available_objects]
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """Create a deep copy of the functional group layer


### PR DESCRIPTION
Currently, only the layer type of the parent-ref is considered for resolving inheritance. I changed the return type of `_compute_available_objects()` to return the objects together with their source layer and specialization level.

I also changed the the specialization level of objects imported from ECU-SHARED-DATA according to 7.3.2.4.4.

Motivation: in my PDX file two functional groups FG1 and FG2 inherit from the same protocol PR. FG1 overrides some object. Resolving the objects of base variant BV, which inherits both FG1 and FG2, causes conflicts with the current odxtools implementation.