### PR TITLE
Name the offending element when a reference points to the wrong kind of DOP

### DIFF
--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -32,7 +32,7 @@ class ParameterWithDOP(Parameter):
         return self._dop
 
     @property
-    def _dop_description(self) -> str:
+    def dop_info(self) -> str:
         """Describe the referenced DOP for diagnostic messages.
 
         Names the reference as it appears in the ODX file and, if it could be
@@ -40,10 +40,9 @@ class ParameterWithDOP(Parameter):
         """
         name = self.dop_snref if self.dop_snref is not None else (
             self.dop_ref.ref_id if self.dop_ref is not None else "<unspecified>")
-        dop = getattr(self, "_dop", None)
-        if dop is None:
-            return f"DOP '{name}' which could not be resolved"
-        return f"DOP '{name}' which is a {type(dop).__name__}"
+        if self.dop is None:
+            return f"unresolvable DOP '{name}'"
+        return f"{type(self.dop).__name__} DOP '{name}'"
 
     @staticmethod
     @override

--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -31,6 +31,20 @@ class ParameterWithDOP(Parameter):
 
         return self._dop
 
+    @property
+    def _dop_description(self) -> str:
+        """Describe the referenced DOP for diagnostic messages.
+
+        Names the reference as it appears in the ODX file and, if it could be
+        resolved, the type of the object which it points to.
+        """
+        name = self.dop_snref if self.dop_snref is not None else (
+            self.dop_ref.ref_id if self.dop_ref is not None else "<unspecified>")
+        dop = getattr(self, "_dop", None)
+        if dop is None:
+            return f"DOP '{name}' which could not be resolved"
+        return f"DOP '{name}' which is a {type(dop).__name__}"
+
     @staticmethod
     @override
     def from_et(et_element: ElementTree.Element, context: OdxDocContext) -> "ParameterWithDOP":

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -70,7 +70,7 @@ class PhysicalConstantParameter(ParameterWithDOP):
         dop = odxrequire(self.dop)
         if not isinstance(dop, DataObjectProperty):
             odxraise(f"PHYS-CONST parameter '{self.short_name}' references "
-                     f"{self._dop_description}, but a simple DOP is required")
+                     f"{self.dop_info}, but a simple DOP is required")
             self._physical_constant_value = cast(ParameterValue, None)
             return
 

--- a/odxtools/parameters/physicalconstantparameter.py
+++ b/odxtools/parameters/physicalconstantparameter.py
@@ -69,7 +69,8 @@ class PhysicalConstantParameter(ParameterWithDOP):
 
         dop = odxrequire(self.dop)
         if not isinstance(dop, DataObjectProperty):
-            odxraise("The type of PHYS-CONST parameters must be a simple DOP")
+            odxraise(f"PHYS-CONST parameter '{self.short_name}' references "
+                     f"{self._dop_description}, but a simple DOP is required")
             self._physical_constant_value = cast(ParameterValue, None)
             return
 

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -69,7 +69,7 @@ class ValueParameter(ParameterWithDOP):
             dop = odxrequire(self.dop)
             if not isinstance(dop, DataObjectProperty):
                 odxraise(f"VALUE parameter '{self.short_name}' specifies a physical "
-                         f"default value, but references {self._dop_description}; "
+                         f"default value, but references {self.dop_info}; "
                          f"this requires a simple DOP")
                 return
             base_data_type = dop.physical_type.base_data_type

--- a/odxtools/parameters/valueparameter.py
+++ b/odxtools/parameters/valueparameter.py
@@ -68,8 +68,9 @@ class ValueParameter(ParameterWithDOP):
         if self.physical_default_value_raw is not None:
             dop = odxrequire(self.dop)
             if not isinstance(dop, DataObjectProperty):
