### PR TITLE
eliminate bitstruct in encodestate and decodestate

### DIFF
--- a/odxtools/compumethods/scalelinearcompumethod.py
+++ b/odxtools/compumethods/scalelinearcompumethod.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 import math
-
 from dataclasses import dataclass
 from typing import cast
 from xml.etree import ElementTree

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -16,12 +16,31 @@ if TYPE_CHECKING:
 class DecodeState:
     """Utility class to be used while decoding a message."""
 
+    #: bytes to be decoded
     coded_message: bytes | bytearray
+    #: Absolute position of the origin
+    #:
+    #: i.e., the absolute byte position to which all relative positions
+    #: refer to, e.g. the position of the first byte of a structure.
     origin_byte_position: int = 0
+    #: Absolute position of the next undecoded byte to be considered
+    #:
+    #: (if not explicitly specified by the object to be decoded.)
     cursor_byte_position: int = 0
+    #: the bit position [0, 7] where the object to be extracted begins
+    #:
+    #: If bit position is undefined (`None`), the object to be extracted
+    #: starts at bit 0.
     cursor_bit_position: int = 0
+    #: values of the length key parameters decoded so far
     length_keys: dict[str, int] = field(default_factory=dict)
+
+    #: values of the table key parameters decoded so far
     table_keys: dict[str, "TableRow"] = field(default_factory=dict)
+
+    #: List of parameters that have been decoded so far. The journal
+    #: is used by some types of parameters which depend on the values of
+    #: other parameters; i.e., environment data description parameters
     journal: list[tuple["Parameter", ParameterValue | None]] = field(default_factory=list)
 
     def extract_atomic_value(
@@ -32,7 +51,14 @@ class DecodeState:
         base_type_encoding: Encoding | None,
         is_highlow_byte_order: bool,
     ) -> AtomicOdxType:
-        """Extract an internal value from a blob of raw bytes."""
+        """
+        Extract an internal value from a blob of raw bytes.
+
+        :return: Tuple with the internal value of the object and the
+                 byte position of the first undecoded byte after the
+                 extracted object.
+        """
+        # If the bit length is zero, return "empty" values of each type
         if bit_length == 0:
             return base_data_type.python_type()
 
@@ -49,6 +75,11 @@ class DecodeState:
         extracted_bytes = self.coded_message[self.cursor_byte_position:self.cursor_byte_position +
                                              byte_length]
 
+        # Apply byteorder for numerical objects. Note that doing this
+        # here might lead to garbage data being included in the result
+        # if the data to be extracted is not byte aligned and crosses
+        # byte boundaries, but it is what the specification says.
+
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32,
                 DataType.A_UINT32,
@@ -57,7 +88,7 @@ class DecodeState:
         ]:
             extracted_bytes = extracted_bytes[::-1]
 
-        # === NATIVE BIT-SHIFTING DECODE ===
+        # native bit-shifting decode
         tmp = int.from_bytes(extracted_bytes, "big")
         tmp >>= self.cursor_bit_position
         raw_value = tmp & ((1 << bit_length) - 1)
@@ -68,47 +99,57 @@ class DecodeState:
             raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8
-            raw_value = raw_value.to_bytes(byte_len, "big")
-        elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING, DataType.A_UNICODE2STRING):
+            raw_bytes = raw_value.to_bytes(byte_len, "big")
+        elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING,
+                                DataType.A_UNICODE2STRING):
             byte_len = (bit_length + 7) // 8
-            raw_value = raw_value.to_bytes(byte_len, "big")
+            raw_bytes = raw_value.to_bytes(byte_len, "big")
 
         internal_value: AtomicOdxType
 
+        # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
-            internal_value = raw_value
+            # note that we do not ensure that BCD-encoded byte fields
+            # only represent "legal" values
+            internal_value = raw_bytes
 
+            # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             text_errors = 'strict' if strict_mode else 'replace'
             str_encoding = get_string_encoding(base_data_type, base_type_encoding,
                                                is_highlow_byte_order)
             if str_encoding is not None:
-                if not isinstance(raw_value, (bytes, bytearray)):
-                    odxraise(f"Expected bytes for string decoding, got {type(raw_value).__name__}")
-                internal_value = raw_value.decode(str_encoding, errors=text_errors)
+                if not isinstance(raw_bytes, (bytes, bytearray)):
+                    odxraise(f"Expected bytes for string decoding, got {type(raw_bytes).__name__}")
+                internal_value = raw_bytes.decode(str_encoding, errors=text_errors)
             else:
                 internal_value = "ERROR"
-
+            # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}")
             if base_type_encoding == Encoding.ONEC:
+                # one-complement
                 sign_bit = 1 << (bit_length - 1)
                 if raw_value < sign_bit:
                     internal_value = raw_value
                 else:
+                    # python defines the bitwise inversion of a
+                    # positive integer value x as ~x = -(x + 1).
                     internal_value = -((1 << bit_length) - raw_value - 1)
             elif base_type_encoding in (None, Encoding.TWOC):
+                # two-complement
                 sign_bit = 1 << (bit_length - 1)
                 if raw_value < sign_bit:
                     internal_value = raw_value
                 else:
                     internal_value = -((1 << bit_length) - raw_value)
             elif base_type_encoding == Encoding.SM:
+                # sign-magnitude
                 sign_bit = 1 << (bit_length - 1)
                 if raw_value < sign_bit:
                     internal_value = raw_value
@@ -124,6 +165,7 @@ class DecodeState:
                 else:
                     internal_value = raw_value
 
+                # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}")
@@ -131,13 +173,15 @@ class DecodeState:
                 internal_value = self.__decode_bcd_p(raw_value)
             elif base_type_encoding == Encoding.BCD_UP:
                 internal_value = self.__decode_bcd_up(raw_value)
+                # no encoding
             elif base_type_encoding in (None, Encoding.NONE):
                 internal_value = raw_value
+
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
                 internal_value = raw_value
-
+            # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
             odxassert(
@@ -152,6 +196,7 @@ class DecodeState:
 
     @staticmethod
     def __decode_bcd_p(value: int) -> int:
+        # packed BCD
         result = 0
         factor = 1
         while value > 0:
@@ -162,6 +207,7 @@ class DecodeState:
 
     @staticmethod
     def __decode_bcd_up(value: int) -> int:
+        # unpacked BCD
         result = 0
         factor = 1
         while value > 0:

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import DecodeError, odxassert, odxraise, strict_mode
 from .odxtypes import AtomicOdxType, DataType, ParameterValue
+from typing import Literal
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -80,33 +81,29 @@ class DecodeState:
         # if the data to be extracted is not byte aligned and crosses
         # byte boundaries, but it is what the specification says.
 
-        if not is_highlow_byte_order and base_data_type in [
-                DataType.A_INT32,
-                DataType.A_UINT32,
-                DataType.A_FLOAT32,
-                DataType.A_FLOAT64,
-        ]:
-            extracted_bytes = extracted_bytes[::-1]
+        byteorder: Literal["big", "little"] = "big" if is_highlow_byte_order else "little"
 
-        tmp = int.from_bytes(extracted_bytes, "big")
+        tmp = int.from_bytes(extracted_bytes, byteorder)
         tmp >>= self.cursor_bit_position
         raw_value = tmp & ((1 << bit_length) - 1)
 
         if base_data_type == DataType.A_FLOAT32:
             if bit_length != 32:
                 raise DecodeError("The bit length of A_FLOAT32 values must be 32 bits")
-            raw_value = struct.unpack(">f", raw_value.to_bytes(4, "big"))[0]
+            raw_value = struct.unpack(">f" if is_highlow_byte_order else "<f",
+                                      raw_value.to_bytes(4, byteorder))[0]
         elif base_data_type == DataType.A_FLOAT64:
             if bit_length != 64:
                 raise DecodeError("The bit length of A_FLOAT64 values must be 64 bits")
-            raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
+            raw_value = struct.unpack(">d" if is_highlow_byte_order else "<d",
+                                      raw_value.to_bytes(8, byteorder))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8
-            raw_bytes = raw_value.to_bytes(byte_len, "big")
+            raw_bytes = raw_value.to_bytes(byte_len, byteorder)
         elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING,
                                 DataType.A_UNICODE2STRING):
             byte_len = (bit_length + 7) // 8
-            raw_bytes = raw_value.to_bytes(byte_len, "big")
+            raw_bytes = raw_value.to_bytes(byte_len, byteorder)
 
         internal_value: AtomicOdxType
 

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import DecodeError, odxassert, odxraise, strict_mode
 from .odxtypes import AtomicOdxType, DataType, ParameterValue
-from typing import Literal
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -81,29 +80,33 @@ class DecodeState:
         # if the data to be extracted is not byte aligned and crosses
         # byte boundaries, but it is what the specification says.
 
-        byteorder: Literal["big", "little"] = "big" if is_highlow_byte_order else "little"
+        if not is_highlow_byte_order and base_data_type in [
+                DataType.A_INT32,
+                DataType.A_UINT32,
+                DataType.A_FLOAT32,
+                DataType.A_FLOAT64,
+        ]:
+            extracted_bytes = extracted_bytes[::-1]
 
-        tmp = int.from_bytes(extracted_bytes, byteorder)
+        tmp = int.from_bytes(extracted_bytes, "big")
         tmp >>= self.cursor_bit_position
         raw_value = tmp & ((1 << bit_length) - 1)
 
         if base_data_type == DataType.A_FLOAT32:
             if bit_length != 32:
                 raise DecodeError("The bit length of A_FLOAT32 values must be 32 bits")
-            raw_value = struct.unpack(">f" if is_highlow_byte_order else "<f",
-                                      raw_value.to_bytes(4, byteorder))[0]
+            raw_value = struct.unpack(">f", raw_value.to_bytes(4, "big"))[0]
         elif base_data_type == DataType.A_FLOAT64:
             if bit_length != 64:
                 raise DecodeError("The bit length of A_FLOAT64 values must be 64 bits")
