### PR TITLE
generalize ODXLINK reference writing

### DIFF
--- a/odxtools/templates/comparam-spec.odx-c.xml.jinja2
+++ b/odxtools/templates/comparam-spec.odx-c.xml.jinja2
@@ -12,6 +12,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!-- Written using odxtools {{odxtools_version}} -->
 <ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
+ {{- set_category_docfrag(comparam_spec.short_name, "COMPARAM-SPEC") }}
  <COMPARAM-SPEC  {{- poc.printOdxCategoryAttribs(comparam_spec) }}>
    {{- poc.printOdxCategorySubtags(comparam_spec)|indent(3) }}
    {%- if comparam_spec.prot_stacks %}

--- a/odxtools/templates/comparam-subset.odx-cs.xml.jinja2
+++ b/odxtools/templates/comparam-subset.odx-cs.xml.jinja2
@@ -15,6 +15,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!-- Written using odxtools {{odxtools_version}} -->
 <ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
+ {{- set_category_docfrag(comparam_subset.short_name, "COMPARAM-SUBSET") }}
  <COMPARAM-SUBSET  {{- poc.printOdxCategoryAttribs(comparam_subset) }} {{make_xml_attrib("CATEGORY", comparam_subset.category)}}>
    {{- poc.printOdxCategorySubtags(comparam_subset)|indent(3) }}
    {%- if comparam_subset.comparams %}

--- a/odxtools/templates/diag_layer_container.odx-d.xml.jinja2
+++ b/odxtools/templates/diag_layer_container.odx-d.xml.jinja2
@@ -14,6 +14,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!-- Written using odxtools {{odxtools_version}} -->
 <ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
+ {{- set_category_docfrag(dlc.short_name, "CONTAINER") }}
  <DIAG-LAYER-CONTAINER {{- poc.printOdxCategoryAttribs(dlc) }}>
   {{- poc.printOdxCategorySubtags(dlc)|indent(3) }}
 {%- if dlc.protocols %}
@@ -44,7 +45,7 @@
  {%- endfor %}
   </BASE-VARIANTS>
 {%- endif %}
-{%- if  dlc.ecu_variants %}
+{%- if dlc.ecu_variants %}
   <ECU-VARIANTS>
  {%- for dl in dlc.ecu_variants %}
   {{pecuv.printEcuVariant(dl)|indent(3)}}

--- a/odxtools/templates/macros/printAdminData.xml.jinja2
+++ b/odxtools/templates/macros/printAdminData.xml.jinja2
@@ -14,9 +14,9 @@
  <COMPANY-DOC-INFOS>
   {%- for cdi in admin_data.company_doc_infos %}
   <COMPANY-DOC-INFO>
-    <COMPANY-DATA-REF ID-REF="{{cdi.company_data_ref.ref_id}}" />
+    <COMPANY-DATA-REF {{make_ref_attribs(cdi.company_data_ref)}} />
    {%- if cdi.team_member_ref is not none %}
-    <TEAM-MEMBER-REF ID-REF="{{cdi.team_member_ref.ref_id}}" />
+    <TEAM-MEMBER-REF {{make_ref_attribs(cdi.team_member_ref)}} />
     {%- endif %}
    {%- if cdi.doc_label is not none %}
     <DOC-LABEL>{{cdi.doc_label|e}}</DOC-LABEL>
@@ -31,7 +31,7 @@
   {%- for doc_revision in admin_data.doc_revisions %}
   <DOC-REVISION>
    {%- if doc_revision.team_member_ref is not none %}
-   <TEAM-MEMBER-REF ID-REF="{{doc_revision.team_member_ref.ref_id}}" />
+   <TEAM-MEMBER-REF {{make_ref_attribs(doc_revision.team_member_ref)}} />
    {%- endif %}
    {%- if doc_revision.revision_label is not none %}
    <REVISION-LABEL>{{doc_revision.revision_label|e}}</REVISION-LABEL>
@@ -47,7 +47,7 @@
    <COMPANY-REVISION-INFOS>
      {%- for cri in doc_revision.company_revision_infos %}
      <COMPANY-REVISION-INFO>
-       <COMPANY-DATA-REF ID-REF="{{cri.company_data_ref.ref_id}}" />
+       <COMPANY-DATA-REF {{make_ref_attribs(cri.company_data_ref)}} />
        {%- if cri.revision_label is not none %}
        <REVISION-LABEL>{{cri.revision_label|e}}</REVISION-LABEL>
        {%- endif %}

--- a/odxtools/templates/macros/printAudience.xml.jinja2
+++ b/odxtools/templates/macros/printAudience.xml.jinja2
@@ -20,14 +20,14 @@
 {%- if audience.enabled_audience_refs %}
  <ENABLED-AUDIENCE-REFS>
 {%- for ref in audience.enabled_audience_refs %}
-  <ENABLED-AUDIENCE-REF ID-REF="{{ref.ref_id}}" />
+  <ENABLED-AUDIENCE-REF {{make_ref_attribs(ref)}} />
 {%- endfor %}
  </ENABLED-AUDIENCE-REFS>
 {%- endif%}
 {%- if audience.disabled_audience_refs %}
  <DISABLED-AUDIENCE-REFS>
 {%- for ref in audience.disabled_audience_refs %}
-  <DISABLED-AUDIENCE-REF ID-REF="{{ref.ref_id}}" />
+  <DISABLED-AUDIENCE-REF {{make_ref_attribs(ref)}} />
 {%- endfor %}
  </DISABLED-AUDIENCE-REFS>
 {%- endif%}