-                odxraise("Value parameters can only define a physical default "
-                         "value if they use a simple DOP")
+                odxraise(f"VALUE parameter '{self.short_name}' specifies a physical "
+                         f"default value, but references {self._dop_description}; "
+                         f"this requires a simple DOP")
                 return
             base_data_type = dop.physical_type.base_data_type
             self._physical_default_value = base_data_type.from_string(

--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -199,7 +199,9 @@ class TableRow(IdentifiableElement):
         if self.dop_ref is not None:
             self._dop = odxlinks.resolve(self.dop_ref)
             if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
-                odxraise("The DOP-REF of TABLE-ROWs must reference a simple DOP!")
+                odxraise(f"The DOP-REF of TABLE-ROW '{self.short_name}' references "
+                         f"'{self.dop_ref.ref_id}' which is a "
+                         f"{type(self._dop).__name__}, but a simple DOP is required")
         if self.structure_ref is not None:
             self._structure = odxlinks.resolve(self.structure_ref, Structure)
 
@@ -248,7 +250,9 @@ class TableRow(IdentifiableElement):
             self._dop = resolve_snref(
                 self.dop_snref, ddd_spec.data_object_props, use_weakrefs=context.use_weakrefs)
             if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
-                odxraise("The DOP-SNREF of TABLE-ROWs must reference a simple DOP!")
+                odxraise(f"The DOP-SNREF of TABLE-ROW '{self.short_name}' references "
+                         f"'{self.dop_snref}' which is a {type(self._dop).__name__}, "
+                         f"but a simple DOP is required")
 
         if self.audience is not None:
             self.audience._resolve_snrefs(context)

--- a/tests/test_dop_type_diagnostics.py
+++ b/tests/test_dop_type_diagnostics.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+"""Diagnostics emitted when a reference points to the wrong kind of DOP.
+
+The ODX standard only allows simple DOPs in a few places, e.g. for the value
+of a PHYS-CONST parameter. When a file violates this, the message needs to
+name the offending element so that it can be found in a large database.
+"""
+import unittest
+
+from odxtools.exceptions import OdxError
+from odxtools.odxlink import (DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef)
+from odxtools.parameters.physicalconstantparameter import PhysicalConstantParameter
+from odxtools.parameters.valueparameter import ValueParameter
+from odxtools.snrefcontext import SnRefContext
+from odxtools.structure import Structure
+
+doc_frags = (OdxDocFragment("test", DocType.CONTAINER),)
+
+
+def _structure(short_name: str) -> Structure:
+    return Structure(
+        odx_id=OdxLinkId(short_name, doc_frags),
+        short_name=short_name,
+        parameters=[],  # type: ignore[arg-type]
+    )
+
+
+class TestDopTypeDiagnostics(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.structure = _structure("a_structure")
+        self.odxlinks = OdxLinkDatabase()
+        self.odxlinks.update({self.structure.odx_id: self.structure})
+        self.context = SnRefContext(use_weakrefs=False)
+
+    def test_physical_constant_parameter_names_the_element(self) -> None:
+        param = PhysicalConstantParameter(
+            short_name="the_constant",
+            physical_constant_value_raw="1",
+            dop_ref=OdxLinkRef.from_id(self.structure.odx_id),
+        )
+        param._resolve_odxlinks(self.odxlinks)
+
+        with self.assertRaises(OdxError) as ctx:
+            param._resolve_snrefs(self.context)
+
+        message = str(ctx.exception)
+        self.assertIn("the_constant", message)
+        self.assertIn("a_structure", message)
+        self.assertIn("Structure", message)
+
+    def test_value_parameter_names_the_element(self) -> None:
+        param = ValueParameter(
+            short_name="the_value",
+            physical_default_value_raw="1",
+            dop_ref=OdxLinkRef.from_id(self.structure.odx_id),
+        )
+        param._resolve_odxlinks(self.odxlinks)
+
+        with self.assertRaises(OdxError) as ctx:
+            param._resolve_snrefs(self.context)
+
+        message = str(ctx.exception)
+        self.assertIn("the_value", message)
+        self.assertIn("a_structure", message)
+        self.assertIn("Structure", message)
+
+    def test_unresolved_reference_is_not_reported_as_a_wrong_type(self) -> None:
+        """An unresolved DOP must read differently from one of the wrong type."""
+        param = PhysicalConstantParameter(
+            short_name="the_constant",
+            physical_constant_value_raw="1",
+            dop_snref="does_not_exist",
+        )
+
+        description = param._dop_description
+        self.assertIn("does_not_exist", description)
+        self.assertIn("could not be resolved", description)
+
+    def test_description_names_the_reference_as_written(self) -> None:
+        """The name in the message is the one the ODX file uses."""
+        param = PhysicalConstantParameter(
+            short_name="the_constant",
+            physical_constant_value_raw="1",
+            dop_ref=OdxLinkRef.from_id(self.structure.odx_id),
+        )
+        param._resolve_odxlinks(self.odxlinks)
+
+        self.assertIn("a_structure", param._dop_description)
+        self.assertIn("Structure", param._dop_description)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dop_type_diagnostics.py
+++ b/tests/test_dop_type_diagnostics.py
@@ -7,10 +7,13 @@ name the offending element so that it can be found in a large database.
 """
 import unittest
 
+import odxtools.exceptions as exceptions
+
 from odxtools.exceptions import OdxError
 from odxtools.odxlink import (DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef)
 from odxtools.parameters.physicalconstantparameter import PhysicalConstantParameter
 from odxtools.parameters.valueparameter import ValueParameter
+from odxtools.nameditemlist import NamedItemList
 from odxtools.snrefcontext import SnRefContext
 from odxtools.structure import Structure
 
@@ -21,7 +24,7 @@ def _structure(short_name: str) -> Structure:
     return Structure(
         odx_id=OdxLinkId(short_name, doc_frags),
         short_name=short_name,
-        parameters=[],  # type: ignore[arg-type]
+        parameters=NamedItemList(),
     )
 
 
@@ -70,12 +73,17 @@ class TestDopTypeDiagnostics(unittest.TestCase):
         param = PhysicalConstantParameter(
             short_name="the_constant",
             physical_constant_value_raw="1",
-            dop_snref="does_not_exist",
+            dop_ref=OdxLinkRef("does_not_exist", doc_frags),
         )
 
-        description = param._dop_description
-        self.assertIn("does_not_exist", description)
-        self.assertIn("could not be resolved", description)
+        exceptions.strict_mode = False
+        try:
+            param._resolve_odxlinks(OdxLinkDatabase())
+        finally:
+            exceptions.strict_mode = True
+
+        self.assertIn("does_not_exist", param.dop_info)
+        self.assertIn("unresolvable", param.dop_info)
 
     def test_description_names_the_reference_as_written(self) -> None:
         """The name in the message is the one the ODX file uses."""
@@ -86,8 +94,8 @@ class TestDopTypeDiagnostics(unittest.TestCase):
         )
         param._resolve_odxlinks(self.odxlinks)
 
-        self.assertIn("a_structure", param._dop_description)
-        self.assertIn("Structure", param._dop_description)
+        self.assertIn("a_structure", param.dop_info)
+        self.assertIn("Structure", param.dop_info)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While looking at #497 I noticed that the message which reports the problem does not say which parameter caused it. On that user's file it is printed 86 times, and only two of those messages differ from each other, so finding the 71 offending parameters in an 877 KB file means searching by hand. That is roughly what happened in the issue thread.

This PR leaves the behaviour alone and only changes the text of the diagnostics.

**Before**

```
The type of PHYS-CONST parameters must be a simple DOP
The type of PHYS-CONST parameters must be a simple DOP
... 86 lines, 2 distinct
```

**After**

```
PHYS-CONST parameter 'Param_HeadlLeftChann1Maste' references DOP
'MUX_LINEA2ByteCurreMUX' which is a Multiplexer, but a simple DOP is required

PHYS-CONST parameter 'Param_DiagnSessiType' references DOP
'DOP_TEXTTABLEDiagnSessiTypes' which could not be resolved, but a simple
DOP is required
```

86 lines, 67 distinct. The second example is worth pointing out: an unresolved reference and a reference of the wrong type used to produce the same sentence, and they are different problems. In non-strict mode `odxrequire()` returns `None`, so the two cases reach the same branch.

The same treatment is applied to the three other places with this constraint, since they share the shortcoming:

- `PhysicalConstantParameter._resolve_snrefs`
- `ValueParameter._resolve_snrefs`
- `TableRow._resolve_odxlinks` (DOP-REF)
- `TableRow._resolve_snrefs` (DOP-SNREF)

The shared part sits in `ParameterWithDOP._dop_description`, which names the reference as written in the file rather than the resolved object, so it also works when resolution failed.

**Verification**

Numbers above are from loading the file attached to #497 in non-strict mode before and after the change. `yapf`, `ruff` and `mypy` are clean, and the test suite goes from 155 to 159 passing — four new cases in `tests/test_dop_type_diagnostics.py` covering both parameter types, the unresolved case and the reference naming.

I did not touch what is accepted or rejected, so no existing test changed.

Happy to adjust the wording if you would phrase these differently, or to drop the `TableRow` part if you would rather keep the change to the parameters only.