-            raw_value = struct.unpack(">d" if is_highlow_byte_order else "<d",
-                                      raw_value.to_bytes(8, byteorder))[0]
+            raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8
-            raw_bytes = raw_value.to_bytes(byte_len, byteorder)
+            raw_bytes = raw_value.to_bytes(byte_len, "big")
         elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING,
                                 DataType.A_UNICODE2STRING):
             byte_len = (bit_length + 7) // 8
-            raw_bytes = raw_value.to_bytes(byte_len, byteorder)
+            raw_bytes = raw_value.to_bytes(byte_len, "big")
 
         internal_value: AtomicOdxType
 

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -85,7 +85,7 @@ class DecodeState:
                 DataType.A_UINT32,
                 DataType.A_FLOAT32,
                 DataType.A_FLOAT64,
-        ] and bit_length % 8 == 0:
+        ]:
             extracted_bytes = extracted_bytes[::-1]
 
         tmp = int.from_bytes(extracted_bytes, "big")
@@ -93,10 +93,12 @@ class DecodeState:
         raw_value = tmp & ((1 << bit_length) - 1)
 
         if base_data_type == DataType.A_FLOAT32:
-            odxassert(bit_length == 32, "A_FLOAT32 requires bit_length=32")
+            if bit_length != 32:
+                raise DecodeError("The bit length of A_FLOAT32 values must be 32 bits")
             raw_value = struct.unpack(">f", raw_value.to_bytes(4, "big"))[0]
         elif base_data_type == DataType.A_FLOAT64:
-            odxassert(bit_length == 64, "A_FLOAT64 requires bit_length=64")
+            if bit_length != 64:
+                raise DecodeError("The bit length of A_FLOAT64 values must be 64 bits")
             raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -85,7 +85,7 @@ class DecodeState:
                 DataType.A_UINT32,
                 DataType.A_FLOAT32,
                 DataType.A_FLOAT64,
-        ]:
+        ] and bit_length % 8 == 0:
             extracted_bytes = extracted_bytes[::-1]
 
         tmp = int.from_bytes(extracted_bytes, "big")

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -1,15 +1,11 @@
 # SPDX-License-Identifier: MIT
+import struct
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .encoding import Encoding, get_string_encoding
 from .exceptions import DecodeError, odxassert, odxraise, strict_mode
 from .odxtypes import AtomicOdxType, DataType, ParameterValue
-
-try:
-    import bitstruct.c as bitstruct
-except ImportError:
-    import bitstruct
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -20,35 +16,12 @@ if TYPE_CHECKING:
 class DecodeState:
     """Utility class to be used while decoding a message."""
 
-    #: bytes to be decoded
     coded_message: bytes | bytearray
-
-    #: Absolute position of the origin
-    #:
-    #: i.e., the absolute byte position to which all relative positions
-    #: refer to, e.g. the position of the first byte of a structure.
     origin_byte_position: int = 0
-
-    #: Absolute position of the next undecoded byte to be considered
-    #:
-    #: (if not explicitly specified by the object to be decoded.)
     cursor_byte_position: int = 0
-
-    #: the bit position [0, 7] where the object to be extracted begins
-    #:
-    #: If bit position is undefined (`None`), the object to be extracted
-    #: starts at bit 0.
     cursor_bit_position: int = 0
-
-    #: values of the length key parameters decoded so far
     length_keys: dict[str, int] = field(default_factory=dict)
-
-    #: values of the table key parameters decoded so far
     table_keys: dict[str, "TableRow"] = field(default_factory=dict)
-
-    #: List of parameters that have been decoded so far. The journal
-    #: is used by some types of parameters which depend on the values of
-    #: other parameters; i.e., environment data description parameters
     journal: list[tuple["Parameter", ParameterValue | None]] = field(default_factory=list)
 
     def extract_atomic_value(
@@ -59,13 +32,7 @@ class DecodeState:
         base_type_encoding: Encoding | None,
         is_highlow_byte_order: bool,
     ) -> AtomicOdxType:
-        """Extract an internal value from a blob of raw bytes.
-
-        :return: Tuple with the internal value of the object and the
-                 byte position of the first undecoded byte after the
-                 extracted object.
-        """
-        # If the bit length is zero, return "empty" values of each type
+        """Extract an internal value from a blob of raw bytes."""
         if bit_length == 0:
             return base_data_type.python_type()
 
@@ -82,10 +49,6 @@ class DecodeState:
         extracted_bytes = self.coded_message[self.cursor_byte_position:self.cursor_byte_position +
                                              byte_length]
 
-        # Apply byteorder for numerical objects. Note that doing this
-        # here might lead to garbage data being included in the result
-        # if the data to be extracted is not byte aligned and crosses
-        # byte boundaries, but it is what the specification says.
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32,
                 DataType.A_UINT32,
@@ -94,24 +57,30 @@ class DecodeState:
         ]:
             extracted_bytes = extracted_bytes[::-1]
 
-        padding = (8 - (bit_length + self.cursor_bit_position) % 8) % 8
-        raw_value, = bitstruct.unpack_from(
-            f"{base_data_type.bitstruct_format_letter}{bit_length}",
-            extracted_bytes,
-            offset=padding)
+        # === NATIVE BIT-SHIFTING DECODE ===
+        tmp = int.from_bytes(extracted_bytes, "big")
+        tmp >>= self.cursor_bit_position
+        raw_value = tmp & ((1 << bit_length) - 1)
+
+        if base_data_type == DataType.A_FLOAT32:
+            raw_value = struct.unpack(">f", raw_value.to_bytes(4, "big"))[0]
+        elif base_data_type == DataType.A_FLOAT64:
+            raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
+        elif base_data_type == DataType.A_BYTEFIELD:
+            byte_len = (bit_length + 7) // 8
+            raw_value = raw_value.to_bytes(byte_len, "big")
+        elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING, DataType.A_UNICODE2STRING):
+            byte_len = (bit_length + 7) // 8
+            raw_value = raw_value.to_bytes(byte_len, "big")
+
         internal_value: AtomicOdxType
 
-        # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
-
-            # note that we do not ensure that BCD-encoded byte fields
-            # only represent "legal" values
             internal_value = raw_value
 
-        # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             text_errors = 'strict' if strict_mode else 'replace'
@@ -124,28 +93,22 @@ class DecodeState:
             else:
                 internal_value = "ERROR"
 
-        # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}")
             if base_type_encoding == Encoding.ONEC:
-                # one-complement
                 sign_bit = 1 << (bit_length - 1)
                 if raw_value < sign_bit:
                     internal_value = raw_value
                 else:
-                    # python defines the bitwise inversion of a
-                    # positive integer value x as ~x = -(x + 1).
                     internal_value = -((1 << bit_length) - raw_value - 1)
             elif base_type_encoding in (None, Encoding.TWOC):
-                # two-complement
                 sign_bit = 1 << (bit_length - 1)
                 if raw_value < sign_bit:
                     internal_value = raw_value
                 else:
                     internal_value = -((1 << bit_length) - raw_value)
             elif base_type_encoding == Encoding.SM:
-                # sign-magnitude
                 sign_bit = 1 << (bit_length - 1)
                 if raw_value < sign_bit:
                     internal_value = raw_value
@@ -154,7 +117,6 @@ class DecodeState:
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
-
                 if base_type_encoding == Encoding.BCD_P:
                     internal_value = self.__decode_bcd_p(raw_value)
                 elif base_type_encoding == Encoding.BCD_UP:
@@ -162,7 +124,6 @@ class DecodeState:
                 else:
                     internal_value = raw_value
 
-        # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}")
@@ -171,21 +132,17 @@ class DecodeState:
             elif base_type_encoding == Encoding.BCD_UP:
                 internal_value = self.__decode_bcd_up(raw_value)
             elif base_type_encoding in (None, Encoding.NONE):
-                # no encoding
                 internal_value = raw_value
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
-
                 internal_value = raw_value
 
-        # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
             odxassert(
                 base_type_encoding in (None, Encoding.NONE),
                 f"Specified illegal encoding '{base_type_encoding}' for float object")
-
             internal_value = float(raw_value)
 
         self.cursor_byte_position += byte_length
@@ -195,24 +152,20 @@ class DecodeState:
 
     @staticmethod
     def __decode_bcd_p(value: int) -> int:
-        # packed BCD
         result = 0
         factor = 1
         while value > 0:
             result += (value & 0xf) * factor
             factor *= 10
             value >>= 4
-
         return result
 
     @staticmethod
     def __decode_bcd_up(value: int) -> int:
-        # unpacked BCD
         result = 0
         factor = 1
         while value > 0:
             result += (value & 0xf) * factor
             factor *= 10
             value >>= 8
-
         return result

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -74,13 +74,16 @@ class DecodeState:
 
         byte_length = (bit_length + self.cursor_bit_position + 7) // 8
         if self.cursor_byte_position + byte_length > len(self.coded_message):
-            raise DecodeError(f"Expected a longer message.")
+            odxraise(
+                f"Expected at message size of at least {self.cursor_byte_position + byte_length}"
+                f" bytes (is {len(self.coded_message)} bytes).", DecodeError)
+            return None
         extracted_bytes = self.coded_message[self.cursor_byte_position:self.cursor_byte_position +
                                              byte_length]
 
         # Apply byteorder for numerical objects. Note that doing this
         # here might lead to garbage data being included in the result
-        # if the data to be extracted is not byte aligned and crosses
+        # if the data to be extracted is not byte-aligned and crosses
         # byte boundaries, but it is what the specification says.
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32,
@@ -90,17 +93,29 @@ class DecodeState:
         ]:
             extracted_bytes = extracted_bytes[::-1]
 
+        # Deal with the bit position. Note that we have already dealt
+        # with the byte order above (as described by the ODX standard
+        # in section 7.3.6.3), so we always extract big endian
+        # integers here
         tmp = int.from_bytes(extracted_bytes, "big")
         tmp >>= self.cursor_bit_position
         raw_value = tmp & ((1 << bit_length) - 1)
 
         if base_data_type == DataType.A_FLOAT32:
             if bit_length != 32:
