### PR TITLE
fix(matchingparameter): add nested odxrequire for None safety

### DIFF
--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -50,7 +50,8 @@ class MatchingParameter:
         if (out_param_snref_el := et_element.find("OUT-PARAM-IF-SNREF")) is not None:
             out_param_if_snref = odxrequire(out_param_snref_el.get("SHORT-NAME"))
         elif (out_param_snpathref_el := et_element.find("OUT-PARAM-IF-SNPATHREF")) is not None:
-            out_param_if_snpathref = odxrequire(out_param_snpathref_el.get("SHORT-NAME-PATH"))
+            out_param_if_snpathref = odxrequire(
+                odxrequire(out_param_snpathref_el).get("SHORT-NAME-PATH"))
         else:
             odxraise("Output parameter must not be left unspecified")
 


### PR DESCRIPTION
# PR #464: MatchingParameter None Safety Fix

## Summary
Fixes a mypy type checking error in matchingparameter.py by adding nested odxrequire for None safety.

## Problem
The original code called .get("SHORT-NAME-PATH") directly on out_param_snpathref_el without ensuring the element is not None. This caused a mypy error:
Item "None" of "Element[str] | None" has no attribute "get" [union-attr]

## Solution
Wrap out_param_snpathref_el in odxrequire() before calling .get() to guarantee it is not None.

Before:
out_param_if_snpathref = odxrequire(out_param_snpathref_el.get("SHORT-NAME-PATH"))

After:
out_param_if_snpathref = odxrequire(
    odxrequire(out_param_snpathref_el).get("SHORT-NAME-PATH")
)

## Changes
- Single line change (nested odxrequire)
- All original comments and docstrings preserved
- No functional changes, only type safety improvement

## Quality Assurance

| Check | Status |
|-------|--------|
| Syntax | Pass |
| Mypy | Pass |
| Ruff | Pass |

## Author
Seif Galal

## Checklist
- [x] Single line change
- [x] All original code preserved
- [x] Mypy error resolved
- [x] DCO signed off