--- a/odxtools/templates/macros/printComparam.xml.jinja2
+++ b/odxtools/templates/macros/printComparam.xml.jinja2
@@ -45,7 +45,7 @@
           CPUSAGE="{{cp.cpusage.value}}">
   {{ peid.printElementIdSubtags(cp)|indent(1) }}
   <PHYSICAL-DEFAULT-VALUE>{{cp.physical_default_value_raw}}</PHYSICAL-DEFAULT-VALUE>
- <DATA-OBJECT-PROP-REF ID-REF="{{cp.dop_ref.ref_id}}" />
+ <DATA-OBJECT-PROP-REF {{make_ref_attribs(cp.dop_ref)}} />
 </COMPARAM>
 {%- endmacro %}
 

--- a/odxtools/templates/macros/printComparamRef.xml.jinja2
+++ b/odxtools/templates/macros/printComparamRef.xml.jinja2
@@ -7,9 +7,7 @@
 {#- -#}
 
 {%- macro printComparamRef(cp) %}
-<COMPARAM-REF ID-REF="{{cp.spec_ref.ref_id}}"
-              DOCREF="{{cp.spec_ref.ref_docs[0].doc_name}}"
-              DOCTYPE="COMPARAM-SUBSET">
+<COMPARAM-REF {{make_ref_attribs(cp.spec_ref)}}>
   {%- if cp.value is string %}
   <SIMPLE-VALUE>{{cp.value}}</SIMPLE-VALUE>
   {{ pd.printDescription(cp.description) }}

--- a/odxtools/templates/macros/printCompuMethod.xml.jinja2
+++ b/odxtools/templates/macros/printCompuMethod.xml.jinja2
@@ -103,7 +103,7 @@
   {%- if pc.library_refs %}
   <LIBRARY-REFS>
     {%- for libref in pc.library_refs %}
-    <LIBRARY-REF ID-REF="{{libref.ref_id}}" />
+    <LIBRARY-REF {{make_ref_attribs(libref)}} />
     {%- endfor %}
   </LIBRARY-REFS>
   {%- endif %}

--- a/odxtools/templates/macros/printDOP.xml.jinja2
+++ b/odxtools/templates/macros/printDOP.xml.jinja2
@@ -113,7 +113,7 @@
  {{- printInternalConstr(dop.internal_constr, False)|indent(1) }}
  {%- endif %}
  {%- if dop.unit_ref %}
- <UNIT-REF ID-REF="{{ dop.unit_ref.ref_id }}" />
+ <UNIT-REF {{make_ref_attribs(dop.unit_ref)}} />
  {%- endif %}
  {%- if dop.physical_constr %}
  {{- printInternalConstr(dop.internal_constr, True)|indent(1) }}
@@ -131,7 +131,7 @@
  <DTCS>
  {%- for dtc in dop.dtcs_raw %}
  {%- if hasattr(dtc, "ref_id") %}
-  <DTC-REF ID-REF="{{dtc.ref_id}}" />
+  <DTC-REF {{make_ref_attribs(dtc)}} />
  {%- else %}
   <DTC {{-peid.printElementIdAttribs(dtc)}}>
    <SHORT-NAME>{{dtc.short_name}}</SHORT-NAME>
@@ -159,7 +159,7 @@
        {%- endfor %}
      </NOT-INHERITED-DTC-SNREFS>
      {%- endif %}
-     <DTC-DOP-REF ID-REF="{{linked_dtc_dop.dtc_dop_ref.ref_id}}" />
+     <DTC-DOP-REF {{make_ref_attribs(linked_dtc_dop.dtc_dop_ref)}} />
    </LINKED-DTC-DOP>
    {%- endfor %}
  </LINKED-DTC-DOPS>

--- a/odxtools/templates/macros/printDiagComm.xml.jinja2
+++ b/odxtools/templates/macros/printDiagComm.xml.jinja2
@@ -28,7 +28,7 @@
  {%- if dc.functional_class_refs %}
  <FUNCT-CLASS-REFS>
   {%- for ref in dc.functional_class_refs %}
-  <FUNCT-CLASS-REF ID-REF="{{ref.ref_id}}" />
+  <FUNCT-CLASS-REF {{make_ref_attribs(ref)}} />
   {%- endfor %}
  </FUNCT-CLASS-REFS>
  {%- endif%}
@@ -45,7 +45,7 @@
  {%- if dc.related_diag_comm_refs %}
  <RELATED-DIAG-COMM-REFS>
   {%- for ref in dc.related_diag_comm_refs %}
-  <RELATED-DIAG-COMM-REF ID-REF="{{ref.ref_id}}">
+  <RELATED-DIAG-COMM-REF {{make_ref_attribs(ref)}}>
    <RELATION-TYPE>{{ref.relation_type}}</RELATION-TYPE>
   </RELATED-DIAG-COMM-REF>
   {%- endfor %}

--- a/odxtools/templates/macros/printDiagLayer.xml.jinja2
+++ b/odxtools/templates/macros/printDiagLayer.xml.jinja2
@@ -33,6 +33,7 @@
 {%- endmacro -%}
 
 {%- macro printDiagLayerSubtags(dl) -%}
+{{- set_layer_docfrag(dl.short_name) }}
 {%- set dlr = dl.diag_layer_raw %}
 {{ peid.printElementIdSubtags(dlr)|indent(1) }}
 {%- if dlr.admin_data is not none %}
@@ -149,7 +150,7 @@
 
   {%- if hasattr(dc, "ref_id") %}
   {#- -> reference to a diag-comm object #}
-  <DIAG-COMM-REF ID-REF="{{dc.ref_id}}" />
+  <DIAG-COMM-REF {{make_ref_attribs(dc)}} />
   {%- elif hasattr(dc, "request") %}
   {#- -> service #}
   {{ ps.printService(dc)|indent(2) }}

--- a/odxtools/templates/macros/printDiagVariable.xml.jinja2
+++ b/odxtools/templates/macros/printDiagVariable.xml.jinja2
@@ -14,7 +14,7 @@
   {%- if diag_variable.admin_data is not none %}
   {{ pad.printAdminData(diag_variable.admin_data)|indent(2) }}
   {%- endif %}
-  <VARIABLE-GROUP-REF ID-REF="{{ diag_var.ref_id }}" />
+  <VARIABLE-GROUP-REF {{make_ref_attribs(diag_var)}} />
   {%- if diag_variable.sw_variables %}
    <SW-VARIABLES>
     {%- for sw_var in diag_variable.sw_variables %}
@@ -34,19 +34,19 @@
       {{ pd.printDescription(comm_relation.description) }}
       <RELATION-TYPE>{{comm_relation.relation_type}}</RELATION-TYPE>
       {%- if comm_relation.diag_comm_ref is not none %}
-      <DIAG-COMM-REF ID-REF="{{comm_relation.diag_comm_ref.ref_id}}" />
+      <DIAG-COMM-REF {{make_ref_attribs(comm_relation.diag_comm_ref)}} />
       {%- endif %}
       {%- if comm_relation.diag_comm_snref is not none %}
       <DIAG-COMM-SNREF SHORT-NAME="{{comm_relation.diag_comm_snref}}" />
       {%- endif %}
       {%- if comm_relation.in_param_if_ref is not none %}
-      <IN-PARAM-IF-REF ID-REF="{{comm_relation.in_param_if_ref.ref_id}}" />
+      <IN-PARAM-IF-REF {{make_ref_attribs(comm_relation.in_param_if_ref)}} />
       {%- endif %}
       {%- if comm_relation.in_param_if_snref is not none %}
       <IN-PARAM-IF-SNREF SHORT-NAME="{{comm_relation.in_param_if_snref}}" />
       {%- endif %}
       {%- if comm_relation.out_param_if_ref is not none %}
-      <OUT-PARAM-IF-REF ID-REF="{{comm_relation.out_param_if_ref.ref_id}}" />
+      <OUT-PARAM-IF-REF {{make_ref_attribs(comm_relation.out_param_if_ref)}} />
       {%- endif %}
       {%- if comm_relation.out_param_if_snref is not none %}
       <OUT-PARAM-IF-SNREF SHORT-NAME="{{comm_relation.out_param_if_snref}}" />

--- a/odxtools/templates/macros/printDynDefinedSpec.xml.jinja2
+++ b/odxtools/templates/macros/printDynDefinedSpec.xml.jinja2
@@ -11,13 +11,13 @@
   <DYN-ID-DEF-MODE-INFO>
     <DEF-MODE>{{ diddmi.def_mode }}</DEF-MODE>
     {%- if diddmi.clear_dyn_def_message_ref is not none %}
-    <CLEAR-DYN-DEF-MESSAGE-REF ID-REF="{{diddmi.clear_dyn_def_message_ref.ref_id}}" />
+    <CLEAR-DYN-DEF-MESSAGE-REF {{make_ref_attribs(diddmi.clear_dyn_def_message_ref)}} />
     {%- endif %}
     {%- if diddmi.clear_dyn_def_message_snref is not none %}
     <CLEAR-DYN-DEF-MESSAGE-SNREF SHORT-NAME="{{diddmi.clear_dyn_def_message_snref}}" />
     {%- endif %}
     {%- if diddmi.read_dyn_def_message_ref is not none %}
-    <READ-DYN-DEF-MESSAGE-REF ID-REF="{{diddmi.read_dyn_def_message_ref.ref_id}}" />
+    <READ-DYN-DEF-MESSAGE-REF {{make_ref_attribs(diddmi.read_dyn_def_message_ref)}} />
     {%- endif %}
     {%- if diddmi.read_dyn_def_message_snref is not none %}
     <READ-DYN-DEF-MESSAGE-SNREF SHORT-NAME="{{diddmi.read_dyn_def_message_snref}}" />
@@ -33,7 +33,7 @@
     <SELECTION-TABLE-REFS>
       {%- for seltref in diddmi.selection_table_refs %}
         {%- if hasattr(seltref, "ref_id") %}
-	<SELECTION-TABLE-REF ID-REF="{{ seltref.ref_id }}" />
+	<SELECTION-TABLE-REF {{make_ref_attribs(seltref)}} />
         {%- else %}
 	<SELECTION-TABLE-SNREF SHORT-NAME="{{ seltref }}" />
         {%- endif %}

--- a/odxtools/templates/macros/printDynamicEndmarkerField.xml.jinja2
+++ b/odxtools/templates/macros/printDynamicEndmarkerField.xml.jinja2
@@ -8,8 +8,8 @@
 {%- macro printStaticField(demf) -%}
 <DYNAMIC-ENDMARKER-FIELD {{-peid.printElementIdAttribs(demf)}}>
  {{ peid.printElementIdSubtags(demf)|indent(1) }}
- <BASIC-STRUCTURE-REF ID-REF="{{demf.structure_ref.ref_id}}" />
- <DYN-END-DOP-REF ID-REF="{{demf.dyn_end_dop_ref.ref_id}}">
+ <BASIC-STRUCTURE-REF {{make_ref_attribs(demf.structure_ref)}} />
+ <DYN-END-DOP-REF {{make_ref_attribs(demf.dyn_end_dop_ref)}}>
    <TERMINATION-VALUE>{{demf.dyn_end_dop_ref.termination_value_raw}}</TERMINATION-VALUE>
  </DYN-END-DOP-REF>
 </DYNAMIC-ENDMARKER-FIELD>

--- a/odxtools/templates/macros/printDynamicLengthField.xml.jinja2
+++ b/odxtools/templates/macros/printDynamicLengthField.xml.jinja2
@@ -8,7 +8,7 @@
 {%- macro printDynamicLengthField(dlf) -%}
 <DYNAMIC-LENGTH-FIELD {{-peid.printElementIdAttribs(dlf)}}>
  {{ peid.printElementIdSubtags(dlf)|indent(1) }}
- <BASIC-STRUCTURE-REF ID-REF="{{dlf.structure_ref.ref_id}}" />
+ <BASIC-STRUCTURE-REF {{make_ref_attribs(dlf.structure_ref)}} />
  <OFFSET>{{dlf.offset}}</OFFSET>
  <DETERMINE-NUMBER-OF-ITEMS>
    {%- set dni = dlf.determine_number_of_items %}
@@ -16,7 +16,7 @@
    {%- if dni.bit_position is not none %}
    <BIT-POSITION>{{dni.bit_position}}</BIT-POSITION>
    {%- endif %}
-   <DATA-OBJECT-PROP-REF ID-REF="{{dni.dop_ref.ref_id}}" />
+   <DATA-OBJECT-PROP-REF {{make_ref_attribs(dni.dop_ref)}} />
  </DETERMINE-NUMBER-OF-ITEMS>
 </DYNAMIC-LENGTH-FIELD>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printEndOfPdu.xml.jinja2
+++ b/odxtools/templates/macros/printEndOfPdu.xml.jinja2
@@ -8,7 +8,7 @@
 {%- macro printEndOfPdu(eopdu) -%}
 <END-OF-PDU-FIELD {{-peid.printElementIdAttribs(eopdu)}}>
  {{ peid.printElementIdSubtags(eopdu)|indent(1) }}
- <BASIC-STRUCTURE-REF ID-REF="{{eopdu.structure_ref.ref_id}}" />
+ <BASIC-STRUCTURE-REF {{make_ref_attribs(eopdu.structure_ref)}} />
  {%- if eopdu.max_number_of_items is not none %}
  <MAX-NUMBER-OF-ITEMS>{{eopdu.max_number_of_items}}</MAX-NUMBER-OF-ITEMS>
  {%- endif %}

--- a/odxtools/templates/macros/printEnvDataDesc.xml.jinja2
+++ b/odxtools/templates/macros/printEnvDataDesc.xml.jinja2
@@ -11,7 +11,7 @@
   <PARAM-SNREF SHORT-NAME="{{env_data_desc.param_snref}}"/>
   <ENV-DATA-REFS>
     {%- for env_data_ref in env_data_desc.env_data_refs %}
-    <ENV-DATA-REF ID-REF="{{env_data_ref.ref_id}}"/>
+    <ENV-DATA-REF {{make_ref_attribs(env_data_ref)}}/>
     {%- endfor %}
   </ENV-DATA-REFS>
 </ENV-DATA-DESC>

--- a/odxtools/templates/macros/printMux.xml.jinja2
+++ b/odxtools/templates/macros/printMux.xml.jinja2
@@ -18,13 +18,13 @@
     {%- if mux.switch_key.bit_position is not none %}
     <BIT-POSITION>{{mux.switch_key.bit_position}}</BIT-POSITION>
     {%- endif %}
-    <DATA-OBJECT-PROP-REF ID-REF="{{mux.switch_key.dop_ref.ref_id}}"/>
+    <DATA-OBJECT-PROP-REF {{make_ref_attribs(mux.switch_key.dop_ref)}}/>
   </SWITCH-KEY>
   {%- if mux.default_case is not none %}
   <DEFAULT-CASE>
     {{ peid.printElementIdSubtags(mux.default_case)|indent(4) }}
     {%- if mux.default_case.structure_ref is not none %}
-    <STRUCTURE-REF ID-REF="{{mux.default_case.structure_ref.ref_id}}"/>
+    <STRUCTURE-REF {{make_ref_attribs(mux.default_case.structure_ref)}}/>
     {%- endif %}
     {%- if mux.default_case.structure_snref is not none %}
     <STRUCTURE-SNREF SHORT_NAME="{{mux.default_case.structure_snref}}"/>
@@ -37,7 +37,7 @@
     <CASE>
       {{ peid.printElementIdSubtags(case)|indent(6) }}
       {%- if case.structure_ref is not none %}
-      <STRUCTURE-REF ID-REF="{{case.structure_ref.ref_id}}"/>
+      <STRUCTURE-REF {{make_ref_attribs(case.structure_ref)}}/>
       {%- endif %}
       {%- if case.structure_snref is not none %}
       <STRUCTURE-SNREF SHORT_NAME="{{case.structure_snref}}"/>

--- a/odxtools/templates/macros/printParam.xml.jinja2
+++ b/odxtools/templates/macros/printParam.xml.jinja2
@@ -49,7 +49,7 @@
  <PHYSICAL-DEFAULT-VALUE>{{param.physical_default_value_raw | e}}</PHYSICAL-DEFAULT-VALUE>
 {%- endif %}
 {%- if param.dop_ref %}
- <DOP-REF ID-REF="{{param.dop_ref.ref_id}}"/>
+ <DOP-REF {{make_ref_attribs(param.dop_ref)}}/>
 {%- elif param.dop_snref %}
  <DOP-SNREF SHORT-NAME="{{param.dop_snref}}"/>
 {%- elif param.diag_coded_type is defined %}
@@ -59,7 +59,7 @@
 {%- endif %}
 {%- if param.parameter_type == "TABLE-KEY" %}
  {%- if param.table_ref %}
- <TABLE-REF ID-REF="{{param.table_ref.ref_id}}"/>
+ <TABLE-REF {{make_ref_attribs(param.table_ref)}}/>
  {%- endif %}
  {%- if param.table_snref %}
  <TABLE-SNREF SHORT-NAME="{{param.table_snref}}"/>
@@ -68,12 +68,12 @@
  <TABLE-ROW-SNREF SHORT-NAME="{{param.table_row_snref}}"/>
  {%- endif %}
  {%- if param.table_row_ref %}
- <TABLE-ROW-REF ID-REF="{{param.table_row_ref.ref_id}}"/>
+ <TABLE-ROW-REF {{make_ref_attribs(param.table_row_ref)}}/>
  {%- endif %}
 {%- endif %}
 {%- if param.parameter_type == "TABLE-STRUCT" %}
  {%- if param.table_key_ref %}
- <TABLE-KEY-REF ID-REF="{{param.table_key_ref.ref_id}}"/>
+ <TABLE-KEY-REF {{make_ref_attribs(param.table_key_ref)}}/>
  {%- endif %}
  {%- if param.table_key_snref %}
  <TABLE-KEY-SNREF SHORT-NAME="{{param.table_key_snref}}"/>

--- a/odxtools/templates/macros/printParentRef.xml.jinja2
+++ b/odxtools/templates/macros/printParentRef.xml.jinja2
@@ -4,11 +4,7 @@
 -#}
 
 {%- macro printParentRef(par) -%}
-<PARENT-REF ID-REF="{{par.layer.odx_id.local_id}}"
-{%- if par.layer_ref.ref_docs|length == 1 %}
-            DOCREF="{{par.layer_ref.ref_docs[0].doc_name}}"
-            DOCTYPE="CONTAINER"
-{%- endif %}
+<PARENT-REF {{make_ref_attribs(par.layer_ref)}}
             xsi:type="{{par.layer.variant_type.value}}-REF">
 {%- if par.not_inherited_diag_comms %}
  <NOT-INHERITED-DIAG-COMMS>

--- a/odxtools/templates/macros/printPreConditionStateRef.xml.jinja2
+++ b/odxtools/templates/macros/printPreConditionStateRef.xml.jinja2
@@ -4,7 +4,7 @@
 -#}
 
 {%- macro printPreConditionStateRef(ps_ref) -%}
-<PRE-CONDITION-STATE-REF ID-REF="{{ps_ref.ref_id}}">
+<PRE-CONDITION-STATE-REF {{make_ref_attribs(ps_ref)}}>
   {%- if ps_ref.value is not none %}
   <VALUE>{{ ps_ref.value }}</VALUE>
   {%- endif %}

--- a/odxtools/templates/macros/printProtStack.xml.jinja2
+++ b/odxtools/templates/macros/printProtStack.xml.jinja2
@@ -14,7 +14,7 @@
  {%- if ps.comparam_subset_refs %}
  <COMPARAM-SUBSET-REFS>
   {%- for csr in ps.comparam_subset_refs %}
-  <COMPARAM-SUBSET-REF ID-REF="{{csr.ref_id}}" DOCREF="{{csr.ref_id}}" DOCTYPE="COMPARAM-SUBSET"/>
+  <COMPARAM-SUBSET-REF {{make_ref_attribs(csr)}}/>
   {%- endfor %}
  </COMPARAM-SUBSET-REFS>
  {%- endif %}

--- a/odxtools/templates/macros/printProtocol.xml.jinja2
+++ b/odxtools/templates/macros/printProtocol.xml.jinja2
@@ -13,7 +13,7 @@
   {%- set dlr = protocol.protocol_raw %}
 
   {%- set cps_docfrag = dlr.comparam_spec_ref.ref_docs[-1] %}
-  <COMPARAM-SPEC-REF ID-REF="{{dlr.comparam_spec_ref.ref_id}}" DOCREF="{{cps_docfrag.doc_name}}" DOCTYPE="{{cps_docfrag.doc_type.value}}" />
+  <COMPARAM-SPEC-REF {{make_ref_attribs(dlr.comparam_spec_ref)}} />
 
   {%- if dlr.prot_stack_snref is not none %}
   <PROT-STACK-SNREF SHORT-NAME="{{ dlr.prot_stack_snref }}" />

--- a/odxtools/templates/macros/printService.xml.jinja2
+++ b/odxtools/templates/macros/printService.xml.jinja2
@@ -56,19 +56,19 @@
   </COMPARAM-REFS>
   {%- endif%}
   {%- if service.request_ref %}
-  <REQUEST-REF ID-REF="{{service.request_ref.ref_id}}"/>
+  <REQUEST-REF {{make_ref_attribs(service.request_ref)}}/>
   {%- endif %}
   {%- if service.pos_response_refs %}
   <POS-RESPONSE-REFS>
     {%- for ref in service.pos_response_refs %}
-    <POS-RESPONSE-REF ID-REF="{{ref.ref_id}}" />
+    <POS-RESPONSE-REF {{make_ref_attribs(ref)}} />
     {%- endfor %}
   </POS-RESPONSE-REFS>
   {%- endif%}
   {%- if service.neg_response_refs %}
   <NEG-RESPONSE-REFS>
     {%- for ref in service.neg_response_refs %}
-    <NEG-RESPONSE-REF ID-REF="{{ref.ref_id}}" />
+    <NEG-RESPONSE-REF {{make_ref_attribs(ref)}} />
     {%- endfor %}
   </NEG-RESPONSE-REFS>
   {%- endif%}

--- a/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
+++ b/odxtools/templates/macros/printSingleEcuJob.xml.jinja2
@@ -47,7 +47,7 @@
 {%- if param.physical_default_value is not none %}
  <PHYSICAL-DEFAULT-VALUE>{{param.physical_default_value | e}}</PHYSICAL-DEFAULT-VALUE>
 {%- endif %}
- <DOP-BASE-REF ID-REF="{{param.dop_base_ref.ref_id}}" />
+ <DOP-BASE-REF {{make_ref_attribs(param.dop_base_ref)}} />
 </INPUT-PARAM>
 {%- endmacro -%}
 
@@ -56,7 +56,7 @@
               {{-make_xml_attrib("OID", param.oid)}}
               {{-make_xml_attrib("SEMANTIC", param.semantic)}}>
  {{ peid.printElementIdSubtags(param)|indent(1) }}
- <DOP-BASE-REF ID-REF="{{param.dop_base_ref.ref_id}}" />
+ <DOP-BASE-REF {{make_ref_attribs(param.dop_base_ref)}} />
 </OUTPUT-PARAM>
 {%- endmacro -%}
 
@@ -64,6 +64,6 @@
 {%- macro printNegOutputParam(param) -%}
 <NEG-OUTPUT-PARAM>
  {{ peid.printElementIdSubtags(param)|indent(1) }}
- <DOP-BASE-REF ID-REF="{{param.dop_base_ref.ref_id}}" />
+ <DOP-BASE-REF {{make_ref_attribs(param.dop_base_ref)}} />
 </NEG-OUTPUT-PARAM>
 {%- endmacro -%}

--- a/odxtools/templates/macros/printSpecialData.xml.jinja2
+++ b/odxtools/templates/macros/printSpecialData.xml.jinja2
@@ -25,7 +25,7 @@
 {%- macro printSpecialDataGroup(sdg) %}
 <SDG {{-make_xml_attrib("SI", sdg.semantic_info)}}>
  {%- if sdg.sdg_caption_ref %}
- <SDG-CAPTION-REF ID-REF="{{sdg.sdg_caption_ref.ref_id}}" />
+ <SDG-CAPTION-REF {{make_ref_attribs(sdg.sdg_caption_ref)}} />
  {%- elif sdg.sdg_caption %}
  {{- printSdgCaption(sdg.sdg_caption) | indent(1, first=True) }}
  {%- endif %}

--- a/odxtools/templates/macros/printStateTransitionRef.xml.jinja2
+++ b/odxtools/templates/macros/printStateTransitionRef.xml.jinja2
@@ -4,7 +4,7 @@
 -#}
 
 {%- macro printStateTransitionRef(st_ref) -%}
-<STATE-TRANSITION-REF ID-REF="{{st_ref.ref_id}}">
+<STATE-TRANSITION-REF {{make_ref_attribs(st_ref)}}>
   {%- if st_ref.value is not none %}
   <VALUE>{{ st_ref.value }}</VALUE>
   {%- endif %}

--- a/odxtools/templates/macros/printStaticField.xml.jinja2
+++ b/odxtools/templates/macros/printStaticField.xml.jinja2
@@ -8,7 +8,7 @@
 {%- macro printStaticField(sf) -%}
 <STATIC-FIELD {{-peid.printElementIdAttribs(sf)}}>
  {{ peid.printElementIdSubtags(sf)|indent(1) }}
- <BASIC-STRUCTURE-REF ID-REF="{{sf.structure_ref.ref_id}}" />
+ <BASIC-STRUCTURE-REF {{make_ref_attribs(sf.structure_ref)}} />
  <FIXED-NUMBER-OF-ITEMS>{{sf.fixed_number_of_items}}</FIXED-NUMBER-OF-ITEMS>
  <ITEM-BYTE-SIZE>{{sf.item_byte_size}}</ITEM-BYTE-SIZE>
 </STATIC-FIELD>

--- a/odxtools/templates/macros/printSubComponent.xml.jinja2
+++ b/odxtools/templates/macros/printSubComponent.xml.jinja2
@@ -40,7 +40,7 @@
 {%- macro printTableRowConnector(conn) %}
 <TABLE-ROW-CONNECTOR>
   {{ peid.printElementIdSubtags(conn)|indent(2) }}
-  <TABLE-REF ID-REF="{{ conn.table_ref.ref_id }}" />
+  <TABLE-REF {{make_ref_attribs(conn.table_ref)}} />
   <TABLE-ROW-SNREF {{- make_xml_attrib("SHORT-NAME", conn.table_row_snref ) }} />
 </TABLE-ROW-CONNECTOR>
 {%- endmacro %}
@@ -48,7 +48,7 @@
 {%- macro printEnvDataConnector(conn) %}
 <ENV-DATA-CONNECTOR>
   {{ peid.printElementIdSubtags(conn)|indent(2) }}
-  <ENV-DATA-DESC-REF ID-REF="{{ conn.env_data_desc_ref.ref_id }}" />
+  <ENV-DATA-DESC-REF {{make_ref_attribs(conn.env_data_desc_ref)}} />
   <ENV-DATA-SNREF {{- make_xml_attrib("SHORT-NAME", conn.env_data_snref ) }} />
 </ENV-DATA-CONNECTOR>
 {%- endmacro %}
@@ -56,7 +56,7 @@
 {%- macro printDtcConnector(conn) %}
 <DTC-CONNECTOR>
   {{ peid.printElementIdSubtags(conn)|indent(2) }}
-  <DTC-DOP-REF ID-REF="{{ conn.dtc_dop_ref.ref_id }}" />
+  <DTC-DOP-REF {{make_ref_attribs(conn.dtc_dop_ref)}} />
   <DOP-SNREF {{- make_xml_attrib("SHORT-NAME", conn.dtc_snref ) }} />
 </DTC-CONNECTOR>
 {%- endmacro %}

--- a/odxtools/templates/macros/printTable.xml.jinja2
+++ b/odxtools/templates/macros/printTable.xml.jinja2
@@ -16,7 +16,7 @@
        {{-make_xml_attrib("SEMANTIC", table.semantic)}}>
  {{ peid.printElementIdSubtags(table)|indent(1) }}
 {%- if table.key_dop_ref %}
- <KEY-DOP-REF ID-REF="{{ table.key_dop_ref.ref_id }}" />
+ <KEY-DOP-REF {{make_ref_attribs(table.key_dop_ref)}} />
 {%- endif %}
  {%- for table_row in table.table_rows_raw %}
  {%- if hasattr(table_row, "key") %}
@@ -25,13 +25,13 @@
   {{-peid.printElementIdSubtags(table_row)}}
   <KEY>{{table_row.key|e}}</KEY>
   {%- if table_row.dop_ref is not none %}
-  <DATA-OBJECT-PROP-REF ID-REF="{{ table_row.dop_ref.ref_id }}" />
+  <DATA-OBJECT-PROP-REF {{make_ref_attribs(table_row.dop_ref)}} />
   {%- endif %}
   {%- if table_row.dop_snref is not none %}
   <DATA-OBJECT-PROP-SNREF SHORT-NAME="{{ table_row.dop_snref }}" />
   {%- endif %}
   {%- if table_row.structure_ref is not none %}
-  <STRUCTURE-REF ID-REF="{{ table_row.structure_ref.ref_id }}" />
+  <STRUCTURE-REF {{make_ref_attribs(table_row.structure_ref)}} />
   {%- endif %}
   {%- if table_row.structure_snref is not none %}
   <STRUCTURE-SNREF SHORT-NAME="{{ table_row.structure_snref }}" />
@@ -43,7 +43,7 @@
   {%- if table_row.functional_class_refs %}
   <FUNCT-CLASS-REFS>
     {%- for fc_ref in table_row.functional_class_refs %}
-    <FUNCT-CLASS-REF ID-REF="{{ fc_ref.ref_id }}" />
+    <FUNCT-CLASS-REF {{make_ref_attribs(fc_ref)}} />
     {%- endfor %}
   </FUNCT-CLASS-REFS>
   {%- endif %}
@@ -66,7 +66,7 @@
   {%- endif %}
  </TABLE-ROW>
  {%- else %}
- <TABLE-ROW-REF ID-REF="{{ table_row.ref_id }}" />
+ <TABLE-ROW-REF {{make_ref_attribs(table_row)}} />
  {%- endif %}
 {%- endfor %}
  {%- if table_diag_comm_connectors %}
@@ -75,7 +75,7 @@
   <TABLE-DIAG-COMM-CONNECTOR>
    <SEMANTIC>{{tdcc.semantic}}</SEMANTIC>
    {%- if tdcc.diag_comm_ref %}
-   <DIAG-COMM-REF ID-REF="{{ tdcc.diag_comm_ref.ref_id }}" />
+   <DIAG-COMM-REF {{make_ref_attribs(tdcc.diag_comm_ref)}} />
    {%- elif tdcc.diag_comm_snref %}
    <DIAG-COMM-SNREF SHORT-NAME="{{ tdcc.diag_comm_snref }}" />
    {%- endif %}

--- a/odxtools/templates/macros/printUnitSpec.xml.jinja2
+++ b/odxtools/templates/macros/printUnitSpec.xml.jinja2
@@ -49,7 +49,7 @@
  <OFFSET-SI-TO-UNIT>{{ unit.offset_si_to_unit }}</OFFSET-SI-TO-UNIT>
  {%- endif %}
  {%- if unit.physical_dimension_ref %}
- <PHYSICAL-DIMENSION-REF ID-REF="{{ unit.physical_dimension_ref.ref_id }}" />
+ <PHYSICAL-DIMENSION-REF {{make_ref_attribs(unit.physical_dimension_ref)}} />
  {%- endif %}
 </UNIT>
 {%- endmacro -%}
@@ -61,7 +61,7 @@
  {%- if group.unit_refs %}
  <UNIT-REFS>
  {%- for ref in group.unit_refs %}
-  <UNIT-REF ID-REF="{{ ref.ref_id }}" />
+  <UNIT-REF {{make_ref_attribs(ref)}} />
  {%- endfor %}
  </UNIT-REFS>
  {%- endif %}

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -17,8 +17,6 @@ from .odxtypes import bool_to_odxstr
 
 odxdatabase: Database | None = None
 
-cur_docfrags: list[OdxDocFragment] = []
-
 
 def jinja2_odxraise_helper(msg: str) -> None:
     raise Exception(msg)

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -15,8 +15,6 @@ from .database import Database
 from .odxlink import DocType, OdxDocFragment, OdxLinkRef
 from .odxtypes import bool_to_odxstr
 
-odxdatabase: Database | None = None
-
 
 def jinja2_odxraise_helper(msg: str) -> None:
     raise Exception(msg)
@@ -82,10 +80,6 @@ def write_pdx_file(
     """
     Write an internalized database to a PDX file.
     """
-    global odxdatabase
-
-    odxdatabase = database
-
     file_index = []
     with zipfile.ZipFile(output_file_name, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
 

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -12,9 +12,12 @@ import jinja2
 import odxtools
 
 from .database import Database
+from .odxlink import DocType, OdxDocFragment, OdxLinkRef
 from .odxtypes import bool_to_odxstr
 
 odxdatabase: Database | None = None
+
+cur_docfrags: list[OdxDocFragment] = []
 
 
 def jinja2_odxraise_helper(msg: str) -> None:
@@ -33,6 +36,39 @@ def make_bool_xml_attrib(attrib_name: str, attrib_val: bool | None) -> str:
         return ""
 
     return make_xml_attrib(attrib_name, bool_to_odxstr(attrib_val))
+
+
+def set_category_docfrag(jinja_vars: dict[str, Any], category_short_name: str,
+                         category_type: str) -> str:
+    jinja_vars["cur_docfrags"] = [OdxDocFragment(category_short_name, DocType(category_type))]
+
+    return ""
+
+
+def set_layer_docfrag(jinja_vars: dict[str, Any], layer_short_name: str | None) -> str:
+    cur_docfrags = jinja_vars["cur_docfrags"]
+
+    if layer_short_name is None:
+        cur_docfrags = cur_docfrags[:1]
+        return ""
+
+    if len(cur_docfrags) == 1:
+        cur_docfrags.append(OdxDocFragment(layer_short_name, DocType.LAYER))
+    else:
+        cur_docfrags[1] = OdxDocFragment(layer_short_name, DocType.LAYER)
+
+    return ""
+
+
+def make_ref_attribs(jinja_vars: dict[str, Any], ref: OdxLinkRef) -> str:
+    cur_docfrags = jinja_vars["cur_docfrags"]
+
+    for ref_frag in ref.ref_docs:
+        if ref_frag in cur_docfrags:
+            return f"ID-REF=\"{ref.ref_id}\""
+
+    docfrag = ref.ref_docs[-1]
+    return f"ID-REF=\"{ref.ref_id}\" DOCREF=\"{docfrag.doc_name}\" DOCTYPE=\"{docfrag.doc_type.value}\""
 
 
 __module_filename = inspect.getsourcefile(odxtools)
@@ -128,9 +164,14 @@ def write_pdx_file(
         jinja_env.globals["make_xml_attrib"] = make_xml_attrib
         jinja_env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
 
-        vars: dict[str, Any] = {}
-        vars["odxtools_version"] = odxtools.__version__
-        vars["database"] = database
+        jinja_vars: dict[str, Any] = {}
+        jinja_vars["odxtools_version"] = odxtools.__version__
+        jinja_vars["database"] = database
+
+        jinja_env.globals["set_category_docfrag"] = lambda cname, ctype: set_category_docfrag(
+            jinja_vars, cname, ctype)
+        jinja_env.globals["set_layer_docfrag"] = lambda lname: set_layer_docfrag(jinja_vars, lname)
+        jinja_env.globals["make_ref_attribs"] = lambda ref: make_ref_attribs(jinja_vars, ref)
 
         # write the communication parameter subsets
         comparam_subset_tpl = jinja_env.get_template("comparam-subset.odx-cs.xml.jinja2")
@@ -139,13 +180,13 @@ def write_pdx_file(
             zf_file_cdate = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
             zf_mime_type = "application/x-asam.odx.odx-cs"
 
-            vars["comparam_subset"] = comparam_subset
+            jinja_vars["comparam_subset"] = comparam_subset
 
             file_index.append((zf_file_name, zf_file_cdate, zf_mime_type))
 
-            zf.writestr(zf_file_name, comparam_subset_tpl.render(**vars))
+            zf.writestr(zf_file_name, comparam_subset_tpl.render(**jinja_vars))
 
-            del vars["comparam_subset"]
+            del jinja_vars["comparam_subset"]
 
         # write the communication parameter specs
         comparam_spec_tpl = jinja_env.get_template("comparam-spec.odx-c.xml.jinja2")
@@ -154,18 +195,18 @@ def write_pdx_file(
             zf_file_cdate = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
             zf_mime_type = "application/x-asam.odx.odx-c"
 
-            vars["comparam_spec"] = comparam_spec
+            jinja_vars["comparam_spec"] = comparam_spec
 
             file_index.append((zf_file_name, zf_file_cdate, zf_mime_type))
 
-            zf.writestr(zf_file_name, comparam_spec_tpl.render(**vars))
+            zf.writestr(zf_file_name, comparam_spec_tpl.render(**jinja_vars))
 
-            del vars["comparam_spec"]
+            del jinja_vars["comparam_spec"]
 
         # write the actual diagnostic data.
         dlc_tpl = jinja_env.get_template("diag_layer_container.odx-d.xml.jinja2")
         for dlc in database.diag_layer_containers:
-            vars["dlc"] = dlc
+            jinja_vars["dlc"] = dlc
 
             file_name = f"{dlc.short_name}.odx-d"
             file_cdate = datetime.datetime.now()
@@ -173,13 +214,13 @@ def write_pdx_file(
             mime_type = "application/x-asam.odx.odx-d"
 
             file_index.append((file_name, creation_date, mime_type))
-            zf.writestr(file_name, dlc_tpl.render(**vars))
-            del vars["dlc"]
+            zf.writestr(file_name, dlc_tpl.render(**jinja_vars))
+            del jinja_vars["dlc"]
 
         # write the index.xml file
-        vars["file_index"] = file_index
+        jinja_vars["file_index"] = file_index
         index_tpl = jinja_env.get_template("index.xml.jinja2")
-        text = index_tpl.render(**vars)
+        text = index_tpl.render(**jinja_vars)
         zf.writestr("index.xml", text)
 
     return True


### PR DESCRIPTION
writing ODXLINK references should now always work regardless of in which document fragments the reference and the target objects are located.

this works by providing three new "magical" global functions to the jinja macros for output:

- `set_category_docfrag()`: Specify the document fragment for the ODX category which is applicable for all subsequent macro invocations.
- `set_layer_docfrag()`: Specify the document fragment for the diagnostic layer which is applicable for all subsequent macro invocations (for DIAG-LAYER-CONTAINER).
- `make_ref_attribs(ref: OdxLinkRef)`: produces all necessary XML attributes required for an ODX link reference XML tag. (i.e., ID-REF, DOCREF and DOCTYPE)

internally, these functions require a dictionary parameter for storing "magic" global variables. On the jinja side, this is not necessary because lambda functions are used as wrappers.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