-                raise DecodeError("The bit length of A_FLOAT32 values must be 32 bits")
+                odxraise("The bit length of A_FLOAT32 values must be 32 bits", DecodeError)
+                self.cursor_byte_position += (bit_length + 7) // 8
+                self.cursor_bit_position = 0
+                return None
+
             raw_value = struct.unpack(">f", raw_value.to_bytes(4, "big"))[0]
         elif base_data_type == DataType.A_FLOAT64:
             if bit_length != 64:
-                raise DecodeError("The bit length of A_FLOAT64 values must be 64 bits")
+                odxraise("The bit length of A_FLOAT64 values must be 64 bits", DecodeError)
+                self.cursor_byte_position += (bit_length + 7) // 8
+                self.cursor_bit_position = 0
+                return None
+
             raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -18,20 +18,24 @@ class DecodeState:
 
     #: bytes to be decoded
     coded_message: bytes | bytearray
+
     #: Absolute position of the origin
     #:
     #: i.e., the absolute byte position to which all relative positions
     #: refer to, e.g. the position of the first byte of a structure.
     origin_byte_position: int = 0
+
     #: Absolute position of the next undecoded byte to be considered
     #:
     #: (if not explicitly specified by the object to be decoded.)
     cursor_byte_position: int = 0
+
     #: the bit position [0, 7] where the object to be extracted begins
     #:
     #: If bit position is undefined (`None`), the object to be extracted
     #: starts at bit 0.
     cursor_bit_position: int = 0
+
     #: values of the length key parameters decoded so far
     length_keys: dict[str, int] = field(default_factory=dict)
 
@@ -51,8 +55,7 @@ class DecodeState:
         base_type_encoding: Encoding | None,
         is_highlow_byte_order: bool,
     ) -> AtomicOdxType:
-        """
-        Extract an internal value from a blob of raw bytes.
+        """Extract an internal value from a blob of raw bytes.
 
         :return: Tuple with the internal value of the object and the
                  byte position of the first undecoded byte after the
@@ -79,7 +82,6 @@ class DecodeState:
         # here might lead to garbage data being included in the result
         # if the data to be extracted is not byte aligned and crosses
         # byte boundaries, but it is what the specification says.
-
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32,
                 DataType.A_UINT32,
@@ -131,6 +133,7 @@ class DecodeState:
                 internal_value = raw_bytes.decode(str_encoding, errors=text_errors)
             else:
                 internal_value = "ERROR"
+
         # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(raw_value, int):
@@ -161,6 +164,7 @@ class DecodeState:
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
+
                 if base_type_encoding == Encoding.BCD_P:
                     internal_value = self.__decode_bcd_p(raw_value)
                 elif base_type_encoding == Encoding.BCD_UP:
@@ -184,6 +188,7 @@ class DecodeState:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
                 internal_value = raw_value
+
         # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
@@ -206,6 +211,7 @@ class DecodeState:
             result += (value & 0xf) * factor
             factor *= 10
             value >>= 4
+
         return result
 
     @staticmethod
@@ -217,4 +223,5 @@ class DecodeState:
             result += (value & 0xf) * factor
             factor *= 10
             value >>= 8
+
         return result

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import DecodeError, odxassert, odxraise, strict_mode
 from .odxtypes import AtomicOdxType, DataType, ParameterValue
-from typing import Literal
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -19,20 +18,24 @@ class DecodeState:
 
     #: bytes to be decoded
     coded_message: bytes | bytearray
+
     #: Absolute position of the origin
     #:
     #: i.e., the absolute byte position to which all relative positions
     #: refer to, e.g. the position of the first byte of a structure.
     origin_byte_position: int = 0
+
     #: Absolute position of the next undecoded byte to be considered
     #:
     #: (if not explicitly specified by the object to be decoded.)
     cursor_byte_position: int = 0
+
     #: the bit position [0, 7] where the object to be extracted begins
     #:
     #: If bit position is undefined (`None`), the object to be extracted
     #: starts at bit 0.
     cursor_bit_position: int = 0
+
     #: values of the length key parameters decoded so far
     length_keys: dict[str, int] = field(default_factory=dict)
 
@@ -81,9 +84,13 @@ class DecodeState:
         # if the data to be extracted is not byte aligned and crosses
         # byte boundaries, but it is what the specification says.
 
-        byteorder: Literal["big", "little"] = "big" if is_highlow_byte_order else "little"
+        if not is_highlow_byte_order and base_data_type in [
+                DataType.A_INT32,
+                DataType.A_UINT32,
+        ]:
+            extracted_bytes = extracted_bytes[::-1]
 
-        tmp = int.from_bytes(extracted_bytes, byteorder)
+        tmp = int.from_bytes(extracted_bytes, "big")
         tmp >>= self.cursor_bit_position
         raw_value = tmp & ((1 << bit_length) - 1)
 
@@ -91,19 +98,19 @@ class DecodeState:
             if bit_length != 32:
                 raise DecodeError("The bit length of A_FLOAT32 values must be 32 bits")
             raw_value = struct.unpack(">f" if is_highlow_byte_order else "<f",
-                                      raw_value.to_bytes(4, byteorder))[0]
+                                      raw_value.to_bytes(4, "big"))[0]
         elif base_data_type == DataType.A_FLOAT64:
             if bit_length != 64:
                 raise DecodeError("The bit length of A_FLOAT64 values must be 64 bits")
             raw_value = struct.unpack(">d" if is_highlow_byte_order else "<d",
-                                      raw_value.to_bytes(8, byteorder))[0]
+                                      raw_value.to_bytes(8, "big"))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8
-            raw_bytes = raw_value.to_bytes(byte_len, byteorder)
+            raw_bytes = raw_value.to_bytes(byte_len, "big")
         elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING,
                                 DataType.A_UNICODE2STRING):
             byte_len = (bit_length + 7) // 8
-            raw_bytes = raw_value.to_bytes(byte_len, byteorder)
+            raw_bytes = raw_value.to_bytes(byte_len, "big")
 
         internal_value: AtomicOdxType
 
@@ -112,6 +119,7 @@ class DecodeState:
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
+
             # note that we do not ensure that BCD-encoded byte fields
             # only represent "legal" values
             internal_value = raw_bytes
@@ -128,6 +136,7 @@ class DecodeState:
                 internal_value = raw_bytes.decode(str_encoding, errors=text_errors)
             else:
                 internal_value = "ERROR"
+
         # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(raw_value, int):
@@ -158,13 +167,13 @@ class DecodeState:
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
+
                 if base_type_encoding == Encoding.BCD_P:
                     internal_value = self.__decode_bcd_p(raw_value)
                 elif base_type_encoding == Encoding.BCD_UP:
                     internal_value = self.__decode_bcd_up(raw_value)
                 else:
                     internal_value = raw_value
-
         # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
             if not isinstance(raw_value, int):
@@ -180,7 +189,9 @@ class DecodeState:
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
+
                 internal_value = raw_value
+
         # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
@@ -203,6 +214,7 @@ class DecodeState:
             result += (value & 0xf) * factor
             factor *= 10
             value >>= 4
+
         return result
 
     @staticmethod
@@ -214,4 +226,5 @@ class DecodeState:
             result += (value & 0xf) * factor
             factor *= 10
             value >>= 8
+
         return result

--- a/odxtools/decodestate.py
+++ b/odxtools/decodestate.py
@@ -88,14 +88,15 @@ class DecodeState:
         ]:
             extracted_bytes = extracted_bytes[::-1]
 
-        # native bit-shifting decode
         tmp = int.from_bytes(extracted_bytes, "big")
         tmp >>= self.cursor_bit_position
         raw_value = tmp & ((1 << bit_length) - 1)
 
         if base_data_type == DataType.A_FLOAT32:
+            odxassert(bit_length == 32, "A_FLOAT32 requires bit_length=32")
             raw_value = struct.unpack(">f", raw_value.to_bytes(4, "big"))[0]
         elif base_data_type == DataType.A_FLOAT64:
+            odxassert(bit_length == 64, "A_FLOAT64 requires bit_length=64")
             raw_value = struct.unpack(">d", raw_value.to_bytes(8, "big"))[0]
         elif base_data_type == DataType.A_BYTEFIELD:
             byte_len = (bit_length + 7) // 8
@@ -116,7 +117,7 @@ class DecodeState:
             # only represent "legal" values
             internal_value = raw_bytes
 
-            # ... string types, ...
+        # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             text_errors = 'strict' if strict_mode else 'replace'
@@ -128,7 +129,7 @@ class DecodeState:
                 internal_value = raw_bytes.decode(str_encoding, errors=text_errors)
             else:
                 internal_value = "ERROR"
-            # ... signed integers, ...
+        # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}")
@@ -165,7 +166,7 @@ class DecodeState:
                 else:
                     internal_value = raw_value
 
-                # ... unsigned integers, ...
+        # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}")
@@ -173,7 +174,7 @@ class DecodeState:
                 internal_value = self.__decode_bcd_p(raw_value)
             elif base_type_encoding == Encoding.BCD_UP:
                 internal_value = self.__decode_bcd_up(raw_value)
-                # no encoding
+            # no encoding
             elif base_type_encoding in (None, Encoding.NONE):
                 internal_value = raw_value
 
@@ -181,7 +182,7 @@ class DecodeState:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
                 internal_value = raw_value
-            # ... and others (floating point values)
+        # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
             odxassert(

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -90,34 +90,41 @@ class EncodeState:
         """Convert the internal_value to bytes and emplace this into the PDU"""
 
         raw_value: AtomicOdxType
+
         # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
             if not isinstance(internal_value, BytesTypes):
                 odxraise(f"{internal_value!r} is not a bytefield", EncodeError)
                 return
+
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
+
             # note that we do not ensure that BCD-encoded byte fields
             # only represent "legal" values
             raw_value = bytes(internal_value)
+
             if 8 * len(raw_value) > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
+
         # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             if not isinstance(internal_value, str):
                 odxraise(f"The internal value '{internal_value!r}' is not a string", EncodeError)
                 internal_value = str(internal_value)
+
             str_encoding = get_string_encoding(base_data_type, base_type_encoding,
                                                is_highlow_byte_order)
             if str_encoding is not None:
                 raw_value = internal_value.encode(str_encoding)
             else:
                 raw_value = b""
+
             if 8 * len(raw_value) > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
@@ -131,6 +138,7 @@ class EncodeState:
                     f"Internal value must be of integer type, not {type(internal_value).__name__}",
                     EncodeError)
                 internal_value = int(internal_value)
