### PR TITLE
update CONTRIBUTING.md to use the DCO approach

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,42 +1,58 @@
-<!-- SPDX-License-Identifier: MIT -->
+<!--
+SPDX-FileCopyrightText: 2023 Mercedes-Benz Tech Innovation GmbH
+
+SPDX-License-Identifier: MIT
+-->
+
 # Contributing
 
-This document explains how to contribute to `odxtools`. By
-contributing you will implicitly agree that your contribution will be
-made available under the same license as the relevant content of the
-repository.
+This document explains how to contribute to the odxtools project. By contributing you will agree that your contribution will be put under the GNU Affero General Public License, version 3 (AGPLv3).
 
 ## Table of Contents
 
-* [Communication](#communication)
-* [Contributions](#contributions)
+- [Communication](#communication)
+- [Contributions](#contributions)
 
 ## Communication
 
-We use GitHub to handle bug reports, feature requests, questions and
-general discussions (via the "issues" and "discussions" features of
-GitHub) as well as for managing code and documentation improvements
-(via pull requests). Transparent, inclusive and open communication is
-important to us; thus, all project-related communication should happen
-exclusively on GitHub and using the English language.
+For communication please respect our [FOSS Code of Conduct](https://github.com/mercedes-benz/foss/blob/master/CODE_OF_CONDUCT.md).
 
-In the context of project-related discussions, please respect our
-[Code of Conduct](https://github.com/mercedes-benz/daimler-foss/blob/master/CODE_OF_CONDUCT.md).
+The following communication channels exist for this project:
+- Github for reporting and claiming issues: https://github.com/mercedes-benz/odxtools/issues
+
+Transparent and open communication is important to us. Thus, all project-related communication should happen only through these channels and in English. Issue-related communication should happen within the concerned issue.
 
 ## Contributions
 
-### CLA
+If you would like to contribute code you can do so through Mercedes-Benz using the standard [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow).
 
-Before you can contribute, you will need to sign our Contributor
-License Agreement (CLA). When you create your first pull request, you
-will be requested by our CLA-assistant to sign this CLA.
+When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible.
 
-### Pull requests
+If you are new to contributing on Github, [First Contributions](https://github.com/firstcontributions/first-contributions) might be a good starting point.
 
-*All* changes to the contents of the `odxtools` repository are done via
-GitHub's [standard workflow](https://guides.github.com/introduction/flow/)
---- in particular its pull request mechanism.
+### Developer Certificate of Origin
 
-If you are new to contributing to projects on GitHub, our
-[First Contributions](https://github.com/firstcontributions/first-contributions)
-document might be a good starting point.
+Contributors must agree to the "Developer Certificate of Origin Version 1.1" (DCO) and comply with the sign-off procedure for contributing to `odxtools`.
+All contributions submitted to the `odxtools` repository have to carry a signed-off-by statement in the commit message using the following format:
+
+    Signed-off-by: Firstname Lastname <email.address>
+
+where the specified email address must be associated with your [github account](https://docs.github.com/en/account-and-profile/concepts/email-addresses). If a commit does not carry such a signed-off-by statement, the pull request cannot be merged into the official `odxtools` repository because by adding signed-off-by statements to the commit messages, you convey that you have the necessary rights to contribute the respective changes.
+
+
+### Developer Certificate of Origin (Text)
+```text
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+```
+
+The text of the DCO is also available at <https://developercertificate.org>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-It is Daimler’s goal to offer its customers the best and most secure
-products such as connected cars and other services. Daimler values the
-work of security researchers and whitehat hackers who spend time and
-effort helping us to achieve this goal.
-
-For further information, please visit our
-[Vulnerability Reporting Policy](https://www.daimler.com/whitehat/).


### PR DESCRIPTION
this updates the boiler plate files to the things which have changed over the last few years: i.e., the contributer's license agreement has been replaced by the developer certificate of origin approach (*yay*) and `SECURITY.md` file has become obsolete.
