### PR TITLE
Improve non-strict robustness

### DIFF
--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -201,9 +201,9 @@ class HierarchyElement(DiagLayer):
         # diagnostic layer. Note that communication parameters do
         # *not* use value inheritance, but a slightly different
         # scheme, cf the docstring of
-        # _compute_available_commmunication_parameters().
+        # _compute_available_communication_parameters().
         #####
-        self._comparam_refs = NamedItemList(self._compute_available_commmunication_parameters())
+        self._comparam_refs = NamedItemList(self._compute_available_communication_parameters())
 
         #####
         # resolve all SNREFs. TODO: We allow SNREFS to objects that
@@ -484,7 +484,7 @@ class HierarchyElement(DiagLayer):
     #####
     # <communication parameter handling>
     #####
-    def _compute_available_commmunication_parameters(self) -> list[ComparamInstance]:
+    def _compute_available_communication_parameters(self) -> list[ComparamInstance]:
         """Compute the list of communication parameters that apply to
         the diagnostic layer
 
@@ -517,7 +517,7 @@ class HierarchyElement(DiagLayer):
             parent_layer = parent_ref.layer
             if not isinstance(parent_layer, HierarchyElement):
                 continue
-            for cp in parent_layer._compute_available_commmunication_parameters():
+            for cp in parent_layer._compute_available_communication_parameters():
                 com_params_dict[(cp.spec_ref.ref_id, cp.protocol_snref)] = cp
 
         # finally, handle the locally defined communication parameters

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -518,10 +518,14 @@ class HierarchyElement(DiagLayer):
             if not isinstance(parent_layer, HierarchyElement):
                 continue
             for cp in parent_layer._compute_available_communication_parameters():
+                if cp.spec is None:
+                    continue
                 com_params_dict[(cp.spec_ref.ref_id, cp.protocol_snref)] = cp
 
         # finally, handle the locally defined communication parameters
         for cp in getattr(self.hierarchy_element_raw, "comparam_refs", []):
+            if cp.spec is None:
+                continue
             com_params_dict[(cp.spec_ref.ref_id, cp.protocol_snref)] = cp
 
         return list(com_params_dict.values())


### PR DESCRIPTION
It turns out that if the specification for a COMPARAM-REF did not exist, odxtools failed to load a dataset even in non-strict mode. Since I was bitten by this issue for a few of our datasets, I decided to fix it.

Besides this, I stumbled over and fixed a typo in the name of a private method of `HierarchyElement` (`_compute_available_commmunication_parameters()` instead of `_compute_available_communication_parameters()`)

Andreas Lauser <[andreas.lauser@mercedes-benz.com](mailto:andreas.lauser@mercedes-benz.com)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