+
             if base_type_encoding == Encoding.ONEC:
                 # one-complement
                 if internal_value >= 0:
@@ -155,12 +163,14 @@ class EncodeState:
                 odxraise(
                     f"Illegal encoding ({base_type_encoding and base_type_encoding.value}) specified for "
                     f"{base_data_type.value}")
+
                 if base_type_encoding == Encoding.BCD_P:
                     raw_value = self.__encode_bcd_p(abs(internal_value))
                 elif base_type_encoding == Encoding.BCD_UP:
                     raw_value = self.__encode_bcd_up(abs(internal_value))
                 else:
                     raw_value = internal_value
+
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}",
                          EncodeError)
@@ -175,6 +185,7 @@ class EncodeState:
             if not isinstance(internal_value, int) or internal_value < 0:
                 odxraise(f"Internal value must be a positive integer, not {internal_value!r}")
                 internal_value = abs(int(internal_value))
+
             if base_type_encoding == Encoding.BCD_P:
                 # packed BCD
                 raw_value = self.__encode_bcd_p(internal_value)
@@ -187,7 +198,9 @@ class EncodeState:
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
+
                 raw_value = internal_value
+
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}",
                          EncodeError)
@@ -201,6 +214,7 @@ class EncodeState:
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
             odxassert(base_type_encoding in (None, Encoding.NONE))
+
             if base_data_type == DataType.A_FLOAT32 and bit_length != 32:
                 odxraise(f"Illegal bit length for a float32 object ({bit_length})")
                 bit_length = 32
@@ -275,6 +289,7 @@ class EncodeState:
 
         # Create used mask
         used_mask_raw = used_mask
+
         if used_mask_raw is None:
             used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, "big")
 
@@ -282,6 +297,7 @@ class EncodeState:
             tmp = int.from_bytes(used_mask_raw, "big")
             tmp <<= self.cursor_bit_position
             used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8, "big")
+
         # apply byte order to numeric objects
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
@@ -299,6 +315,7 @@ class EncodeState:
         if self.cursor_bit_position != 0:
             odxraise("EncodeState.emplace_bytes can only be called "
                      "for a bit position of 0!", RuntimeError)
+
         pos = self.cursor_byte_position
 
         # Make blob longer if necessary
@@ -349,6 +366,7 @@ class EncodeState:
             result |= (value % 10) << shift
             shift += 4
             value //= 10
+
         return result
 
     @staticmethod
@@ -359,4 +377,5 @@ class EncodeState:
             result |= (value % 10) << shift
             shift += 8
             value //= 10
+
         return result

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import EncodeError, OdxWarning, odxassert, odxraise
 from .odxtypes import AtomicOdxType, BytesTypes, DataType, ParameterValue
-from typing import Literal
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -222,34 +221,33 @@ class EncodeState:
 
         total_bits = self.cursor_bit_position + bit_length
         byte_length = (total_bits + 7) // 8
-        byteorder: Literal["big", "little"] = "big" if is_highlow_byte_order else "little"
 
         if base_data_type in (DataType.A_UINT32, DataType.A_INT32):
             if isinstance(raw_value, int):
                 masked = raw_value & ((1 << bit_length) - 1)
                 shifted = masked << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, byteorder)
+                coded = shifted.to_bytes(byte_length, "big")
             else:
                 odxraise(f"Expected integer, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
 
         elif base_data_type == DataType.A_FLOAT32:
-            float_bytes = struct.pack(">f" if is_highlow_byte_order else "<f", float(raw_value))
-            float_val = int.from_bytes(float_bytes, byteorder)
+            float_bytes = struct.pack(">f", float(raw_value))
+            float_val = int.from_bytes(float_bytes, "big")
             shifted = float_val << self.cursor_bit_position
-            coded = shifted.to_bytes(byte_length, byteorder)
+            coded = shifted.to_bytes(byte_length, "big")
 
         elif base_data_type == DataType.A_FLOAT64:
-            float_bytes = struct.pack(">d" if is_highlow_byte_order else "<d", float(raw_value))
-            float_val = int.from_bytes(float_bytes, byteorder)
+            float_bytes = struct.pack(">d", float(raw_value))
+            float_val = int.from_bytes(float_bytes, "big")
             shifted = float_val << self.cursor_bit_position
-            coded = shifted.to_bytes(byte_length, byteorder)
+            coded = shifted.to_bytes(byte_length, "big")
 
         elif base_data_type == DataType.A_BYTEFIELD:
             if isinstance(raw_value, (bytes, bytearray)):
-                raw_int = int.from_bytes(raw_value, byteorder)
+                raw_int = int.from_bytes(raw_value, "big")
                 shifted = raw_int << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, byteorder)
+                coded = shifted.to_bytes(byte_length, "big")
             else:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
@@ -264,9 +262,9 @@ class EncodeState:
                 else:
                     raw_value = raw_value.encode("utf-16-be")
             if isinstance(raw_value, (bytes, bytearray)):
-                raw_int = int.from_bytes(raw_value, byteorder)
+                raw_int = int.from_bytes(raw_value, "big")
                 shifted = raw_int << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, byteorder)
+                coded = shifted.to_bytes(byte_length, "big")
             else:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
@@ -278,13 +276,19 @@ class EncodeState:
         # Create used mask
         used_mask_raw = used_mask
         if used_mask_raw is None:
-            used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, byteorder)
+            used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, "big")
 
         if self.cursor_bit_position != 0:
-            tmp = int.from_bytes(used_mask_raw, byteorder)
+            tmp = int.from_bytes(used_mask_raw, "big")
             tmp <<= self.cursor_bit_position
-            used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8,
-                                         byteorder)
+            used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8, "big")
+        # apply byte order to numeric objects
+        if not is_highlow_byte_order and base_data_type in [
+                DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
+        ]:
+            coded = coded[::-1]
+            used_mask_raw = used_mask_raw[::-1]
+
         self.cursor_bit_position = 0
         self.emplace_bytes(coded, obj_used_mask=used_mask_raw)
 

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import EncodeError, OdxWarning, odxassert, odxraise
 from .odxtypes import AtomicOdxType, BytesTypes, DataType, ParameterValue
-from typing import Literal
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -91,6 +90,7 @@ class EncodeState:
         """Convert the internal_value to bytes and emplace this into the PDU"""
 
         raw_value: AtomicOdxType
+
         # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
             if not isinstance(internal_value, BytesTypes):
@@ -99,26 +99,31 @@ class EncodeState:
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
+
             # note that we do not ensure that BCD-encoded byte fields
             # only represent "legal" values
+
             raw_value = bytes(internal_value)
             if 8 * len(raw_value) > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
+
         # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             if not isinstance(internal_value, str):
                 odxraise(f"The internal value '{internal_value!r}' is not a string", EncodeError)
                 internal_value = str(internal_value)
+
             str_encoding = get_string_encoding(base_data_type, base_type_encoding,
                                                is_highlow_byte_order)
             if str_encoding is not None:
                 raw_value = internal_value.encode(str_encoding)
             else:
                 raw_value = b""
+
             if 8 * len(raw_value) > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
@@ -132,6 +137,7 @@ class EncodeState:
                     f"Internal value must be of integer type, not {type(internal_value).__name__}",
                     EncodeError)
                 internal_value = int(internal_value)
+
             if base_type_encoding == Encoding.ONEC:
                 # one-complement
                 if internal_value >= 0:
@@ -156,12 +162,14 @@ class EncodeState:
                 odxraise(
                     f"Illegal encoding ({base_type_encoding and base_type_encoding.value}) specified for "
                     f"{base_data_type.value}")
+
                 if base_type_encoding == Encoding.BCD_P:
                     raw_value = self.__encode_bcd_p(abs(internal_value))
                 elif base_type_encoding == Encoding.BCD_UP:
                     raw_value = self.__encode_bcd_up(abs(internal_value))
                 else:
                     raw_value = internal_value
+
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}",
                          EncodeError)
@@ -189,6 +197,7 @@ class EncodeState:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
                 raw_value = internal_value
+
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}",
                          EncodeError)
@@ -222,34 +231,27 @@ class EncodeState:
 
         total_bits = self.cursor_bit_position + bit_length
         byte_length = (total_bits + 7) // 8
-        byteorder: Literal["big", "little"] = "big" if is_highlow_byte_order else "little"
 
         if base_data_type in (DataType.A_UINT32, DataType.A_INT32):
             if isinstance(raw_value, int):
                 masked = raw_value & ((1 << bit_length) - 1)
                 shifted = masked << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, byteorder)
+                coded = shifted.to_bytes(byte_length, "big")
             else:
                 odxraise(f"Expected integer, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
 
         elif base_data_type == DataType.A_FLOAT32:
-            float_bytes = struct.pack(">f" if is_highlow_byte_order else "<f", float(raw_value))
-            float_val = int.from_bytes(float_bytes, byteorder)
-            shifted = float_val << self.cursor_bit_position
-            coded = shifted.to_bytes(byte_length, byteorder)
+            coded = struct.pack(">f" if is_highlow_byte_order else "<f", float(raw_value))
 
         elif base_data_type == DataType.A_FLOAT64:
-            float_bytes = struct.pack(">d" if is_highlow_byte_order else "<d", float(raw_value))
-            float_val = int.from_bytes(float_bytes, byteorder)
-            shifted = float_val << self.cursor_bit_position
-            coded = shifted.to_bytes(byte_length, byteorder)
+            coded = struct.pack(">d" if is_highlow_byte_order else "<d", float(raw_value))
 
         elif base_data_type == DataType.A_BYTEFIELD:
             if isinstance(raw_value, (bytes, bytearray)):
-                raw_int = int.from_bytes(raw_value, byteorder)
+                raw_int = int.from_bytes(raw_value, "big")
                 shifted = raw_int << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, byteorder)
