### PR TITLE
`browse`: add support for [Home], [End], [PageUp], and [PageDown] keys for list selection

### DIFF
--- a/odxtools/cli/_browse_utils.py
+++ b/odxtools/cli/_browse_utils.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+from typing import Any
+
+from InquirerPy.prompts.list import ListPrompt
+from InquirerPy.separator import Separator
+from prompt_toolkit.keys import Keys
+
+
+class _ListPromptWithCustomKeys(ListPrompt):  # type: ignore[misc,unused-ignore]
+    """InquirerPy prompt for lists that adds support for PageDown, PageUp, Home and End keys."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.kb_maps.setdefault("page-up", []).append({"key": Keys.PageUp})
+        self.kb_maps.setdefault("page-down", []).append({"key": Keys.PageDown})
+        self.kb_maps.setdefault("home", []).append({"key": Keys.Home})
+        self.kb_maps.setdefault("end", []).append({"key": Keys.End})
+        self.kb_func_lookup["page-up"] = [{"func": self._handle_page_up}]
+        self.kb_func_lookup["page-down"] = [{"func": self._handle_page_down}]
+        self.kb_func_lookup["home"] = [{"func": self._handle_home}]
+        self.kb_func_lookup["end"] = [{"func": self._handle_end}]
+
+    def _handle_page_up(self, event: Any) -> None:
+        page_size = getattr(self, "_dimmension_max_height", 10)
+        for _ in range(page_size):
+            old_idx = self.content_control.selected_choice_index
+            if old_idx == 0:
+                break
+            self._handle_up(event)
+            if self.content_control.selected_choice_index >= old_idx:
+                break
+
+    def _handle_page_down(self, event: Any) -> None:
+        page_size = getattr(self, "_dimmension_max_height", 10)
+        last_idx = self.content_control.choice_count - 1
+        for _ in range(page_size):
+            old_idx = self.content_control.selected_choice_index
+            if old_idx == last_idx:
+                break
+            self._handle_down(event)
+            if self.content_control.selected_choice_index <= old_idx:
+                break
+
+    def _handle_home(self, event: Any) -> None:
+        for index, choice in enumerate(self.content_control.choices):
+            if not isinstance(choice["value"], Separator):
+                self.content_control.selected_choice_index = index
+                break
+
+    def _handle_end(self, event: Any) -> None:
+        for index in range(self.content_control.choice_count - 1, -1, -1):
+            if not isinstance(self.content_control.choices[index]["value"], Separator):
+                self.content_control.selected_choice_index = index
+                break

--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -2,13 +2,10 @@
 import argparse
 import logging
 import sys
-from typing import Any, cast
+from typing import cast
 
-from InquirerPy.prompts.list import ListPrompt
 from InquirerPy.resolver import prompt as IP_prompt
 from InquirerPy.resolver import question_mapping
-from InquirerPy.separator import Separator
-from prompt_toolkit.keys import Keys
 from rich import print as rich_print
 
 from ..complexdop import ComplexDop
@@ -27,63 +24,14 @@ from ..parameters.parameterwithdop import ParameterWithDOP
 from ..parameters.valueparameter import ValueParameter
 from ..request import Request
 from ..response import Response
-from . import _parser_utils
+from . import _browse_utils, _parser_utils
 from ._parser_utils import SubparsersList
 from ._print_utils import build_parameter_table
 
 # name of the tool
 _odxtools_tool_name_ = "browse"
 
-
-class _ListPromptWithCustomKeys(ListPrompt):  # type: ignore[misc,unused-ignore]
-    """InquirerPy prompt for lists that adds support for PageDown, PageUp, Home and End keys."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.kb_maps.setdefault("page-up", []).append({"key": Keys.PageUp})
-        self.kb_maps.setdefault("page-down", []).append({"key": Keys.PageDown})
-        self.kb_maps.setdefault("home", []).append({"key": Keys.Home})
-        self.kb_maps.setdefault("end", []).append({"key": Keys.End})
-        self.kb_func_lookup["page-up"] = [{"func": self._handle_page_up}]
-        self.kb_func_lookup["page-down"] = [{"func": self._handle_page_down}]
-        self.kb_func_lookup["home"] = [{"func": self._handle_home}]
-        self.kb_func_lookup["end"] = [{"func": self._handle_end}]
-
-    def _handle_page_up(self, event: Any) -> None:
-        page_size = getattr(self, "_dimmension_max_height", 10)
-        for _ in range(page_size):
-            old_idx = self.content_control.selected_choice_index
-            if old_idx == 0:
-                break
-            self._handle_up(event)
-            if self.content_control.selected_choice_index >= old_idx:
-                break
-
-    def _handle_page_down(self, event: Any) -> None:
-        page_size = getattr(self, "_dimmension_max_height", 10)
-        last_idx = self.content_control.choice_count - 1
-        for _ in range(page_size):
-            old_idx = self.content_control.selected_choice_index
-            if old_idx == last_idx:
-                break
-            self._handle_down(event)
-            if self.content_control.selected_choice_index <= old_idx:
-                break
-
-    def _handle_home(self, event: Any) -> None:
-        for index, choice in enumerate(self.content_control.choices):
-            if not isinstance(choice["value"], Separator):
-                self.content_control.selected_choice_index = index
-                break
-
-    def _handle_end(self, event: Any) -> None:
-        for index in range(self.content_control.choice_count - 1, -1, -1):
-            if not isinstance(self.content_control.choices[index]["value"], Separator):
-                self.content_control.selected_choice_index = index
-                break
-
-
-question_mapping["list"] = _ListPromptWithCustomKeys
+question_mapping["list"] = _browse_utils._ListPromptWithCustomKeys
 
 
 def _convert_string_to_odx_type(string_value: str, odx_type: DataType) -> AtomicOdxType:

