### PR TITLE
remove unnecessary `__deepcopy__()` methods

### DIFF
--- a/odxtools/diaglayers/basevariant.py
+++ b/odxtools/diaglayers/basevariant.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: MIT
 from collections.abc import Iterable
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -81,23 +80,6 @@ class BaseVariant(HierarchyElement):
             isinstance(self.diag_layer_raw, BaseVariantRaw),
             "The raw diagnostic layer passed to BaseVariant "
             "must be a BaseVariantRaw")
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the base variant
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-
-        result = super().__deepcopy__(memo)
-
-        # note that the self.base_variant_raw object is *not* copied at
-        # this place because the attribute points to the same object
-        # as self.diag_layer_raw.
-        result.base_variant_raw = deepcopy(self.base_variant_raw, memo)
-
-        return result
 
     @override
     def _compute_value_inheritance(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from collections.abc import Callable, Iterable
-from copy import copy, deepcopy
+from copy import copy
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import chain
@@ -165,21 +165,6 @@ class DiagLayer:
 
         """
         return get_local_objects(self)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the diagnostic layer
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-
-        result.diag_layer_raw = deepcopy(self.diag_layer_raw, memo)
-
-        return result
 
     #####
     # <convenience functionality>

--- a/odxtools/diaglayers/ecushareddata.py
+++ b/odxtools/diaglayers/ecushareddata.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 from xml.etree import ElementTree
 
 from ..diagvariable import DiagVariable
@@ -77,20 +76,3 @@ class EcuSharedData(DiagLayer):
         context.diag_layer = self
         self._resolve_snrefs(context)
         context.diag_layer = None
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the protocol layer
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-
-        result = super().__deepcopy__(memo)
-
-        # note that the self.ecu_shared_data_raw object is *not* copied at
-        # this place because the attribute points to the same object
-        # as self.diag_layer_raw.
-        result.ecu_shared_data_raw = deepcopy(self.ecu_shared_data_raw, memo)
-
-        return result

--- a/odxtools/diaglayers/ecuvariant.py
+++ b/odxtools/diaglayers/ecuvariant.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: MIT
 from collections.abc import Iterable
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -81,23 +80,6 @@ class EcuVariant(HierarchyElement):
             isinstance(self.diag_layer_raw, EcuVariantRaw),
             "The raw diagnostic layer passed to EcuVariant "
             "must be a EcuVariantRaw")
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the ECU variant
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-
-        result = super().__deepcopy__(memo)
-
-        # note that the self.ecu_variant_raw object is *not* copied at
-        # this place because the attribute points to the same object
-        # as self.diag_layer_raw.
-        result.ecu_variant_raw = deepcopy(self.ecu_variant_raw, memo)
-
-        return result
 
     @override
     def _compute_value_inheritance(self, odxlinks: OdxLinkDatabase) -> None:

--- a/odxtools/diaglayers/functionalgroup.py
+++ b/odxtools/diaglayers/functionalgroup.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: MIT
 from collections.abc import Iterable
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -92,20 +91,3 @@ class FunctionalGroup(HierarchyElement):
             return []
 
         return self._compute_available_objects(get_local_objects_fn, not_inherited_fn)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the functional group layer
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-
-        result = super().__deepcopy__(memo)
-
-        # note that the self.functional_group_raw object is *not* copied at
-        # this place because the attribute points to the same object
-        # as self.diag_layer_raw.
-        result.functional_group_raw = deepcopy(self.functional_group_raw, memo)
-
-        return result

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -2,7 +2,6 @@
 import re
 import warnings
 from collections.abc import Callable, Iterable
-from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
@@ -72,23 +71,6 @@ class HierarchyElement(DiagLayer):
 
     def _resolve_snrefs(self, context: SnRefContext) -> None:
         super()._resolve_snrefs(context)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the hierarchy element
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-
-        new_he = super().__deepcopy__(memo)
-
-        # note that the self.hierarchy_element_raw object is *not*
-        # copied at this place because the attribute points to the
-        # same object as self.diag_layer_raw.
-        new_he.hierarchy_element_raw = deepcopy(self.hierarchy_element_raw)
-
-        return new_he
 
     def _finalize_init(self, database: "Database", odxlinks: OdxLinkDatabase) -> None:
         """This method deals with everything inheritance related and

--- a/odxtools/diaglayers/protocol.py
+++ b/odxtools/diaglayers/protocol.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 from xml.etree import ElementTree
 
 from ..comparamspec import ComparamSpec
@@ -59,20 +58,3 @@ class Protocol(HierarchyElement):
             isinstance(self.diag_layer_raw, ProtocolRaw),
             "The raw diagnostic layer passed to Protocol "
             "must be a ProtocolRaw")
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        """Create a deep copy of the protocol layer
-
-        Note that the copied diagnostic layer is not fully
-        initialized, so `_finalize_init()` should to be called on it
-        before it can be used normally.
-        """
-
-        result = super().__deepcopy__(memo)
-
-        # note that the self.protocol_raw object is *not* copied at
-        # this place because the attribute points to the same object
-        # as self.diag_layer_raw.
-        result.protocol_raw = deepcopy(self.protocol_raw, memo)
-
-        return result

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -2,7 +2,6 @@
 import abc
 import typing
 from collections.abc import Collection, Iterable
-from copy import deepcopy
 from keyword import iskeyword
 from typing import Any, SupportsIndex, TypeVar, overload, runtime_checkable
 
@@ -177,20 +176,11 @@ class ItemAttributeList(list[T]):
         return f"{type(self).__name__}([{', '.join([repr(x) for x in self])}])"
 
     def __copy__(self) -> Any:
-        return self.__class__(list(self))
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        result._item_dict = {}
-        for x in self:
-            result.append(deepcopy(x, memo))
-
-        return result
+        return self.__class__(self)
 
     def __reduce__(self) -> tuple[Any, ...]:
         """Support for Python's pickle protocol.
+
         This method ensures that the object can be reconstructed with its current state,
         using its class and the list of items it contains.
         It returns a tuple containing the reconstruction function (the class)


### PR DESCRIPTION
This is a spin-off PR of #443: What these methods were meant to do is done by the `memo` dictionary...

Andreas Lauser <[andreas.lauser@mercedes-benz.com](mailto:andreas.lauser@mercedes-benz.com)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