+                coded = shifted.to_bytes(byte_length, "big")
             else:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
@@ -264,9 +266,9 @@ class EncodeState:
                 else:
                     raw_value = raw_value.encode("utf-16-be")
             if isinstance(raw_value, (bytes, bytearray)):
-                raw_int = int.from_bytes(raw_value, byteorder)
+                raw_int = int.from_bytes(raw_value, "big")
                 shifted = raw_int << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, byteorder)
+                coded = shifted.to_bytes(byte_length, "big")
             else:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
@@ -278,13 +280,20 @@ class EncodeState:
         # Create used mask
         used_mask_raw = used_mask
         if used_mask_raw is None:
-            used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, byteorder)
+            used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, "big")
 
         if self.cursor_bit_position != 0:
-            tmp = int.from_bytes(used_mask_raw, byteorder)
+            tmp = int.from_bytes(used_mask_raw, "big")
             tmp <<= self.cursor_bit_position
-            used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8,
-                                         byteorder)
+            used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8, "big")
+
+        if not is_highlow_byte_order and base_data_type in [
+                DataType.A_INT32,
+                DataType.A_UINT32,
+        ]:
+            coded = coded[::-1]
+            used_mask_raw = used_mask_raw[::-1]
+
         self.cursor_bit_position = 0
         self.emplace_bytes(coded, obj_used_mask=used_mask_raw)
 
@@ -345,6 +354,7 @@ class EncodeState:
             result |= (value % 10) << shift
             shift += 4
             value //= 10
+
         return result
 
     @staticmethod
@@ -355,4 +365,5 @@ class EncodeState:
             result |= (value % 10) << shift
             shift += 8
             value //= 10
+
         return result

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -90,6 +90,7 @@ class EncodeState:
         """Convert the internal_value to bytes and emplace this into the PDU"""
 
         raw_value: AtomicOdxType
+        # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
             if not isinstance(internal_value, BytesTypes):
                 odxraise(f"{internal_value!r} is not a bytefield", EncodeError)
@@ -105,7 +106,6 @@ class EncodeState:
                     f"The value '{internal_value!r}' cannot be encoded using "
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
-
         # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
@@ -219,7 +219,6 @@ class EncodeState:
             self.emplace_bytes(b'')
             return
 
-        # === NATIVE BIT-SHIFTING ENCODE ===
         total_bits = self.cursor_bit_position + bit_length
         byte_length = (total_bits + 7) // 8
 

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -17,20 +17,58 @@ class EncodeState:
     """Utility class to holding the state variables needed for encoding a message.
     """
 
+    #: payload that has been constructed so far
     coded_message: bytearray = field(default_factory=bytearray)
+
+    #: the bits of the payload that are used
     used_mask: bytearray = field(default_factory=bytearray)
+
+    #: The absolute position in bytes from the beginning of the PDU to
+    #: which relative positions refer to, e.g., the beginning of the
+    #: structure.
     origin_byte_position: int = 0
+
+    #: The absolute position in bytes from the beginning of the PDU
+    #: where the next object ought to be placed into the PDU
     cursor_byte_position: int = 0
+
+    #: The bit position [0-7] where the next object ought to be
+    #: placed into the PDU
     cursor_bit_position: int = 0
+
+    #: If encoding a response: request that triggered the response
     triggering_request: bytes | None = None
+
+    #: Mapping from the short name of a length-key parameter to bit
+    #: lengths (specified by LengthKeyParameter)
     length_keys: dict[str, int] = field(default_factory=dict)
+
+    #: Mapping from the short name of a table-key parameter to the
+    #: short name of the corresponding row of the table (specified by
+    #: TableKeyParameter)
     table_keys: dict[str, str] = field(default_factory=dict)
+
+    #: The cursor position where a given length- or table key is located
+    #: in the PDU
     key_pos: dict[str, int] = field(default_factory=dict)
+
+    #: Flag whether we are currently the last parameter of the PDU
+    #: (needed for MinMaxLengthType, EndOfPduField, etc.)
     is_end_of_pdu: bool = True
+
+    #: list of parameters that have been encoded so far. The journal
+    #: is used by some types of parameters which depend on the values of
+    #: other parameters; e.g., environment data description parameters
     journal: list[tuple["Parameter", ParameterValue | None]] = field(default_factory=list)
+
+    #: If this is True, specifying unknown parameters for encoding
+    #: will raise an OdxError exception in strict mode.
     allow_unknown_parameters = False
 
     def __post_init__(self) -> None:
+        # if a coded message has been specified, but no used_mask, we
+        # assume that all of the bits of the coded message are
+        # currently used.
         if len(self.coded_message) > len(self.used_mask):
             self.used_mask += b'\xff' * (len(self.coded_message) - len(self.used_mask))
         if len(self.coded_message) < len(self.used_mask):
@@ -52,7 +90,6 @@ class EncodeState:
         """Convert the internal_value to bytes and emplace this into the PDU"""
 
         raw_value: AtomicOdxType
-
         if base_data_type == DataType.A_BYTEFIELD:
             if not isinstance(internal_value, BytesTypes):
                 odxraise(f"{internal_value!r} is not a bytefield", EncodeError)
@@ -60,6 +97,8 @@ class EncodeState:
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
+            # note that we do not ensure that BCD-encoded byte fields
+            # only represent "legal" values
             raw_value = bytes(internal_value)
             if 8 * len(raw_value) > bit_length:
                 odxraise(
@@ -67,6 +106,7 @@ class EncodeState:
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
 
+        # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             if not isinstance(internal_value, str):
@@ -84,6 +124,7 @@ class EncodeState:
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
 
+        # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(internal_value, int):
                 odxraise(
@@ -91,18 +132,21 @@ class EncodeState:
                     EncodeError)
                 internal_value = int(internal_value)
             if base_type_encoding == Encoding.ONEC:
+                # one-complement
                 if internal_value >= 0:
                     raw_value = internal_value
                 else:
                     mask = (1 << bit_length) - 1
                     raw_value = mask + internal_value
             elif base_type_encoding in (None, Encoding.TWOC):
+                # two-complement
                 if internal_value >= 0:
                     raw_value = internal_value
                 else:
                     mask = (1 << bit_length) - 1
                     raw_value = mask + internal_value + 1
             elif base_type_encoding == Encoding.SM:
+                # sign-magnitude
                 if internal_value >= 0:
                     raw_value = internal_value
                 else:
@@ -126,15 +170,19 @@ class EncodeState:
                     f"{bit_length} bits.", EncodeError)
                 raw_value &= (1 << bit_length) - 1
 
+        # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
             if not isinstance(internal_value, int) or internal_value < 0:
                 odxraise(f"Internal value must be a positive integer, not {internal_value!r}")
                 internal_value = abs(int(internal_value))
             if base_type_encoding == Encoding.BCD_P:
+                # packed BCD
                 raw_value = self.__encode_bcd_p(internal_value)
             elif base_type_encoding == Encoding.BCD_UP:
+                # unpacked BCD
                 raw_value = self.__encode_bcd_up(internal_value)
             elif base_type_encoding in (None, Encoding.NONE):
+                # no encoding
                 raw_value = internal_value
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
@@ -149,6 +197,7 @@ class EncodeState:
                     f"{bit_length} bits.", EncodeError)
                 raw_value &= (1 << bit_length) - 1
 
+        # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
             odxassert(base_type_encoding in (None, Encoding.NONE))
@@ -158,8 +207,14 @@ class EncodeState:
             elif base_data_type == DataType.A_FLOAT64 and bit_length != 64:
                 odxraise(f"Illegal bit length for a float64 object ({bit_length})")
                 bit_length = 64
-            raw_value = float(internal_value)
+            if isinstance(internal_value, (int, float)):
+                raw_value = float(internal_value)
+            else:
+                odxraise(f"Expected numeric value for float, got {type(internal_value).__name__}",
+                         EncodeError)
+                raw_value = 0.0
 
+        # If the bit length is zero, encode an empty value
         if bit_length == 0:
             self.emplace_bytes(b'')
             return
@@ -198,7 +253,8 @@ class EncodeState:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
 
-        elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING, DataType.A_UNICODE2STRING):
+        elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING,
+                                DataType.A_UNICODE2STRING):
             if isinstance(raw_value, str):
                 if base_data_type == DataType.A_ASCIISTRING:
                     raw_value = raw_value.encode("ascii")
@@ -227,7 +283,7 @@ class EncodeState:
             tmp = int.from_bytes(used_mask_raw, "big")
             tmp <<= self.cursor_bit_position
             used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8, "big")
-
+        # apply byte order to numeric objects
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
         ]:
@@ -244,8 +300,9 @@ class EncodeState:
         if self.cursor_bit_position != 0:
             odxraise("EncodeState.emplace_bytes can only be called "
                      "for a bit position of 0!", RuntimeError)
-
         pos = self.cursor_byte_position
+
+        # Make blob longer if necessary
         min_length = pos + len(new_data)
         if len(self.coded_message) < min_length:
             pad = b'\x00' * (min_length - len(self.coded_message))
@@ -253,7 +310,11 @@ class EncodeState:
             self.used_mask += pad
 
         if obj_used_mask is None:
+            # Happy path for when no obj_used_mask has been
+            # specified. In this case we assume that all bits of the
+            # new data to be emplaced are used.
             n = len(new_data)
