### PR TITLE
Fix SNPATHREF validation in PreConditionStateRef

### DIFF
--- a/odxtools/preconditionstateref.py
+++ b/odxtools/preconditionstateref.py
@@ -54,7 +54,7 @@ class PreConditionStateRef(OdxLinkRef):
 
     def __post_init__(self) -> None:
         if self.value is not None:
-            odxassert(self.in_param_if_snref is not None or self.in_param_if_snref is not None,
+            odxassert(self.in_param_if_snref is not None or self.in_param_if_snpathref is not None,
                       "If VALUE is specified, a parameter must be referenced")
 
     def _build_odxlinks(self) -> dict[OdxLinkId, Any]:


### PR DESCRIPTION
Description:

Fix the SNPATHREF validation in `PreConditionStateRef`.

When `VALUE` is specified, the validation checks `in_param_if_snref` twice. The second check should be `in_param_if_snpathref`.

This allows a reference supplied exclusively through `IN-PARAM-IF-SNPATHREF` to satisfy the validation.

Related issue: #515