### PR TITLE
Revert "perf(writepdxfile): cache Jinja2 environment to avoid re-parsing templates"

### DIFF
--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -74,18 +74,6 @@ assert isinstance(__module_filename, str)
 __templates_dir = os.path.sep.join([os.path.dirname(__module_filename), "templates"])
 
 
-@cache
-def _get_jinja_env(templates_dir: str) -> jinja2.Environment:
-    """Return a cached Jinja2 environment for the given templates directory."""
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
-    env.globals["getattr"] = getattr
-    env.globals["hasattr"] = hasattr
-    env.globals["odxraise"] = jinja2_odxraise_helper
-    env.globals["make_xml_attrib"] = make_xml_attrib
-    env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
-    return env
-
-
 def write_pdx_file(
     output_file_name: str,
     database: Database,
@@ -166,7 +154,13 @@ def write_pdx_file(
                 file_index.append((zf_name, creation_date, mime_type))
                 out_file.write(data_file.read())
 
-        jinja_env = _get_jinja_env(templates_dir)
+        jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
+        jinja_env.globals["getattr"] = getattr
+        jinja_env.globals["hasattr"] = hasattr
+        jinja_env.globals["odxraise"] = jinja2_odxraise_helper
+        jinja_env.globals["make_xml_attrib"] = make_xml_attrib
+        jinja_env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
+
         jinja_vars: dict[str, Any] = {}
         jinja_vars["odxtools_version"] = odxtools.__version__
         jinja_vars["database"] = database


### PR DESCRIPTION
This reverts commit 413e3036aa241a05feb42973496820d19c897d73. Turns out that this [broke the correctness of repeated writes](https://github.com/mercedes-benz/odxtools/issues/505) from within the same proccess (but at least they were fast ;))