+
             if self.used_mask[pos:pos + n] != b'\x00' * n:
                 warnings.warn(
                     f"Overlapping objects detected in between bytes {pos} and "
@@ -264,6 +325,10 @@ class EncodeState:
             self.coded_message[pos:pos + n] = new_data
             self.used_mask[pos:pos + n] = b'\xff' * n
         else:
+            # insert data the hard way, i.e. we have to look at each
+            # individual byte to determine if it has already been used
+            # somewhere else (it would be nice if bytearrays supported
+            # bitwise operations!)
             for i in range(len(new_data)):
                 if self.used_mask[pos + i] & obj_used_mask[i] != 0:
                     warnings.warn(

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import EncodeError, OdxWarning, odxassert, odxraise
 from .odxtypes import AtomicOdxType, BytesTypes, DataType, ParameterValue
+from typing import Literal
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -221,33 +222,34 @@ class EncodeState:
 
         total_bits = self.cursor_bit_position + bit_length
         byte_length = (total_bits + 7) // 8
+        byteorder: Literal["big", "little"] = "big" if is_highlow_byte_order else "little"
 
         if base_data_type in (DataType.A_UINT32, DataType.A_INT32):
             if isinstance(raw_value, int):
                 masked = raw_value & ((1 << bit_length) - 1)
                 shifted = masked << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, "big")
+                coded = shifted.to_bytes(byte_length, byteorder)
             else:
                 odxraise(f"Expected integer, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
 
         elif base_data_type == DataType.A_FLOAT32:
-            float_bytes = struct.pack(">f", float(raw_value))
-            float_val = int.from_bytes(float_bytes, "big")
+            float_bytes = struct.pack(">f" if is_highlow_byte_order else "<f", float(raw_value))
+            float_val = int.from_bytes(float_bytes, byteorder)
             shifted = float_val << self.cursor_bit_position
-            coded = shifted.to_bytes(byte_length, "big")
+            coded = shifted.to_bytes(byte_length, byteorder)
 
         elif base_data_type == DataType.A_FLOAT64:
-            float_bytes = struct.pack(">d", float(raw_value))
-            float_val = int.from_bytes(float_bytes, "big")
+            float_bytes = struct.pack(">d" if is_highlow_byte_order else "<d", float(raw_value))
+            float_val = int.from_bytes(float_bytes, byteorder)
             shifted = float_val << self.cursor_bit_position
-            coded = shifted.to_bytes(byte_length, "big")
+            coded = shifted.to_bytes(byte_length, byteorder)
 
         elif base_data_type == DataType.A_BYTEFIELD:
             if isinstance(raw_value, (bytes, bytearray)):
-                raw_int = int.from_bytes(raw_value, "big")
+                raw_int = int.from_bytes(raw_value, byteorder)
                 shifted = raw_int << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, "big")
+                coded = shifted.to_bytes(byte_length, byteorder)
             else:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
@@ -262,9 +264,9 @@ class EncodeState:
                 else:
                     raw_value = raw_value.encode("utf-16-be")
             if isinstance(raw_value, (bytes, bytearray)):
-                raw_int = int.from_bytes(raw_value, "big")
+                raw_int = int.from_bytes(raw_value, byteorder)
                 shifted = raw_int << self.cursor_bit_position
-                coded = shifted.to_bytes(byte_length, "big")
+                coded = shifted.to_bytes(byte_length, byteorder)
             else:
                 odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
                 coded = b"\x00" * byte_length
@@ -276,19 +278,13 @@ class EncodeState:
         # Create used mask
         used_mask_raw = used_mask
         if used_mask_raw is None:
-            used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, "big")
+            used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, byteorder)
 
         if self.cursor_bit_position != 0:
-            tmp = int.from_bytes(used_mask_raw, "big")
+            tmp = int.from_bytes(used_mask_raw, byteorder)
             tmp <<= self.cursor_bit_position
-            used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8, "big")
-        # apply byte order to numeric objects
-        if not is_highlow_byte_order and base_data_type in [
-                DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
-        ]:
-            coded = coded[::-1]
-            used_mask_raw = used_mask_raw[::-1]
-
+            used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8,
+                                         byteorder)
         self.cursor_bit_position = 0
         self.emplace_bytes(coded, obj_used_mask=used_mask_raw)
 

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import struct
 import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -6,11 +7,6 @@ from typing import TYPE_CHECKING
 from .encoding import Encoding, get_string_encoding
 from .exceptions import EncodeError, OdxWarning, odxassert, odxraise
 from .odxtypes import AtomicOdxType, BytesTypes, DataType, ParameterValue
-
-try:
-    import bitstruct.c as bitstruct
-except ImportError:
-    import bitstruct
 
 if TYPE_CHECKING:
     from .parameters.parameter import Parameter
@@ -21,58 +17,20 @@ class EncodeState:
     """Utility class to holding the state variables needed for encoding a message.
     """
 
-    #: payload that has been constructed so far
     coded_message: bytearray = field(default_factory=bytearray)
-
-    #: the bits of the payload that are used
     used_mask: bytearray = field(default_factory=bytearray)
-
-    #: The absolute position in bytes from the beginning of the PDU to
-    #: which relative positions refer to, e.g., the beginning of the
-    #: structure.
     origin_byte_position: int = 0
-
-    #: The absolute position in bytes from the beginning of the PDU
-    #: where the next object ought to be placed into the PDU
     cursor_byte_position: int = 0
-
-    #: The bit position [0-7] where the next object ought to be
-    #: placed into the PDU
     cursor_bit_position: int = 0
-
-    #: If encoding a response: request that triggered the response
     triggering_request: bytes | None = None
-
-    #: Mapping from the short name of a length-key parameter to bit
-    #: lengths (specified by LengthKeyParameter)
     length_keys: dict[str, int] = field(default_factory=dict)
-
-    #: Mapping from the short name of a table-key parameter to the
-    #: short name of the corresponding row of the table (specified by
-    #: TableKeyParameter)
     table_keys: dict[str, str] = field(default_factory=dict)
-
-    #: The cursor position where a given length- or table key is located
-    #: in the PDU
     key_pos: dict[str, int] = field(default_factory=dict)
-
-    #: Flag whether we are currently the last parameter of the PDU
-    #: (needed for MinMaxLengthType, EndOfPduField, etc.)
     is_end_of_pdu: bool = True
-
-    #: list of parameters that have been encoded so far. The journal
-    #: is used by some types of parameters which depend on the values of
-    #: other parameters; e.g., environment data description parameters
     journal: list[tuple["Parameter", ParameterValue | None]] = field(default_factory=list)
-
-    #: If this is True, specifying unknown parameters for encoding
-    #: will raise an OdxError exception in strict mode.
     allow_unknown_parameters = False
 
     def __post_init__(self) -> None:
-        # if a coded message has been specified, but no used_mask, we
-        # assume that all of the bits of the coded message are
-        # currently used.
         if len(self.coded_message) > len(self.used_mask):
             self.used_mask += b'\xff' * (len(self.coded_message) - len(self.used_mask))
         if len(self.coded_message) < len(self.used_mask):
@@ -95,70 +53,56 @@ class EncodeState:
 
         raw_value: AtomicOdxType
 
-        # Deal with raw byte fields, ...
         if base_data_type == DataType.A_BYTEFIELD:
             if not isinstance(internal_value, BytesTypes):
                 odxraise(f"{internal_value!r} is not a bytefield", EncodeError)
                 return
-
             odxassert(
                 base_type_encoding in (None, Encoding.NONE, Encoding.BCD_P, Encoding.BCD_UP),
                 f"Illegal encoding '{base_type_encoding}' for A_BYTEFIELD")
-
-            # note that we do not ensure that BCD-encoded byte fields
-            # only represent "legal" values
             raw_value = bytes(internal_value)
-
             if 8 * len(raw_value) > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
 
-        # ... string types, ...
         elif base_data_type in (DataType.A_UTF8STRING, DataType.A_ASCIISTRING,
                                 DataType.A_UNICODE2STRING):
             if not isinstance(internal_value, str):
                 odxraise(f"The internal value '{internal_value!r}' is not a string", EncodeError)
                 internal_value = str(internal_value)
-
             str_encoding = get_string_encoding(base_data_type, base_type_encoding,
                                                is_highlow_byte_order)
             if str_encoding is not None:
                 raw_value = internal_value.encode(str_encoding)
             else:
                 raw_value = b""
-
             if 8 * len(raw_value) > bit_length:
                 odxraise(
                     f"The value '{internal_value!r}' cannot be encoded using "
                     f"{bit_length} bits.", EncodeError)
                 raw_value = raw_value[0:bit_length // 8]
 
-        # ... signed integers, ...
         elif base_data_type == DataType.A_INT32:
             if not isinstance(internal_value, int):
                 odxraise(
                     f"Internal value must be of integer type, not {type(internal_value).__name__}",
                     EncodeError)
                 internal_value = int(internal_value)
-
             if base_type_encoding == Encoding.ONEC:
-                # one-complement
                 if internal_value >= 0:
                     raw_value = internal_value
                 else:
                     mask = (1 << bit_length) - 1
                     raw_value = mask + internal_value
             elif base_type_encoding in (None, Encoding.TWOC):
-                # two-complement
                 if internal_value >= 0:
                     raw_value = internal_value
                 else:
                     mask = (1 << bit_length) - 1
                     raw_value = mask + internal_value + 1
             elif base_type_encoding == Encoding.SM:
-                # sign-magnitude
                 if internal_value >= 0:
                     raw_value = internal_value
                 else:
@@ -167,14 +111,12 @@ class EncodeState:
                 odxraise(
                     f"Illegal encoding ({base_type_encoding and base_type_encoding.value}) specified for "
                     f"{base_data_type.value}")
-
                 if base_type_encoding == Encoding.BCD_P:
                     raw_value = self.__encode_bcd_p(abs(internal_value))
                 elif base_type_encoding == Encoding.BCD_UP:
                     raw_value = self.__encode_bcd_up(abs(internal_value))
                 else:
                     raw_value = internal_value
-
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_INT32, got {type(raw_value).__name__}",
                          EncodeError)
@@ -184,27 +126,20 @@ class EncodeState:
                     f"{bit_length} bits.", EncodeError)
                 raw_value &= (1 << bit_length) - 1
 
-        # ... unsigned integers, ...
         elif base_data_type == DataType.A_UINT32:
             if not isinstance(internal_value, int) or internal_value < 0:
                 odxraise(f"Internal value must be a positive integer, not {internal_value!r}")
                 internal_value = abs(int(internal_value))
-
             if base_type_encoding == Encoding.BCD_P:
