### PR TITLE
make `pyright` happy

### DIFF
--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -4,16 +4,16 @@ import logging
 import sys
 from typing import cast
 
-import InquirerPy.prompt as IP_prompt
+from InquirerPy.resolver import prompt as IP_prompt
 
 from ..complexdop import ComplexDop
 from ..database import Database
 from ..dataobjectproperty import DataObjectProperty
-from ..diaglayer import DiagLayer
+from ..diaglayers.diaglayer import DiagLayer
+from ..diaglayers.hierarchyelement import HierarchyElement
 from ..diagservice import DiagService
 from ..dopbase import DopBase
 from ..exceptions import odxraise, odxrequire
-from ..hierarchyelement import HierarchyElement
 from ..odxlink import resolve_snref
 from ..odxtypes import AtomicOdxType, DataType, ParameterValueDict
 from ..parameters.matchingrequestparameter import MatchingRequestParameter
@@ -247,6 +247,8 @@ def encode_message_from_string_values(
 
             typed_dict = parameter_value.copy()
             for inner_param_sn, inner_param_value in parameter_value.items():
+                if not isinstance(inner_param_sn, str):
+                    odxraise(f"Expected string parameter name, got {type(inner_param_sn).__name__}")
                 inner_param = resolve_snref(inner_param_sn, inner_params, Parameter)
                 if inner_param is None:
                     print(f"Unknown sub-parameter {inner_param_sn}")
@@ -303,12 +305,12 @@ def browse(odxdb: Database) -> None:
         assert isinstance(variant, DiagLayer)
 
         if isinstance(variant, HierarchyElement):
-            if (rx_id := variant.get_receive_id()) is not None:
+            if (rx_id := variant.get_can_receive_id()) is not None:
                 recv_id = hex(rx_id)
             else:
                 recv_id = "None"
 
-            if (tx_id := variant.get_send_id()) is not None:
+            if (tx_id := variant.get_can_send_id()) is not None:
                 send_id = hex(tx_id)
             else:
                 send_id = "None"

--- a/odxtools/cli/compare.py
+++ b/odxtools/cli/compare.py
@@ -48,11 +48,7 @@ from ..response import Response
 from ..unit import Unit
 from . import _parser_utils
 from ._parser_utils import SubparsersList
-from ._print_utils import (
-    build_service_table,
-    print_dl_metrics,
-    print_service_parameters,
-)
+from ._print_utils import build_service_table, print_dl_metrics, print_service_parameters
 
 ParameterAttributeChangesDict = dict[str, str]
 ParameterChangesDict = dict[str, str | list[ParameterAttributeChangesDict]]

--- a/odxtools/cli/snoop.py
+++ b/odxtools/cli/snoop.py
@@ -235,7 +235,7 @@ def run(args: argparse.Namespace) -> None:
 
     odx_diag_layer = None
     if odx_database is not None:
-        odx_diag_layer = odx_database.diag_layers.get(args.variant)
+        odx_diag_layer = odx_database.diag_layers.get(str(args.variant))
 
         if odx_diag_layer is None:
             print(f"Variant '{args.variant}' does not exist. Available variants:")

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -120,7 +120,8 @@ class DataObjectProperty(DopBase):
         if not isinstance(physical_value, (int, float, str, BytesTypes)):
             odxraise(f"Invalid type '{type(physical_value).__name__}' for physical value. "
                      f"(Expect atomic type!)")
-        internal_value = self.compu_method.convert_physical_to_internal(physical_value)
+        internal_value = self.compu_method.convert_physical_to_internal(
+            physical_value)  # pyright: ignore[reportArgumentType]
         self.diag_coded_type.encode_into_pdu(internal_value, encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -14,7 +14,7 @@ from .exceptions import EncodeError, odxraise, odxrequire
 from .internalconstr import InternalConstr
 from .odxdoccontext import OdxDocContext
 from .odxlink import OdxLinkDatabase, OdxLinkId, OdxLinkRef
-from .odxtypes import AtomicOdxType, BytesTypes, ParameterValue
+from .odxtypes import AtomicOdxType, ParameterValue
 from .physicaltype import PhysicalType
 from .snrefcontext import SnRefContext
 from .unit import Unit
@@ -117,11 +117,11 @@ class DataObjectProperty(DopBase):
                 f"The value {repr(physical_value)} of type {type(physical_value).__name__}"
                 f" is not a valid.")
 
-        if not isinstance(physical_value, (int, float, str, BytesTypes)):
+        if not isinstance(physical_value, AtomicOdxType):
             odxraise(f"Invalid type '{type(physical_value).__name__}' for physical value. "
                      f"(Expect atomic type!)")
-        internal_value = self.compu_method.convert_physical_to_internal(
-            physical_value)  # pyright: ignore[reportArgumentType]
+            return
+        internal_value = self.compu_method.convert_physical_to_internal(physical_value)
         self.diag_coded_type.encode_into_pdu(internal_value, encode_state)
 
     def decode_from_pdu(self, decode_state: DecodeState) -> ParameterValue:

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -118,12 +118,16 @@ class DecodeState:
             str_encoding = get_string_encoding(base_data_type, base_type_encoding,
                                                is_highlow_byte_order)
             if str_encoding is not None:
+                if not isinstance(raw_value, (bytes, bytearray)):
+                    odxraise(f"Expected bytes for string decoding, got {type(raw_value).__name__}")
                 internal_value = raw_value.decode(str_encoding, errors=text_errors)
             else:
                 internal_value = "ERROR"
 
         # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
+            if not isinstance(raw_value, int):
+                odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}")
             if base_type_encoding == Encoding.ONEC:
                 # one-complement
                 sign_bit = 1 << (bit_length - 1)
