### PR TITLE
fix(cli): improve error messages for unavailable tools

### DIFF
--- a/odxtools/cli/dummy_sub_parser.py
+++ b/odxtools/cli/dummy_sub_parser.py
@@ -18,14 +18,36 @@ class DummyTool:
     should bail out.
     """
 
+    # Map missing modules to install hints
+    _INSTALL_HINTS: dict[str, str] = {
+        "InquirerPy": 'pip install "odxtools[browse-tool]"',
+        "PyYAML": 'pip install "odxtools[compare-tool]"',
+        "can_isotp": 'pip install "odxtools[examples]"',
+    }
+
     def __init__(self, tool_name: str, error: Exception):
         self._odxtools_tool_name_ = tool_name
         self._error = error
 
+    def _format_error(self) -> str:
+        """Return a user-friendly error message."""
+        if isinstance(self._error, ModuleNotFoundError) and self._error.name is not None:
+            hint = self._INSTALL_HINTS.get(self._error.name)
+            if hint:
+                return (
+                    f"Error: Tool '{self._odxtools_tool_name_}' requires '{self._error.name}'.\n"
+                    f"Install it with: {hint}"
+                )
+            return (
+                f"Error: Tool '{self._odxtools_tool_name_}' requires '{self._error.name}'.\n"
+                f"Install it with: pip install {self._error.name}"
+            )
+
+        return f"Error: Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}"
+
     def add_subparser(self, subparser_list: SubparsersList) -> None:
         desc = StringIO()
-
-        print(f"Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}", file=desc)
+        print(self._format_error(), file=desc)
         print(file=desc)
         print(f"Traceback:", file=desc)
         traceback.print_tb(self._error.__traceback__, file=desc)
@@ -38,8 +60,5 @@ class DummyTool:
         )
 
     def run(self, args: argparse.Namespace) -> None:
-        print(
-            f"Error: Tool '{self._odxtools_tool_name_}' is unavailable: {self._error}",
-            file=sys.stderr,
-        )
+        print(self._format_error(), file=sys.stderr)
         exit(1)


### PR DESCRIPTION
When a tool fails to load due to a missing optional dependency, print a user-friendly message with the correct pip install command instead of a raw exception traceback.

- Map known missing modules to their odxtools extra install hints
- Keep full traceback in --help description for debugging
- Clean up run() output to stderr for better UX
- this PR addresses the suggestion from PR #467