### PR TITLE
Apply the weakref fix from #500 to the TABLE-ROW messages as well

### DIFF
--- a/odxtools/tablerow.py
+++ b/odxtools/tablerow.py
@@ -201,7 +201,7 @@ class TableRow(IdentifiableElement):
             if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
                 odxraise(f"The DOP-REF of TABLE-ROW '{self.short_name}' references "
                          f"'{self.dop_ref.ref_id}' which is a "
-                         f"{type(self._dop).__name__}, but a simple DOP is required")
+                         f"{self._dop.__class__.__name__}, but a simple DOP is required")
         if self.structure_ref is not None:
             self._structure = odxlinks.resolve(self.structure_ref, Structure)
 
@@ -251,7 +251,7 @@ class TableRow(IdentifiableElement):
                 self.dop_snref, ddd_spec.data_object_props, use_weakrefs=context.use_weakrefs)
             if not isinstance(self._dop, (DataObjectProperty, DtcDop)):
                 odxraise(f"The DOP-SNREF of TABLE-ROW '{self.short_name}' references "
-                         f"'{self.dop_snref}' which is a {type(self._dop).__name__}, "
+                         f"'{self.dop_snref}' which is a {self._dop.__class__.__name__}, "
                          f"but a simple DOP is required")
 
         if self.audience is not None:


### PR DESCRIPTION
Follow-up to #500, which fixed `ParameterWithDOP.dop_info` to read the class through the object instead of through `type()`.

The two `TABLE-ROW` messages that came in with #499 have the same issue and I missed them. Both paths in `tablerow.py` can hold a proxy — `_resolve_odxlinks()` goes through `odxlinks.resolve()`, and `_resolve_snrefs()` passes `use_weakrefs=context.use_weakrefs` explicitly — so on a database loaded with weak references they report:

```
The DOP-SNREF of TABLE-ROW 'x' references 'y' which is a ProxyType,
but a simple DOP is required
```

instead of naming the type the file actually used.

```python
>>> p = weakref.proxy(structure)
>>> type(p).__name__
'ProxyType'
>>> p.__class__.__name__
'Structure'
```

Same one-line change as yours, applied to both. `yapf`, `ruff`, `mypy .` clean, suite unchanged at 159.

Apologies for the extra round — I should have looked for the rest of the pattern when you pointed it out rather than only reading the diff.