@@ -160,6 +164,8 @@ class DecodeState:
 
         # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
+            if not isinstance(raw_value, int):
+                odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}")
             if base_type_encoding == Encoding.BCD_P:
                 internal_value = self.__decode_bcd_p(raw_value)
             elif base_type_encoding == Encoding.BCD_UP:

--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -343,7 +343,7 @@ class DiagLayer:
         return prefix_tree
 
     @staticmethod
-    def _extend_prefix_tree(prefix_tree: PrefixTree, coded_prefix: bytes,
+    def _extend_prefix_tree(prefix_tree: PrefixTree, coded_prefix: bytes | bytearray,
                             service: DiagService) -> None:
 
         # make sure that tree has an entry for the given prefix

--- a/odxtools/dynenddopref.py
+++ b/odxtools/dynenddopref.py
@@ -24,8 +24,9 @@ class DynEndDopRef(OdxLinkRef):
         ...
 
     @staticmethod
-    def from_et(et_element: ElementTree.Element | None,
-                context: OdxDocContext) -> Optional["DynEndDopRef"]:
+    def from_et(  # pyright: ignore[reportIncompatibleMethodOverride]
+            et_element: ElementTree.Element | None,
+            context: OdxDocContext) -> Optional["DynEndDopRef"]:
 
         if et_element is None:
             odxraise("Mandatory DYN-END-DOP-REF tag is missing")

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -175,6 +175,9 @@ class EncodeState:
                 else:
                     raw_value = internal_value
 
+            if not isinstance(raw_value, int):
+                odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}",
+                         EncodeError)
             if raw_value.bit_length() > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
@@ -202,6 +205,9 @@ class EncodeState:
 
                 raw_value = internal_value
 
+            if not isinstance(raw_value, int):
+                odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}",
+                         EncodeError)
             if raw_value.bit_length() > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "

--- a/odxtools/environmentdatadescription.py
+++ b/odxtools/environmentdatadescription.py
@@ -189,7 +189,9 @@ class EnvironmentDataDescription(ComplexDop):
                 tmp = env_data.decode_from_pdu(decode_state)
                 if not isinstance(tmp, dict):
                     odxraise()
-                result.update(tmp)
+                    break
+                result.update(tmp)  # pyright: ignore[reportArgumentType,reportCallIssue]
+
                 break
 
         # find the environment data corresponding to the given trouble
@@ -199,7 +201,9 @@ class EnvironmentDataDescription(ComplexDop):
                 tmp = env_data.decode_from_pdu(decode_state)
                 if not isinstance(tmp, dict):
                     odxraise()
-                result.update(tmp)
+                    break
+                result.update(tmp)  # pyright: ignore[reportArgumentType,reportCallIssue]
+
                 break
 
         return result

--- a/odxtools/identvalue.py
+++ b/odxtools/identvalue.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from typing import cast
 from xml.etree import ElementTree
 
 from .exceptions import odxraise
@@ -36,7 +37,7 @@ class IdentValue:
             value_type = IdentValueType(et_element.attrib["TYPE"])
         except Exception as e:
             odxraise(f"Cannot parse IDENT-VALUE-TYPE: {e}")
-            value_type = None
+            value_type = cast(IdentValueType, None)
 
         return IdentValue(value_raw=value_raw, value_type=value_type)
 

--- a/odxtools/matchingparameter.py
+++ b/odxtools/matchingparameter.py
@@ -50,8 +50,7 @@ class MatchingParameter:
         if (out_param_snref_el := et_element.find("OUT-PARAM-IF-SNREF")) is not None:
             out_param_if_snref = odxrequire(out_param_snref_el.get("SHORT-NAME"))
         elif (out_param_snpathref_el := et_element.find("OUT-PARAM-IF-SNPATHREF")) is not None:
