### PR TITLE
Clean up the names of the load methods

### DIFF
--- a/odxtools/__init__.py
+++ b/odxtools/__init__.py
@@ -67,6 +67,7 @@ from .loadfile import load_file as load_file  # noqa: F401
 from .loadfile import load_files  # noqa: F401
 from .loadfile import load_odx_d_file as load_odx_d_file  # noqa: F401
 from .loadfile import load_pdx_file as load_pdx_file  # noqa: F401
+from .loadfile import load_xml_file as load_xml_file  # noqa: F401
 from .version import __version__ as __version__  # noqa: F401
 from .writepdxfile import write_pdx_file as write_pdx_file  # noqa: F401
 

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -7,6 +7,7 @@ from typing import IO, Any, Union
 from xml.etree import ElementTree
 from zipfile import ZipFile
 
+from deprecation import deprecated
 from packaging.version import Version
 
 from .comparamspec import ComparamSpec
@@ -75,8 +76,12 @@ class Database:
             else:
                 self.add_auxiliary_file(zip_member, pdx_zip.open(zip_member))
 
-    def add_odx_file(self, odx_file_name: Union[str, "PathLike[Any]"]) -> None:
+    def add_xml_file(self, odx_file_name: Union[str, "PathLike[Any]"]) -> None:
         self.add_xml_tree(ElementTree.parse(odx_file_name).getroot())
+
+    @deprecated("use .add_xml_file()")  # type: ignore[misc]
+    def add_odx_file(self, odx_file_name: Union[str, "PathLike[Any]"]) -> None:
+        self.add_xml_file(odx_file_name)
 
     def add_auxiliary_file(self,
                            aux_file_name: Union[str, "PathLike[Any]"],

--- a/odxtools/loadfile.py
+++ b/odxtools/loadfile.py
@@ -2,6 +2,8 @@
 import os
 from pathlib import Path
 
+from deprecation import deprecated
+
 from .database import Database
 
 
@@ -12,19 +14,24 @@ def load_pdx_file(pdx_file: str | Path) -> Database:
     return db
 
 
-def load_odx_d_file(odx_d_file_name: str | Path) -> Database:
+def load_xml_file(xml_file_name: str | Path) -> Database:
     db = Database()
-    db.add_odx_file(str(odx_d_file_name))
+    db.add_xml_file(str(xml_file_name))
     db.refresh()
 
     return db
+
+
+@deprecated("use load_xml_file()")  # type: ignore[misc]
+def load_odx_d_file(odx_d_file_name: str | Path) -> Database:
+    return load_xml_file(odx_d_file_name)
 
 
 def load_file(file_name: str | Path) -> Database:
     if str(file_name).lower().endswith(".pdx"):
         return load_pdx_file(str(file_name))
     elif Path(file_name).suffix.lower().startswith(".odx"):
-        return load_odx_d_file(str(file_name))
+        return load_xml_file(str(file_name))
     else:
         raise RuntimeError(f"Could not guess the file format of file '{file_name}'!")
 
@@ -36,7 +43,7 @@ def load_files(*file_names: str | Path) -> Database:
         if p.suffix.lower() == ".pdx":
             db.add_pdx_file(str(file_name))
         elif p.suffix.lower().startswith(".odx"):
-            db.add_odx_file(str(file_name))
+            db.add_xml_file(str(file_name))
         elif p.name.lower() != "index.xml":
             db.add_auxiliary_file(str(file_name))
 
@@ -55,7 +62,7 @@ def load_directory(dir_name: str | Path) -> Database:
         if p.suffix.lower() == ".pdx":
             db.add_pdx_file(str(p))
         elif p.suffix.lower().startswith(".odx"):
-            db.add_odx_file(str(p))
+            db.add_xml_file(str(p))
         elif p.name.lower() != "index.xml":
             db.add_auxiliary_file(p.name, open(str(p), "rb"))
 


### PR DESCRIPTION
This makes the naming more consistent and less misleading:
    
- In `Database` the method for internalizing an already parsed XML tree is named `.add_xml_tree()`, not `.load_odx_tree()`. For consistency, the method which internalizes an XML file should thus be called `.add_xml_file()` instead of `.add_odx_file()`.
- For quite some time `load_odx_d_file()` could be used to load an XML file containing any ODX category, not just ones featureing `DIAG-LAYER-CONTAINER`. To make this function name consistent with the corrosponding method of `Database`, it is renamed to `load_xml_file()`.

The old names still exist, but they are marked deprecated and are implemented as shallow shims around the new functions.

Andreas Lauser <[andreas.lauser@mercedes-benz.com](mailto:andreas.lauser@mercedes-benz.com)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