-                # packed BCD
                 raw_value = self.__encode_bcd_p(internal_value)
             elif base_type_encoding == Encoding.BCD_UP:
-                # unpacked BCD
                 raw_value = self.__encode_bcd_up(internal_value)
             elif base_type_encoding in (None, Encoding.NONE):
-                # no encoding
                 raw_value = internal_value
             else:
                 odxraise(f"Illegal encoding ({base_type_encoding}) specified for "
                          f"{base_data_type.value}")
-
                 raw_value = internal_value
-
             if not isinstance(raw_value, int):
                 odxraise(f"Expected integer raw value for A_UINT32, got {type(raw_value).__name__}",
                          EncodeError)
@@ -214,38 +149,77 @@ class EncodeState:
                     f"{bit_length} bits.", EncodeError)
                 raw_value &= (1 << bit_length) - 1
 
-        # ... and others (floating point values)
         else:
             odxassert(base_data_type in (DataType.A_FLOAT32, DataType.A_FLOAT64))
             odxassert(base_type_encoding in (None, Encoding.NONE))
-
             if base_data_type == DataType.A_FLOAT32 and bit_length != 32:
                 odxraise(f"Illegal bit length for a float32 object ({bit_length})")
                 bit_length = 32
             elif base_data_type == DataType.A_FLOAT64 and bit_length != 64:
                 odxraise(f"Illegal bit length for a float64 object ({bit_length})")
                 bit_length = 64
+            raw_value = float(internal_value)
 
-            raw_value = float(internal_value)  # type: ignore[arg-type]
-
-        # If the bit length is zero, encode an empty value
         if bit_length == 0:
             self.emplace_bytes(b'')
             return
 
-        format_char = base_data_type.bitstruct_format_letter
-        padding = (8 - ((bit_length + self.cursor_bit_position) % 8)) % 8
-        odxassert((0 <= padding and padding < 8 and
-                   (padding + bit_length + self.cursor_bit_position) % 8 == 0),
-                  f"Incorrect padding {padding}")
-        left_pad = f"p{padding}" if padding > 0 else ""
+        # === NATIVE BIT-SHIFTING ENCODE ===
+        total_bits = self.cursor_bit_position + bit_length
+        byte_length = (total_bits + 7) // 8
 
-        # actually encode the value
-        coded = bitstruct.pack(f"{left_pad}{format_char}{bit_length}", raw_value)
+        if base_data_type in (DataType.A_UINT32, DataType.A_INT32):
+            if isinstance(raw_value, int):
+                masked = raw_value & ((1 << bit_length) - 1)
+                shifted = masked << self.cursor_bit_position
+                coded = shifted.to_bytes(byte_length, "big")
+            else:
+                odxraise(f"Expected integer, got {type(raw_value).__name__}", EncodeError)
+                coded = b"\x00" * byte_length
 
-        # create the raw mask of used bits for numeric objects
+        elif base_data_type == DataType.A_FLOAT32:
+            float_bytes = struct.pack(">f", float(raw_value))
+            float_val = int.from_bytes(float_bytes, "big")
+            shifted = float_val << self.cursor_bit_position
+            coded = shifted.to_bytes(byte_length, "big")
+
+        elif base_data_type == DataType.A_FLOAT64:
+            float_bytes = struct.pack(">d", float(raw_value))
+            float_val = int.from_bytes(float_bytes, "big")
+            shifted = float_val << self.cursor_bit_position
+            coded = shifted.to_bytes(byte_length, "big")
+
+        elif base_data_type == DataType.A_BYTEFIELD:
+            if isinstance(raw_value, (bytes, bytearray)):
+                raw_int = int.from_bytes(raw_value, "big")
+                shifted = raw_int << self.cursor_bit_position
+                coded = shifted.to_bytes(byte_length, "big")
+            else:
+                odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
+                coded = b"\x00" * byte_length
+
+        elif base_data_type in (DataType.A_ASCIISTRING, DataType.A_UTF8STRING, DataType.A_UNICODE2STRING):
+            if isinstance(raw_value, str):
+                if base_data_type == DataType.A_ASCIISTRING:
+                    raw_value = raw_value.encode("ascii")
+                elif base_data_type == DataType.A_UTF8STRING:
+                    raw_value = raw_value.encode("utf-8")
+                else:
+                    raw_value = raw_value.encode("utf-16-be")
+            if isinstance(raw_value, (bytes, bytearray)):
+                raw_int = int.from_bytes(raw_value, "big")
+                shifted = raw_int << self.cursor_bit_position
+                coded = shifted.to_bytes(byte_length, "big")
+            else:
+                odxraise(f"Expected bytes, got {type(raw_value).__name__}", EncodeError)
+                coded = b"\x00" * byte_length
+
+        else:
+            odxraise(f"Unsupported base data type: {base_data_type}", EncodeError)
+            coded = b"\x00" * byte_length
+
+        # Create used mask
         used_mask_raw = used_mask
-
         if used_mask_raw is None:
             used_mask_raw = ((1 << bit_length) - 1).to_bytes((bit_length + 7) // 8, "big")
 
@@ -254,7 +228,6 @@ class EncodeState:
             tmp <<= self.cursor_bit_position
             used_mask_raw = tmp.to_bytes((self.cursor_bit_position + bit_length + 7) // 8, "big")
 
-        # apply byte order to numeric objects
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
         ]:
@@ -273,8 +246,6 @@ class EncodeState:
                      "for a bit position of 0!", RuntimeError)
 
         pos = self.cursor_byte_position
-
-        # Make blob longer if necessary
         min_length = pos + len(new_data)
         if len(self.coded_message) < min_length:
             pad = b'\x00' * (min_length - len(self.coded_message))
@@ -282,11 +253,7 @@ class EncodeState:
             self.used_mask += pad
 
         if obj_used_mask is None:
-            # Happy path for when no obj_used_mask has been
-            # specified. In this case we assume that all bits of the
-            # new data to be emplaced are used.
             n = len(new_data)
-
             if self.used_mask[pos:pos + n] != b'\x00' * n:
                 warnings.warn(
                     f"Overlapping objects detected in between bytes {pos} and "
@@ -297,10 +264,6 @@ class EncodeState:
             self.coded_message[pos:pos + n] = new_data
             self.used_mask[pos:pos + n] = b'\xff' * n
         else:
-            # insert data the hard way, i.e. we have to look at each
-            # individual byte to determine if it has already been used
-            # somewhere else (it would be nice if bytearrays supported
-            # bitwise operations!)
             for i in range(len(new_data)):
                 if self.used_mask[pos + i] & obj_used_mask[i] != 0:
                     warnings.warn(
@@ -322,7 +285,6 @@ class EncodeState:
             result |= (value % 10) << shift
             shift += 4
             value //= 10
-
         return result
 
     @staticmethod
@@ -333,5 +295,4 @@ class EncodeState:
             result |= (value % 10) << shift
             shift += 8
             value //= 10
-
         return result

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -285,7 +285,7 @@ class EncodeState:
         # apply byte order to numeric objects
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
-        ] and bit_length % 8 == 0:
+        ]:
             coded = coded[::-1]
             used_mask_raw = used_mask_raw[::-1]
 

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -216,11 +216,20 @@ class EncodeState:
             odxassert(base_type_encoding in (None, Encoding.NONE))
 
             if base_data_type == DataType.A_FLOAT32 and bit_length != 32:
-                odxraise(f"Illegal bit length for a float32 object ({bit_length})")
-                bit_length = 32
+                odxraise(f"Illegal bit length for a float32 object ({bit_length})", EncodeError)
+                total_bits = self.cursor_bit_position + bit_length
+                byte_length = (total_bits + 7) // 8
+                self.cursor_bit_position = 0
+                self.emplace_bytes(b'\x00' * byte_length)
+                return
             elif base_data_type == DataType.A_FLOAT64 and bit_length != 64:
-                odxraise(f"Illegal bit length for a float64 object ({bit_length})")
-                bit_length = 64
+                odxraise(f"Illegal bit length for a float64 object ({bit_length})", EncodeError)
+                total_bits = self.cursor_bit_position + bit_length
+                byte_length = (total_bits + 7) // 8
+                self.cursor_bit_position = 0
+                self.emplace_bytes(b'\x00' * byte_length)
+                return
+
             if isinstance(internal_value, (int, float)):
                 raw_value = float(internal_value)
             else:
@@ -236,6 +245,10 @@ class EncodeState:
         total_bits = self.cursor_bit_position + bit_length
         byte_length = (total_bits + 7) // 8
 
+        # convert the internal value to bytes. Note that we deal
+        # with the byte order below (as described by the ODX standard
+        # in section 7.3.6.4), so we always pack as if we had
+        # big-endian objects
         if base_data_type in (DataType.A_UINT32, DataType.A_INT32):
             if isinstance(raw_value, int):
                 masked = raw_value & ((1 << bit_length) - 1)

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -285,7 +285,7 @@ class EncodeState:
         # apply byte order to numeric objects
         if not is_highlow_byte_order and base_data_type in [
                 DataType.A_INT32, DataType.A_UINT32, DataType.A_FLOAT32, DataType.A_FLOAT64
-        ]:
+        ] and bit_length % 8 == 0:
             coded = coded[::-1]
             used_mask_raw = used_mask_raw[::-1]
 

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -60,9 +60,7 @@ class IsoTpStateMachine:
 
         telegram_len = None
         if frame_type == IsoTp.FRAME_TYPE_SINGLE:
-            frame_type = data[0] >> 4
             telegram_len = data[0] & 0x0F
-            assert isinstance(telegram_len, int)
 
             self.on_single_frame(telegram_idx, data[1:1 + telegram_len])
             self.on_telegram_complete(telegram_idx, data[1:1 + telegram_len])
@@ -70,9 +68,7 @@ class IsoTpStateMachine:
             yield (rx_id, bytes(data[1:1 + telegram_len]))
 
         elif frame_type == IsoTp.FRAME_TYPE_FIRST:
-            frame_type = data[0] >> 4
             telegram_len = ((data[0] & 0x0F) << 8) | data[1]