-            out_param_if_snpathref = odxrequire(
-                odxrequire(out_param_snpathref_el).get("SHORT-NAME-PATH"))
+            out_param_if_snpathref = odxrequire(out_param_snpathref_el.get("SHORT-NAME-PATH"))
         else:
             odxraise("Output parameter must not be left unspecified")
 

--- a/odxtools/minmaxlengthtype.py
+++ b/odxtools/minmaxlengthtype.py
@@ -92,6 +92,10 @@ class MinMaxLengthType(DiagCodedType):
             else:
                 raw_value = internal_value.encode(str_encoding)
         else:
+            if not isinstance(internal_value, BytesTypes):
+                odxraise(
+                    f"Expected bytes value for MinMaxLengthType, got {type(internal_value).__name__}",
+                    EncodeError)
             raw_value = bytes(internal_value)
 
         data_length = len(raw_value)
@@ -107,7 +111,7 @@ class MinMaxLengthType(DiagCodedType):
                 f"Encoded value for MinMaxLengthType "
                 f"must not be longer than {self.max_length} bytes. "
                 f"(Is: {data_length} bytes.)", EncodeError)
-            data_length = self.max_length
+            data_length = int(self.max_length)
 
         encode_state.emplace_atomic_value(
             internal_value=raw_value,

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -167,6 +167,7 @@ class Multiplexer(ComplexDop):
         elif case_spec is None:
             if self.default_case is None:
                 raise EncodeError(f"Multiplexer {self.short_name} does not define a default case")
+            mux_case = self.default_case
             key_value = 0
         else:
             raise EncodeError(f"Illegal case specification '{case_spec}' for "

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -142,7 +142,8 @@ class ItemAttributeList(list[T]):
     def __getitem__(self, key: slice) -> list[T]:
         ...
 
-    def __getitem__(self, key: SupportsIndex | str | slice) -> T | list[T]:
+    def __getitem__(  # pyright: ignore[reportIncompatibleMethodOverride]
+            self, key: SupportsIndex | str | slice) -> T | list[T]:
         if isinstance(key, (SupportsIndex, slice)):
             return super().__getitem__(key)
         else:

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from typing import cast
 from xml.etree import ElementTree
 
 from .exceptions import odxraise, odxrequire
@@ -53,7 +54,7 @@ class PhysicalType:
             base_data_type = DataType(base_data_type_str)
         except ValueError:
             odxraise(f"Encountered unknown base data type '{base_data_type_str}'")
-            base_data_type = None
+            base_data_type = cast(DataType, None)
 
         display_radix_str = et_element.get("DISPLAY-RADIX")
         if display_radix_str is not None:

--- a/odxtools/sessiondesc.py
+++ b/odxtools/sessiondesc.py
@@ -46,7 +46,7 @@ class SessionDesc(NamedElement):
                 priority = int(priority_str)
             except Exception as e:
                 odxraise(f"Cannot parse PRIORITY: {e}")
-        session_snref = None
+        session_snref = cast(str, None)
         if (session_snref_elem := odxrequire(et_element.find("SESSION-SNREF"))) is not None:
             session_snref = odxrequire(session_snref_elem.attrib.get("SHORT-NAME"))
         diag_comm_snref = None

--- a/odxtools/statetransitionref.py
+++ b/odxtools/statetransitionref.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 from xml.etree import ElementTree
 
 from .basicstructure import BasicStructure
@@ -65,7 +65,7 @@ def _resolve_in_param_helper(
             return None, None
 
         if TYPE_CHECKING:
-            tr = resolve_snref(inner_param_value[0], inner_param.table.table_rows, TableRow)
+            tr = resolve_snref(str(inner_param_value[0]), inner_param.table.table_rows, TableRow)
         else:
             tr = resolve_snref(inner_param_value[0], inner_param.table.table_rows)
 
@@ -86,7 +86,8 @@ def _resolve_in_param_helper(
         odxraise(f"Expected the referenced parameter to be composite")
         return None, None
 
-    return _resolve_in_param_helper(inner_param_list, inner_param_value, path_chunks[1:])
+    return _resolve_in_param_helper(inner_param_list, cast(ParameterValueDict, inner_param_value),
+                                    path_chunks[1:])
 
 
 def _check_applies(ref: Union["StateTransitionRef",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,4 @@ filterwarnings = [
 
 [tool.pyright]
 include = ["odxtools", "tests"]
+reportMissingImports = "none"


### PR DESCRIPTION
`pyright` sometimes flags different issues than `mypy` and having both in their happy zone is thus a good thing. Note that this requires a few `# pyright: ignore` comments where `mypy` and `pyright` are mutually exclusive.

Finally, as a small drive-by, this PR reverts cf1b9cb307043418378fdcc7d882f0b973004128 because both mypy and pyright can infer that `out_param_snpathref_el` cannot be `None` at this place...