### PR TITLE
improve robustness of the non-strict mode

### DIFF
--- a/odxtools/diaglayers/diaglayer.py
+++ b/odxtools/diaglayers/diaglayer.py
@@ -100,6 +100,10 @@ class DiagLayer:
             for import_ref in self.import_refs:
                 imported_dl = odxlinks.resolve(import_ref)
 
+                if imported_dl is None:
+                    # in non-strict mode, odxlinks.resolve() can fail...
+                    continue
+
                 # TODO: ensure that the imported diagnostic layer has
                 # not been referenced in any PARENT-REF of the current
                 # layer or any of its parents.

--- a/odxtools/diaglayers/diaglayerraw.py
+++ b/odxtools/diaglayers/diaglayerraw.py
@@ -234,6 +234,10 @@ class DiagLayerRaw(IdentifiableElement):
         for dc_proxy in self.diag_comms_raw:
             if isinstance(dc_proxy, OdxLinkRef):
                 dc = odxlinks.resolve(dc_proxy, DiagComm)
+
+                if dc is None:
+                    # in non-strict mode, odxlinks.resolve() can return None
+                    continue
             else:
                 dc = dc_proxy
                 dc._resolve_odxlinks(odxlinks)

--- a/odxtools/diaglayers/hierarchyelement.py
+++ b/odxtools/diaglayers/hierarchyelement.py
@@ -243,9 +243,17 @@ class HierarchyElement(DiagLayer):
         self._state_charts = NamedItemList(state_charts)
 
     def _get_parent_refs_sorted_by_priority(self, reverse: bool = False) -> Iterable[ParentRef]:
+
+        def get_inheritance_priority(layer: DiagLayer) -> int:
+            if layer is None:
+                # in non-strict mode, a parent layer ref sometimes
+                # cannot be resolved
+                return 0
+            return layer.variant_type.inheritance_priority
+
         return sorted(
             getattr(self.diag_layer_raw, "parent_refs", []),
-            key=lambda pr: pr.layer.variant_type.inheritance_priority,
+            key=lambda parent_ref: get_inheritance_priority(parent_ref.layer),
             reverse=reverse)
 
     def _compute_available_objects(
@@ -278,6 +286,11 @@ class HierarchyElement(DiagLayer):
         # populate the result dictionary with the inherited objects
         for parent_ref in self._get_parent_refs_sorted_by_priority(reverse=True):
             parent_dl = parent_ref.layer
+
+            if parent_dl is None:
+                # in non-strict mode, parent references sometimes
+                # cannot be resolved
+                continue
 
             # retrieve the set of short names of the objects which we
             # are not supposed to inherit

--- a/odxtools/diaglayers/protocolraw.py
+++ b/odxtools/diaglayers/protocolraw.py
@@ -82,7 +82,7 @@ class ProtocolRaw(HierarchyElementRaw):
         super()._resolve_snrefs(context)
 
         self._prot_stack = None
-        if self.prot_stack_snref is not None:
+        if self.prot_stack_snref is not None and self._comparam_spec is not None:
             self._prot_stack = resolve_snref(
                 self.prot_stack_snref,
                 self._comparam_spec.prot_stacks,

--- a/odxtools/multiplexer.py
+++ b/odxtools/multiplexer.py
@@ -85,8 +85,12 @@ class Multiplexer(ComplexDop):
             self.default_case._resolve_odxlinks(odxlinks)
 
         for mux_case in self.cases:
+            dop = self.switch_key.dop
+            if dop is None:
+                # the DOP can be None in non-strict mode
+                continue
             mux_case._mux_case_resolve_odxlinks(
-                odxlinks, key_physical_type=self.switch_key.dop.physical_type.base_data_type)
+                odxlinks, key_physical_type=dop.physical_type.base_data_type)
 
     @override
     def _resolve_snrefs(self, context: SnRefContext) -> None:

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -52,6 +52,12 @@ class ItemAttributeList(list[T]):
 
         \return The name under which item is accessible
         """
+
+        if not hasattr(item, "short_name"):
+            odxraise(f"Tried to add {type(item).__name__} object to ItemAttributeList which "
+                     f"does not feature .short_name.")
+            return
+
         self._add_attribute_item(item)
 
         super().append(item)

--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -53,9 +53,8 @@ class ItemAttributeList(list[T]):
         \return The name under which item is accessible
         """
 
-        if not hasattr(item, "short_name"):
-            odxraise(f"Tried to add {type(item).__name__} object to ItemAttributeList which "
-                     f"does not feature .short_name.")
+        if item is None:
+            odxraise(f"Tried to add a None object to ItemAttributeList")
             return
 
         self._add_attribute_item(item)

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 from xml.etree import ElementTree
 
 from typing_extensions import override
@@ -63,12 +63,16 @@ class PhysicalConstantParameter(ParameterWithDOP):
 
     @override
     def _resolve_snrefs(self, context: SnRefContext) -> None:
+        self._physical_constant_value: ParameterValue
+
         super()._resolve_snrefs(context)
 
         dop = odxrequire(self.dop)
         if not isinstance(dop, DataObjectProperty):
             odxraise("The type of PHYS-CONST parameters must be a simple DOP")
+            self._physical_constant_value = cast(ParameterValue, None)
             return
+
         base_data_type = dop.physical_type.base_data_type
         self._physical_constant_value = base_data_type.from_string(self.physical_constant_value_raw)
 
@@ -80,6 +84,10 @@ class PhysicalConstantParameter(ParameterWithDOP):
                 f"Value for constant parameter `{self.short_name}` name can "
                 f"only be specified as {self.physical_constant_value!r} (is: {physical_value!r})",
                 EncodeError)
+
+        if self.dop is None:
+            # in non-strict mode, the DOP-REF might not be resolvable
+            return
 
         self.dop.encode_into_pdu(self.physical_constant_value, encode_state)
 

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -70,6 +70,7 @@ class ValueParameter(ParameterWithDOP):
             if not isinstance(dop, DataObjectProperty):
                 odxraise("Value parameters can only define a physical default "
                          "value if they use a simple DOP")
+                return
             base_data_type = dop.physical_type.base_data_type
             self._physical_default_value = base_data_type.from_string(
                 self.physical_default_value_raw)


### PR DESCRIPTION
with this, the file featured by https://github.com/mercedes-benz/odxtools/issues/497 can be loaded in non-strict mode. (although the file is very incomplete and the resulting database is thus probably of limited usefulness.)