### PR TITLE
fix: do not test ElementTree elements for truthiness

### DIFF
--- a/odxtools/dynamicendmarkerfield.py
+++ b/odxtools/dynamicendmarkerfield.py
@@ -39,7 +39,9 @@ class DynamicEndmarkerField(Field):
 
         # ODX 2.0 uses DATA-OBJECT-PROP-REF
         # ODX 2.2 uses DYN-END-DOP-REF
-        dop_ref = et_element.find("DYN-END-DOP-REF") or et_element.find("DATA-OBJECT-PROP-REF")
+        dop_ref = et_element.find("DYN-END-DOP-REF")
+        if dop_ref is None:
+            dop_ref = et_element.find("DATA-OBJECT-PROP-REF")
         dyn_end_dop_ref = DynEndDopRef.from_et(odxrequire(dop_ref), context)
 
         return DynamicEndmarkerField(dyn_end_dop_ref=dyn_end_dop_ref, **kwargs)

--- a/odxtools/subcomponentparamconnector.py
+++ b/odxtools/subcomponentparamconnector.py
@@ -51,7 +51,8 @@ class SubComponentParamConnector(IdentifiableElement):
             odxrequire(et_element.find("DIAG-COMM-SNREF")).get("SHORT-NAME"))
 
         out_param_if_refs = []
-        for elem in et_element.find("OUT-PARAM-IF-REFS") or []:
+        out_param_if_refs_elem = et_element.find("OUT-PARAM-IF-REFS")
+        for elem in [] if out_param_if_refs_elem is None else out_param_if_refs_elem:
             if elem.tag != "OUT-PARAM-IF-SNREF":
                 odxraise("Currently, only SNREFS are supported for OUT-PARAM-IF-REFS")
                 continue
@@ -60,7 +61,8 @@ class SubComponentParamConnector(IdentifiableElement):
                 out_param_if_refs.append(odxrequire(elem.attrib.get("SHORT-NAME")))
 
         in_param_if_refs = []
-        for elem in et_element.find("IN-PARAM-IF-REFS") or []:
+        in_param_if_refs_elem = et_element.find("IN-PARAM-IF-REFS")
+        for elem in [] if in_param_if_refs_elem is None else in_param_if_refs_elem:
             if elem.tag != "IN-PARAM-IF-SNREF":
                 odxraise("Currently, only SNREFS are supported for IN-PARAM-IF-REFS")
                 continue

--- a/tests/test_element_truth_value.py
+++ b/tests/test_element_truth_value.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+import unittest
+import warnings
+from xml.etree import ElementTree
+
+from packaging.version import Version
+
+from odxtools.dynamicendmarkerfield import DynamicEndmarkerField
+from odxtools.odxdoccontext import OdxDocContext
+from odxtools.odxlink import OdxDocFragment
+from odxtools.subcomponentparamconnector import SubComponentParamConnector
+
+doc_frags = (OdxDocFragment("UnitTest", "CONTAINER"),)
+context = OdxDocContext(Version("2.2.0"), doc_frags)
+
+
+class TestElementTruthValue(unittest.TestCase):
+    """Elements must not be tested for truthiness (deprecated since 3.12)."""
+
+    def test_sub_component_param_connector(self) -> None:
+        et_element = ElementTree.fromstring("""
+        <SUB-COMPONENT-PARAM-CONNECTOR ID="connector">
+          <SHORT-NAME>connector</SHORT-NAME>
+          <DIAG-COMM-SNREF SHORT-NAME="service"/>
+          <OUT-PARAM-IF-REFS/>
+          <IN-PARAM-IF-REFS>
+            <IN-PARAM-IF-SNREF SHORT-NAME="param"/>
+          </IN-PARAM-IF-REFS>
+        </SUB-COMPONENT-PARAM-CONNECTOR>""")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            connector = SubComponentParamConnector.from_et(et_element, context)
+
+        self.assertEqual([str(w.message) for w in caught], [])
+        self.assertEqual(connector.out_param_if_refs, [])
+        self.assertEqual(connector.in_param_if_refs, ["param"])
+
+    def test_dynamic_endmarker_field(self) -> None:
+        et_element = ElementTree.fromstring("""
+        <DYNAMIC-ENDMARKER-FIELD ID="field">
+          <SHORT-NAME>field</SHORT-NAME>
+          <BASIC-STRUCTURE-REF ID-REF="structure"/>
+          <DYN-END-DOP-REF ID-REF="dop">
+            <TERMINATION-VALUE>0</TERMINATION-VALUE>
+          </DYN-END-DOP-REF>
+        </DYNAMIC-ENDMARKER-FIELD>""")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            field = DynamicEndmarkerField.from_et(et_element, context)
+
+        self.assertEqual([str(w.message) for w in caught], [])
+        self.assertEqual(field.dyn_end_dop_ref.ref_id, "dop")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #419

An `Element`'s truth value is deprecated since Python 3.12, and it is also `False` for elements without children — so `et_element.find(...) or <fallback>` both warns and silently discards a found-but-childless element. Replaced the three remaining occurrences with explicit `is None` checks.

The new test asserts that parsing these elements emits no `DeprecationWarning`; it fails 2/2 without the source change and passes with it. Full test suite stays green (157 passed).
