### PR TITLE
fix(find): prevent KeyError crash on invalid --variant argument

### DIFF
--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -31,8 +31,8 @@ def print_summary(odxdb: Database,
     service_db: dict[str, DiagService] = {}
     service_ecus: dict[str, list[str]] = {}
     for ecu_name in ecu_names:
-        ecu = odxdb.ecus[ecu_name]
-        if not ecu:
+        ecu = odxdb.diag_layers.get(ecu_name)
+        if ecu is None:
             print(f"The ecu variant [green3]'{ecu_name}'[/green3] could not be found!")
             continue
 


### PR DESCRIPTION
fix(find): prevent KeyError crash on invalid --variant argument

`odxdb.ecus[ecu_name]` raises `KeyError` when the specified ECU variant
doesn't exist. This makes the `if not ecu:` check below it unreachable
dead code — the exception fires before the check can run.

Use `.get()` instead to return `None` on miss, matching the pattern
already used in `decode.py` and allowing the existing error message
to display.

Before:
  $ odxtools find --variant NONEXISTENT somersault.pdx
  KeyError: 'NONEXISTENT'
  [stack trace]

After:
  $ odxtools find --variant NONEXISTENT somersault.pdx
  The ecu variant 'NONEXISTENT' could not be found!
  [continues with next variant if any]