--- a/odxtools/cli/browse.py
+++ b/odxtools/cli/browse.py
@@ -2,9 +2,13 @@
 import argparse
 import logging
 import sys
-from typing import cast
+from typing import Any, cast
 
+from InquirerPy.prompts.list import ListPrompt
 from InquirerPy.resolver import prompt as IP_prompt
+from InquirerPy.resolver import question_mapping
+from InquirerPy.separator import Separator
+from prompt_toolkit.keys import Keys
 from rich import print as rich_print
 
 from ..complexdop import ComplexDop
@@ -29,6 +33,57 @@ from ._print_utils import build_parameter_table
 
 # name of the tool
 _odxtools_tool_name_ = "browse"
+
+
+class _ListPromptWithCustomKeys(ListPrompt):  # type: ignore[misc,unused-ignore]
+    """InquirerPy prompt for lists that adds support for PageDown, PageUp, Home and End keys."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.kb_maps.setdefault("page-up", []).append({"key": Keys.PageUp})
+        self.kb_maps.setdefault("page-down", []).append({"key": Keys.PageDown})
+        self.kb_maps.setdefault("home", []).append({"key": Keys.Home})
+        self.kb_maps.setdefault("end", []).append({"key": Keys.End})
+        self.kb_func_lookup["page-up"] = [{"func": self._handle_page_up}]
+        self.kb_func_lookup["page-down"] = [{"func": self._handle_page_down}]
+        self.kb_func_lookup["home"] = [{"func": self._handle_home}]
+        self.kb_func_lookup["end"] = [{"func": self._handle_end}]
+
+    def _handle_page_up(self, event: Any) -> None:
+        page_size = getattr(self, "_dimmension_max_height", 10)
+        for _ in range(page_size):
+            old_idx = self.content_control.selected_choice_index
+            if old_idx == 0:
+                break
+            self._handle_up(event)
+            if self.content_control.selected_choice_index >= old_idx:
+                break
+
+    def _handle_page_down(self, event: Any) -> None:
+        page_size = getattr(self, "_dimmension_max_height", 10)
+        last_idx = self.content_control.choice_count - 1
+        for _ in range(page_size):
+            old_idx = self.content_control.selected_choice_index
+            if old_idx == last_idx:
+                break
+            self._handle_down(event)
+            if self.content_control.selected_choice_index <= old_idx:
+                break
+
+    def _handle_home(self, event: Any) -> None:
+        for index, choice in enumerate(self.content_control.choices):
+            if not isinstance(choice["value"], Separator):
+                self.content_control.selected_choice_index = index
+                break
+
+    def _handle_end(self, event: Any) -> None:
+        for index in range(self.content_control.choice_count - 1, -1, -1):
+            if not isinstance(self.content_control.choices[index]["value"], Separator):
+                self.content_control.selected_choice_index = index
+                break
+
+
+question_mapping["list"] = _ListPromptWithCustomKeys
 
 
 def _convert_string_to_odx_type(string_value: str, odx_type: DataType) -> AtomicOdxType:

--- a/tests/test_dop_type_diagnostics.py
+++ b/tests/test_dop_type_diagnostics.py
@@ -8,12 +8,11 @@ name the offending element so that it can be found in a large database.
 import unittest
 
 import odxtools.exceptions as exceptions
-
 from odxtools.exceptions import OdxError
-from odxtools.odxlink import (DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef)
+from odxtools.nameditemlist import NamedItemList
+from odxtools.odxlink import DocType, OdxDocFragment, OdxLinkDatabase, OdxLinkId, OdxLinkRef
 from odxtools.parameters.physicalconstantparameter import PhysicalConstantParameter
 from odxtools.parameters.valueparameter import ValueParameter
-from odxtools.nameditemlist import NamedItemList
 from odxtools.snrefcontext import SnRefContext
 from odxtools.structure import Structure
 


### PR DESCRIPTION
this makes navigating long lists much more convenient.