### PR TITLE
fix `ParameterWithDOP.dop_info` for `weakref.proxy` objects

### DIFF
--- a/odxtools/parameters/parameterwithdop.py
+++ b/odxtools/parameters/parameterwithdop.py
@@ -42,7 +42,7 @@ class ParameterWithDOP(Parameter):
             self.dop_ref.ref_id if self.dop_ref is not None else "<unspecified>")
         if self.dop is None:
             return f"unresolvable DOP '{name}'"
-        return f"{type(self.dop).__name__} DOP '{name}'"
+        return f"{self.dop.__class__.__name__} DOP '{name}'"
 
     @staticmethod
     @override


### PR DESCRIPTION
without this, `.dop_info` produces output like
```
PHYS-CONST parameter 'Param_HeadlLeftChann1Slave' references Proxy DOP 'MUX_LINEA2ByteCurre2MUX5', but a simple DOP is required
```
Now, this becomes
```
PHYS-CONST parameter 'Param_HeadlLeftChann1Slave' references Multiplexer DOP 'MUX_LINEA2ByteCurre2MUX5', but a simple DOP is required
```