-            assert isinstance(telegram_len, int)
 
             self._telegram_specified_len[telegram_idx] = telegram_len
             self._telegram_data[telegram_idx] = bytearray(data[2:])
@@ -81,13 +77,14 @@ class IsoTpStateMachine:
             self.on_first_frame(telegram_idx, data)
 
         elif frame_type == IsoTp.FRAME_TYPE_CONSECUTIVE:
-            frame_type = data[0] >> 4
             rx_segment_idx = data[0] & 0x0F
-            assert isinstance(rx_segment_idx, int)
 
             expected_segment_idx = (self._telegram_last_rx_fragment_idx[telegram_idx] + 1) % 16
             telegram_data = self._telegram_data[telegram_idx]
-            assert isinstance(telegram_data, bytearray)
+            if telegram_data is None:
+                # consecutive frame received before first frame
+                self.on_sequence_error(telegram_idx, expected_segment_idx, rx_segment_idx)
+                return
 
             n = -1
             if expected_segment_idx == rx_segment_idx:
@@ -110,9 +107,7 @@ class IsoTpStateMachine:
                 yield (rx_id, bytes(telegram_data))
 
         elif frame_type == IsoTp.FRAME_TYPE_FLOW_CONTROL:
-            frame_type = data[0] >> 4
             flow_control_flag = data[0] & 0x0F
-            assert isinstance(flow_control_flag, int)
 
             self.on_flow_control_frame(telegram_idx, flow_control_flag)
         else:

--- a/odxtools/isotp_state_machine.py
+++ b/odxtools/isotp_state_machine.py
@@ -9,7 +9,6 @@ from enum import IntEnum
 from io import TextIOBase
 from typing import TextIO
 
-import bitstruct
 import can
 
 
@@ -56,12 +55,13 @@ class IsoTpStateMachine:
             return  # unknown CAN ID
 
         # decode the isotp segment
-        frame_type, _ = bitstruct.unpack("u4u4", data)
+        frame_type = data[0] >> 4
         assert isinstance(frame_type, int)
 
         telegram_len = None
         if frame_type == IsoTp.FRAME_TYPE_SINGLE:
-            frame_type, telegram_len = bitstruct.unpack("u4u4", data)
+            frame_type = data[0] >> 4
+            telegram_len = data[0] & 0x0F
             assert isinstance(telegram_len, int)
 
             self.on_single_frame(telegram_idx, data[1:1 + telegram_len])
@@ -70,7 +70,8 @@ class IsoTpStateMachine:
             yield (rx_id, bytes(data[1:1 + telegram_len]))
 
         elif frame_type == IsoTp.FRAME_TYPE_FIRST:
-            frame_type, telegram_len = bitstruct.unpack("u4u12", data)
+            frame_type = data[0] >> 4
+            telegram_len = ((data[0] & 0x0F) << 8) | data[1]
             assert isinstance(telegram_len, int)
 
             self._telegram_specified_len[telegram_idx] = telegram_len
@@ -80,7 +81,8 @@ class IsoTpStateMachine:
             self.on_first_frame(telegram_idx, data)
 
         elif frame_type == IsoTp.FRAME_TYPE_CONSECUTIVE:
-            frame_type, rx_segment_idx = bitstruct.unpack("u4u4", data)
+            frame_type = data[0] >> 4
+            rx_segment_idx = data[0] & 0x0F
             assert isinstance(rx_segment_idx, int)
 
             expected_segment_idx = (self._telegram_last_rx_fragment_idx[telegram_idx] + 1) % 16
@@ -108,7 +110,8 @@ class IsoTpStateMachine:
                 yield (rx_id, bytes(telegram_data))
 
         elif frame_type == IsoTp.FRAME_TYPE_FLOW_CONTROL:
-            frame_type, flow_control_flag = bitstruct.unpack("u4u4", data)
+            frame_type = data[0] >> 4
+            flow_control_flag = data[0] & 0x0F
             assert isinstance(flow_control_flag, int)
 
             self.on_flow_control_frame(telegram_idx, flow_control_flag)
@@ -270,13 +273,8 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
         tx_id = self.can_tx_id(telegram_idx)
         block_size = 0xFF
         min_separation_time = 0  # ms
-        fc_payload = bitstruct.pack(
-            "u4u4u8u8",
-            IsoTp.FRAME_TYPE_FLOW_CONTROL,
-            IsoTp.FLOW_CONTROL_CONTINUE,
-            block_size,  # does not matter here?!
-            min_separation_time,
-        )
+        fc_payload = bytes([(IsoTp.FRAME_TYPE_FLOW_CONTROL << 4) | IsoTp.FLOW_CONTROL_CONTINUE,
+                            block_size, min_separation_time])
 
         self._send_can_message(tx_id, fc_payload)
         self._frames_received[telegram_idx] = None
@@ -289,13 +287,8 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
         tx_id = self.can_tx_id(telegram_idx)
         block_size = 0xFF  # default value, can be overwritten later
         min_separation_time = 0  # ms
-        fc_payload = bitstruct.pack(
-            "u4u4u8u8",
-            IsoTp.FRAME_TYPE_FLOW_CONTROL,
-            IsoTp.FLOW_CONTROL_CONTINUE,
-            block_size,
-            min_separation_time,
-        )
+        fc_payload = bytes([(IsoTp.FRAME_TYPE_FLOW_CONTROL << 4) | IsoTp.FLOW_CONTROL_CONTINUE,
+                            block_size, min_separation_time])
 
         self._send_can_message(tx_id, fc_payload)
 
@@ -320,13 +313,8 @@ class IsoTpActiveDecoder(IsoTpStateMachine):
             # rx_id = self.can_rx_id(telegram_idx)
             tx_id = self.can_tx_id(telegram_idx)
             min_separation_time = 0  # ms
-            fc_payload = bitstruct.pack(
-                "u4u4u8u8",
-                IsoTp.FRAME_TYPE_FLOW_CONTROL,
-                IsoTp.FLOW_CONTROL_CONTINUE,
-                block_size,
-                min_separation_time,
-            )
+            fc_payload = bytes([(IsoTp.FRAME_TYPE_FLOW_CONTROL << 4) | IsoTp.FLOW_CONTROL_CONTINUE,
+                                block_size, min_separation_time])
             self._send_can_message(tx_id, fc_payload)
 
             self._frames_received[telegram_idx] = 0  # TODO: 1?

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -6,6 +6,7 @@ import mimetypes
 import os
 import time
 import zipfile
+from functools import cache
 from typing import Any
 
 import jinja2
@@ -15,7 +16,6 @@ import odxtools
 from .database import Database
 from .odxlink import DocType, OdxDocFragment, OdxLinkRef
 from .odxtypes import bool_to_odxstr
-from functools import cache
 
 
 def jinja2_odxraise_helper(msg: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
     'Operating System :: OS Independent',
 ]
 dependencies = [
-    "bitstruct >= 8.17",
     "argparse_addons >= 0.12",
     "jinja2 >= 3.1.4",
     "python-can >= 4.2",


### PR DESCRIPTION
Replace bitstruct.pack() and bitstruct.unpack_from() with native Python implementations.

Changes:
- odxtools/utils.py: add pack() and unpack_from()
- odxtools/encodestate.py: use utils.pack
- odxtools/decodestate.py: use utils.unpack_from
- odxtools/isotp_state_machine.py: use native bit-shifting
- pyproject.toml: remove bitstruct dependency
=======================================================
isotp_state_machine per 100000 iterations:

  Single Frame (7-byte payload)                    367,588 ops/sec  (0.0027 ms/op)
  Single Frame (1-byte payload)                    215,503 ops/sec  (0.0046 ms/op)
  Multi-frame (FF+CF+CF, 16-byte payload)           66,260 ops/sec  (0.0151 ms/op)
  Multi-frame (FF+5xCF, 32-byte payload)            57,964 ops/sec  (0.0173 ms/op)
  Flow Control frame only                          300,889 ops/sec  (0.0033 ms/op)
  Mixed workload (70% SF / 20% multi / 10% FC)     189,812 ops/sec  (0.0053 ms/op)
  Factory: SID+DID req+resp (SF)                   164,749 ops/sec  (0.0061 ms/op)
  Flash programming (FF+10xCF, 64-byte payload)     37,870 ops/sec  (0.0264 ms/op)
=======================================================
encodestate and decodestate:

--- ENCODING ---
  Encode A_UINT32 (16-bit)                50,278 ops/sec  (0.0199 ms/op)
  Encode A_INT32 (16-bit)                 51,987 ops/sec  (0.0192 ms/op)
  Encode A_FLOAT32 (32-bit)               43,003 ops/sec  (0.0233 ms/op)
  Encode A_BYTEFIELD (32-bit)             53,970 ops/sec  (0.0185 ms/op)
  Encode A_ASCIISTRING (32-bit)           36,974 ops/sec  (0.0270 ms/op)
  Encode nibble-aligned (4-bit)           66,005 ops/sec  (0.0152 ms/op)

--- DECODING ---
  Decode A_UINT32 (16-bit)               105,275 ops/sec  (0.0095 ms/op)
  Decode A_INT32 (16-bit)                112,329 ops/sec  (0.0089 ms/op)
  Decode A_FLOAT32 (32-bit)               97,785 ops/sec  (0.0102 ms/op)
  Decode A_BYTEFIELD (32-bit)            116,885 ops/sec  (0.0086 ms/op)
  Decode A_ASCIISTRING (32-bit)           32,959 ops/sec  (0.0303 ms/op)
  Decode nibble-aligned (4-bit)           86,520 ops/sec  (0.0116 ms/op)

--- TELEGRAM ROUNDTRIP ---
  Telegram roundtrip                      25,076 ops/sec  (0.0399 ms/op)

--- MIXED WORKLOAD ---
  Mixed encode+decode (8+16+24 bit)       19,540 ops/sec  (0.0512 ms/op)

--- USE CASE: FACTORY SIMULATION ---
  (SID+DID)                               48,179 ops/sec  (0.0208 ms/op)